### PR TITLE
Change type validators to use predicate instead of TypeRep

### DIFF
--- a/test/get.js
+++ b/test/get.js
@@ -17,44 +17,45 @@ test('get', function() {
          TypeError,
          'Invalid value\n' +
          '\n' +
-         'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
-         '                       ^^^^^^^\n' +
+         'get :: Accessible a => Function -> String -> a -> Maybe c\n' +
+         '                       ^^^^^^^^\n' +
          '                          1\n' +
          '\n' +
          '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
          '\n' +
-         'The value at position 1 is not a member of ‘TypeRep’.\n');
+         'The value at position 1 is not a member of ‘Function’.\n');
 
-  throws(function() { S.get(Number, [1, 2, 3]); },
+  throws(function() { S.get(S.is(Number), [1, 2, 3]); },
          TypeError,
          'Invalid value\n' +
          '\n' +
-         'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
-         '                                  ^^^^^^\n' +
-         '                                    1\n' +
+         'get :: Accessible a => Function -> String -> a -> Maybe c\n' +
+         '                                   ^^^^^^\n' +
+         '                                     1\n' +
          '\n' +
          '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
          '\n' +
          'The value at position 1 is not a member of ‘String’.\n');
 
-  throws(function() { S.get(Number, 'x', null); },
+  throws(function() { S.get(S.is(Number), 'x', null); },
          TypeError,
          'Type-class constraint violation\n' +
          '\n' +
-         'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
-         '       ^^^^^^^^^^^^                         ^\n' +
-         '                                            1\n' +
+         'get :: Accessible a => Function -> String -> a -> Maybe c\n' +
+         '       ^^^^^^^^^^^^                          ^\n' +
+         '                                             1\n' +
          '\n' +
          '1)  null :: Null\n' +
          '\n' +
          '‘get’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n');
 
-  eq(S.get(Number, 'x', {x: 0, y: 42}), S.Just(0));
-  eq(S.get(Number, 'y', {x: 0, y: 42}), S.Just(42));
-  eq(S.get(Number, 'z', {x: 0, y: 42}), S.Nothing);
-  eq(S.get(String, 'x', {x: 0, y: 42}), S.Nothing);
+  eq(S.get(S.is(Number), 'x', {x: 0, y: 42}), S.Just(0));
+  eq(S.get(S.is(Number), 'y', {x: 0, y: 42}), S.Just(42));
+  eq(S.get(S.is(Number), 'z', {x: 0, y: 42}), S.Nothing);
+  eq(S.get(S.is(String), 'z', {x: 0, y: 42}), S.Nothing);
+  eq(S.get(S.is(String), 'x', {x: 0, y: 42}), S.Nothing);
 
-  eq(S.get(RegExp, 'x', {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
-  eq(S.get(vm.runInNewContext('RegExp'), 'x', {x: /.*/}), S.Just(/.*/));
+  eq(S.get(S.is(RegExp), 'x', {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
+  eq(S.get(S.is(vm.runInNewContext('RegExp')), 'x', {x: /.*/}), S.Just(/.*/));
 
 });

--- a/test/gets.js
+++ b/test/gets.js
@@ -17,47 +17,47 @@ test('gets', function() {
          TypeError,
          'Invalid value\n' +
          '\n' +
-         'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
-         '                        ^^^^^^^\n' +
+         'gets :: Accessible a => Function -> Array String -> a -> Maybe c\n' +
+         '                        ^^^^^^^^\n' +
          '                           1\n' +
          '\n' +
          '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
          '\n' +
-         'The value at position 1 is not a member of ‘TypeRep’.\n');
+         'The value at position 1 is not a member of ‘Function’.\n');
 
-  throws(function() { S.gets(Number, null); },
+  throws(function() { S.gets(S.is(Number), null); },
          TypeError,
          'Invalid value\n' +
          '\n' +
-         'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
-         '                                   ^^^^^^^^^^^^\n' +
-         '                                        1\n' +
+         'gets :: Accessible a => Function -> Array String -> a -> Maybe c\n' +
+         '                                    ^^^^^^^^^^^^\n' +
+         '                                         1\n' +
          '\n' +
          '1)  null :: Null\n' +
          '\n' +
          'The value at position 1 is not a member of ‘Array String’.\n');
 
-  throws(function() { S.gets(Number, [], null); },
+  throws(function() { S.gets(S.is(Number), [], null); },
          TypeError,
          'Type-class constraint violation\n' +
          '\n' +
-         'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
-         '        ^^^^^^^^^^^^                               ^\n' +
-         '                                                   1\n' +
+         'gets :: Accessible a => Function -> Array String -> a -> Maybe c\n' +
+         '        ^^^^^^^^^^^^                                ^\n' +
+         '                                                    1\n' +
          '\n' +
          '1)  null :: Null\n' +
          '\n' +
          '‘gets’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n');
 
-  eq(S.gets(Number, ['x'], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(Number, ['y'], {x: {z: 0}, y: 42}), S.Just(42));
-  eq(S.gets(Number, ['z'], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(Number, ['x', 'z'], {x: {z: 0}, y: 42}), S.Just(0));
-  eq(S.gets(Number, ['a', 'b', 'c'], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(Number, [], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(Object, [], {x: {z: 0}, y: 42}), S.Just({x: {z: 0}, y: 42}));
+  eq(S.gets(S.is(Number), ['x'], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is(Number), ['y'], {x: {z: 0}, y: 42}), S.Just(42));
+  eq(S.gets(S.is(Number), ['z'], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is(Number), ['x', 'z'], {x: {z: 0}, y: 42}), S.Just(0));
+  eq(S.gets(S.is(Number), ['a', 'b', 'c'], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is(Number), [], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is(Object), [], {x: {z: 0}, y: 42}), S.Just({x: {z: 0}, y: 42}));
 
-  eq(S.gets(RegExp, ['x'], {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
-  eq(S.gets(vm.runInNewContext('RegExp'), ['x'], {x: /.*/}), S.Just(/.*/));
+  eq(S.gets(S.is(RegExp), ['x'], {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
+  eq(S.gets(S.is(vm.runInNewContext('RegExp')), ['x'], {x: /.*/}), S.Just(/.*/));
 
 });

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -15,28 +15,28 @@ test('parseJson', function() {
          TypeError,
          'Invalid value\n' +
          '\n' +
-         'parseJson :: TypeRep -> String -> Maybe a\n' +
-         '             ^^^^^^^\n' +
+         'parseJson :: Function -> String -> Maybe b\n' +
+         '             ^^^^^^^^\n' +
          '                1\n' +
          '\n' +
          '1)  "String" :: String\n' +
          '\n' +
-         'The value at position 1 is not a member of ‘TypeRep’.\n');
+         'The value at position 1 is not a member of ‘Function’.\n');
 
-  throws(function() { S.parseJson(Array, [1, 2, 3]); },
+  throws(function() { S.parseJson(S.is(Array), [1, 2, 3]); },
          TypeError,
          'Invalid value\n' +
          '\n' +
-         'parseJson :: TypeRep -> String -> Maybe a\n' +
-         '                        ^^^^^^\n' +
-         '                          1\n' +
+         'parseJson :: Function -> String -> Maybe b\n' +
+         '                         ^^^^^^\n' +
+         '                           1\n' +
          '\n' +
          '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
          '\n' +
          'The value at position 1 is not a member of ‘String’.\n');
 
-  eq(S.parseJson(Object, '[Invalid JSON]'), S.Nothing);
-  eq(S.parseJson(Array, '{"foo":"bar"}'), S.Nothing);
-  eq(S.parseJson(Array, '["foo","bar"]'), S.Just(['foo', 'bar']));
+  eq(S.parseJson(S.is(Object), '[Invalid JSON]'), S.Nothing);
+  eq(S.parseJson(S.is(Array), '{"foo":"bar"}'), S.Nothing);
+  eq(S.parseJson(S.is(Array), '["foo","bar"]'), S.Just(['foo', 'bar']));
 
 });


### PR DESCRIPTION
Commit description:

> This commit will close #149 by changing all functions
> that have built-in type validation to use predicates
> instead of TypeReps to perform their validations.
> 
> The functions affected are:
> - get()
> - gets()
> - parseJson()
> 
> The only function untouched is `is()`, for it is used
> to turn a TypeRep into a predicate.
