### PR TITLE
license: update copyright information and automate future updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,7 @@
-Copyright (c) 2015 Plaid Technologies, Inc.
+The MIT License (MIT)
+
+Copyright (c) 2016 Sanctuary
+Copyright (c) 2016 Plaid Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,13 @@ XYZ = node_modules/.bin/xyz --repo git@github.com:sanctuary-js/sanctuary.git --s
 
 
 .PHONY: all
-all: README.md
+all: LICENSE README.md
+
+.PHONY: LICENSE
+LICENSE:
+	cp -- '$@' '$@.orig'
+	sed 's/Copyright (c) .* Sanctuary/Copyright (c) $(shell git log --date=format:%Y --pretty=format:%ad | sort -r | head -n 1) Sanctuary/' '$@.orig' >'$@'
+	rm -- '$@.orig'
 
 README.md: index.js
 	$(TRANSCRIBE) \

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -3,4 +3,4 @@ set -e
 
 rm -f README.md
 make
-git add README.md
+git add LICENSE README.md


### PR DESCRIPTION
I updated the Plaid copyright year to 2016, where it will remain.

The Sanctuary copyright year will be updated—to reflect the most recently authored commit—each time we run `make release-$LEVEL`.
