### PR TITLE
maybe: change type of S.Nothing from ‘-> Maybe a’ to ‘Maybe a’

### DIFF
--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -23,7 +23,7 @@ describe('Just', function() {
 
   it('provides an "ap" method', function() {
     eq(S.Just(S.inc).ap.length, 1);
-    eq(S.Just(S.inc).ap(S.Nothing()), S.Nothing());
+    eq(S.Just(S.inc).ap(S.Nothing), S.Nothing);
     eq(S.Just(S.inc).ap(S.Just(42)), S.Just(43));
 
     throws(function() { S.Just(S.inc).ap([1, 2, 3]); },
@@ -58,7 +58,7 @@ describe('Just', function() {
 
   it('provides a "concat" method', function() {
     eq(S.Just('foo').concat.length, 1);
-    eq(S.Just('foo').concat(S.Nothing()), S.Just('foo'));
+    eq(S.Just('foo').concat(S.Nothing), S.Just('foo'));
     eq(S.Just('foo').concat(S.Just('bar')), S.Just('foobar'));
 
     throws(function() { S.Just('foo').concat([1, 2, 3]); },
@@ -114,7 +114,7 @@ describe('Just', function() {
     eq(S.Just(42).equals.length, 1);
     eq(S.Just(42).equals(S.Just(42)), true);
     eq(S.Just(42).equals(S.Just(43)), false);
-    eq(S.Just(42).equals(S.Nothing()), false);
+    eq(S.Just(42).equals(S.Nothing), false);
     eq(S.Just(42).equals(null), false);
 
     // Value-based equality:
@@ -153,9 +153,9 @@ describe('Just', function() {
   it('provides a "filter" method', function() {
     eq(S.Just(42).filter.length, 1);
     eq(S.Just(42).filter(R.T), S.Just(42));
-    eq(S.Just(42).filter(R.F), S.Nothing());
+    eq(S.Just(42).filter(R.F), S.Nothing);
     eq(S.Just(42).filter(function(n) { return n > 0; }), S.Just(42));
-    eq(S.Just(42).filter(function(n) { return n < 0; }), S.Nothing());
+    eq(S.Just(42).filter(function(n) { return n < 0; }), S.Nothing);
 
     var m = S.Just(-5);
     var f = function(n) { return n * n; };

--- a/test/Maybe/Maybe.js
+++ b/test/Maybe/Maybe.js
@@ -35,7 +35,7 @@ var IdentityArb = function(arb) {
 
 //  MaybeArb :: Arbitrary a -> Arbitrary (Maybe a)
 var MaybeArb = function(arb) {
-  return jsc.oneof(JustArb(arb), jsc.constant(S.Nothing()));
+  return jsc.oneof(JustArb(arb), jsc.constant(S.Nothing));
 };
 
 //  JustArb :: Arbitrary a -> Arbitrary (Maybe a)

--- a/test/Maybe/MaybeType.js
+++ b/test/Maybe/MaybeType.js
@@ -9,7 +9,7 @@ var S = require('../..');
 describe('MaybeType', function() {
 
   it('has its type definition exported', function() {
-    eq($.test($.env, S.MaybeType($.Number), S.Nothing()), true);
+    eq($.test($.env, S.MaybeType($.Number), S.Nothing), true);
     eq($.test($.env, S.MaybeType($.Number), S.Just(42)), true);
     eq($.test($.env, S.MaybeType($.Number), S.Just('42')), false);
     eq($.test($.env, S.MaybeType($.Number), S.Right(42)), false);

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -13,20 +13,18 @@ var square = require('../utils').square;
 
 describe('Nothing', function() {
 
-  it('is a data constructor', function() {
-    eq(typeof S.Nothing, 'function');
-    eq(S.Nothing.length, 0);
-    eq(S.Nothing()['@@type'], 'sanctuary/Maybe');
-    eq(S.Nothing().isNothing, true);
-    eq(S.Nothing().isJust, false);
+  it('is a member of the "Maybe a" type', function() {
+    eq(S.Nothing['@@type'], 'sanctuary/Maybe');
+    eq(S.Nothing.isNothing, true);
+    eq(S.Nothing.isJust, false);
   });
 
   it('provides an "ap" method', function() {
-    eq(S.Nothing().ap.length, 1);
-    eq(S.Nothing().ap(S.Nothing()), S.Nothing());
-    eq(S.Nothing().ap(S.Just(42)), S.Nothing());
+    eq(S.Nothing.ap.length, 1);
+    eq(S.Nothing.ap(S.Nothing), S.Nothing);
+    eq(S.Nothing.ap(S.Just(42)), S.Nothing);
 
-    throws(function() { S.Nothing().ap([1, 2, 3]); },
+    throws(function() { S.Nothing.ap([1, 2, 3]); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -40,10 +38,10 @@ describe('Nothing', function() {
   });
 
   it('provides a "chain" method', function() {
-    eq(S.Nothing().chain.length, 1);
-    eq(S.Nothing().chain(S.head), S.Nothing());
+    eq(S.Nothing.chain.length, 1);
+    eq(S.Nothing.chain(S.head), S.Nothing);
 
-    throws(function() { S.Nothing().chain(null); },
+    throws(function() { S.Nothing.chain(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -57,11 +55,11 @@ describe('Nothing', function() {
   });
 
   it('provides a "concat" method', function() {
-    eq(S.Nothing().concat.length, 1);
-    eq(S.Nothing().concat(S.Nothing()), S.Nothing());
-    eq(S.Nothing().concat(S.Just('foo')), S.Just('foo'));
+    eq(S.Nothing.concat.length, 1);
+    eq(S.Nothing.concat(S.Nothing), S.Nothing);
+    eq(S.Nothing.concat(S.Just('foo')), S.Just('foo'));
 
-    throws(function() { S.Nothing().concat(null); },
+    throws(function() { S.Nothing.concat(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -73,7 +71,7 @@ describe('Nothing', function() {
                    '\n' +
                    'The value at position 1 is not a member of ‘Maybe a’.\n'));
 
-    throws(function() { S.Nothing().concat(S.Just(1)); },
+    throws(function() { S.Nothing.concat(S.Just(1)); },
            errorEq(TypeError,
                    'Type-class constraint violation\n' +
                    '\n' +
@@ -87,24 +85,24 @@ describe('Nothing', function() {
   });
 
   it('provides an "equals" method', function() {
-    eq(S.Nothing().equals.length, 1);
-    eq(S.Nothing().equals(S.Nothing()), true);
-    eq(S.Nothing().equals(S.Just(42)), false);
-    eq(S.Nothing().equals(null), false);
+    eq(S.Nothing.equals.length, 1);
+    eq(S.Nothing.equals(S.Nothing), true);
+    eq(S.Nothing.equals(S.Just(42)), false);
+    eq(S.Nothing.equals(null), false);
   });
 
   it('provides an "extend" method', function() {
-    eq(S.Nothing().extend.length, 1);
-    eq(S.Nothing().extend(function(x) { return x.value / 2; }), S.Nothing());
+    eq(S.Nothing.extend.length, 1);
+    eq(S.Nothing.extend(function(x) { return x.value / 2; }), S.Nothing);
 
     // associativity
-    var w = S.Nothing();
+    var w = S.Nothing;
     var f = function(x) { return x.value + 1; };
     var g = function(x) { return x.value * x.value; };
     eq(w.extend(g).extend(f),
        w.extend(function(_w) { return f(_w.extend(g)); }));
 
-    throws(function() { S.Nothing().extend(null); },
+    throws(function() { S.Nothing.extend(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -118,11 +116,11 @@ describe('Nothing', function() {
   });
 
   it('provides a "filter" method', function() {
-    eq(S.Nothing().filter.length, 1);
-    eq(S.Nothing().filter(R.T), S.Nothing());
-    eq(S.Nothing().filter(R.F), S.Nothing());
+    eq(S.Nothing.filter.length, 1);
+    eq(S.Nothing.filter(R.T), S.Nothing);
+    eq(S.Nothing.filter(R.F), S.Nothing);
 
-    var m = S.Nothing();
+    var m = S.Nothing;
     var f = function(n) { return n * n; };
     var p = function(n) { return n < 0; };
     var q = function(n) { return n > 0; };
@@ -132,7 +130,7 @@ describe('Nothing', function() {
     assert(m.map(f).filter(q)
            .equals(m.filter(function(x) { return q(f(x)); }).map(f)));
 
-    throws(function() { S.Nothing().filter(null); },
+    throws(function() { S.Nothing.filter(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -146,10 +144,10 @@ describe('Nothing', function() {
   });
 
   it('provides a "map" method', function() {
-    eq(S.Nothing().map.length, 1);
-    eq(S.Nothing().map(function() { return 42; }), S.Nothing());
+    eq(S.Nothing.map.length, 1);
+    eq(S.Nothing.map(function() { return 42; }), S.Nothing);
 
-    throws(function() { S.Nothing().map(null); },
+    throws(function() { S.Nothing.map(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -163,10 +161,10 @@ describe('Nothing', function() {
   });
 
   it('provides a "reduce" method', function() {
-    eq(S.Nothing().reduce.length, 2);
-    eq(S.Nothing().reduce(function(a, b) { return a + b; }, 10), 10);
+    eq(S.Nothing.reduce.length, 2);
+    eq(S.Nothing.reduce(function(a, b) { return a + b; }, 10), 10);
 
-    throws(function() { S.Nothing().reduce(null, null); },
+    throws(function() { S.Nothing.reduce(null, null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -180,31 +178,31 @@ describe('Nothing', function() {
   });
 
   it('provides a "sequence" method', function() {
-    eq(S.Nothing().sequence.length, 1);
-    eq(S.Nothing().sequence(S.Either.of), S.Right(S.Nothing()));
+    eq(S.Nothing.sequence.length, 1);
+    eq(S.Nothing.sequence(S.Either.of), S.Right(S.Nothing));
   });
 
   it('provides a "toBoolean" method', function() {
-    eq(S.Nothing().toBoolean.length, 0);
-    eq(S.Nothing().toBoolean(), false);
+    eq(S.Nothing.toBoolean.length, 0);
+    eq(S.Nothing.toBoolean(), false);
   });
 
   it('provides a "toString" method', function() {
-    eq(S.Nothing().toString.length, 0);
-    eq(S.Nothing().toString(), 'Nothing()');
+    eq(S.Nothing.toString.length, 0);
+    eq(S.Nothing.toString(), 'Nothing');
   });
 
   it('implements Semigroup', function() {
-    var a = S.Nothing();
-    var b = S.Nothing();
-    var c = S.Nothing();
+    var a = S.Nothing;
+    var b = S.Nothing;
+    var c = S.Nothing;
 
     // associativity
     assert(a.concat(b).concat(c).equals(a.concat(b.concat(c))));
   });
 
   it('implements Monoid', function() {
-    var a = S.Nothing();
+    var a = S.Nothing;
 
     // left identity
     assert(a.empty().concat(a).equals(a));
@@ -214,7 +212,7 @@ describe('Nothing', function() {
   });
 
   it('implements Functor', function() {
-    var a = S.Nothing();
+    var a = S.Nothing;
     var f = S.inc;
     var g = square;
 
@@ -226,9 +224,9 @@ describe('Nothing', function() {
   });
 
   it('implements Apply', function() {
-    var a = S.Nothing();
-    var b = S.Nothing();
-    var c = S.Nothing();
+    var a = S.Nothing;
+    var b = S.Nothing;
+    var c = S.Nothing;
 
     // composition
     assert(a.map(function(f) {
@@ -241,8 +239,8 @@ describe('Nothing', function() {
   });
 
   it('implements Applicative', function() {
-    var a = S.Nothing();
-    var b = S.Nothing();
+    var a = S.Nothing;
+    var b = S.Nothing;
     var f = S.inc;
     var x = 7;
 
@@ -257,7 +255,7 @@ describe('Nothing', function() {
   });
 
   it('implements Chain', function() {
-    var a = S.Nothing();
+    var a = S.Nothing;
     var f = S.head;
     var g = S.last;
 
@@ -267,7 +265,7 @@ describe('Nothing', function() {
   });
 
   it('implements Monad', function() {
-    var a = S.Nothing();
+    var a = S.Nothing;
     var f = S.head;
     var x = [1, 2, 3];
 

--- a/test/and.js
+++ b/test/and.js
@@ -30,9 +30,9 @@ describe('and', function() {
   });
 
   it('can be applied to maybes', function() {
-    eq(S.and(S.Nothing(), S.Nothing()), S.Nothing());
-    eq(S.and(S.Nothing(), S.Just(42)), S.Nothing());
-    eq(S.and(S.Just(42), S.Nothing()), S.Nothing());
+    eq(S.and(S.Nothing, S.Nothing), S.Nothing);
+    eq(S.and(S.Nothing, S.Just(42)), S.Nothing);
+    eq(S.and(S.Just(42), S.Nothing), S.Nothing);
     eq(S.and(S.Just(42), S.Just(43)), S.Just(43));
   });
 

--- a/test/at.js
+++ b/test/at.js
@@ -48,10 +48,10 @@ describe('at', function() {
     eq(S.at(-1, ['foo', 'bar', 'baz']), S.Just('baz'));
   });
 
-  it('returns a Nothing if index out of bounds', function() {
-    eq(S.at(3, ['foo', 'bar', 'baz']), S.Nothing());
-    eq(S.at(-4, ['foo', 'bar', 'baz']), S.Nothing());
-    eq(S.at(-0, ['foo', 'bar', 'baz']), S.Nothing());
+  it('returns Nothing if index out of bounds', function() {
+    eq(S.at(3, ['foo', 'bar', 'baz']), S.Nothing);
+    eq(S.at(-4, ['foo', 'bar', 'baz']), S.Nothing);
+    eq(S.at(-0, ['foo', 'bar', 'baz']), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/concat.js
+++ b/test/concat.js
@@ -57,9 +57,9 @@ describe('concat', function() {
   });
 
   it('can be applied to maybes', function() {
-    eq(S.concat(S.Nothing(), S.Nothing()), S.Nothing());
-    eq(S.concat(S.Just('foo'), S.Nothing()), S.Just('foo'));
-    eq(S.concat(S.Nothing(), S.Just('bar')), S.Just('bar'));
+    eq(S.concat(S.Nothing, S.Nothing), S.Nothing);
+    eq(S.concat(S.Just('foo'), S.Nothing), S.Just('foo'));
+    eq(S.concat(S.Nothing, S.Just('bar')), S.Just('bar'));
     eq(S.concat(S.Just('foo'), S.Just('bar')), S.Just('foobar'));
   });
 

--- a/test/drop.js
+++ b/test/drop.js
@@ -40,17 +40,17 @@ describe('drop', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if n is greater than collection length', function() {
-    eq(S.drop(6, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.drop(6, 'abcde'), S.Nothing());
+  it('returns Nothing if n is greater than collection length', function() {
+    eq(S.drop(6, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.drop(6, 'abcde'), S.Nothing);
   });
 
-  it('returns a Nothing if n is negative', function() {
-    eq(S.drop(-3, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.drop(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.drop(-3, 'abcde'), S.Nothing());
-    eq(S.drop(-0, 'abcde'), S.Nothing());
-    eq(S.drop(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing());
+  it('returns Nothing if n is negative', function() {
+    eq(S.drop(-3, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.drop(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.drop(-3, 'abcde'), S.Nothing);
+    eq(S.drop(-0, 'abcde'), S.Nothing);
+    eq(S.drop(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing);
   });
 
   it('returns an empty collection if n is equal to collection length', function() {

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -40,21 +40,21 @@ describe('dropLast', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if n is negative', function() {
-    eq(S.dropLast(-3, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.dropLast(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.dropLast(-3, 'abcde'), S.Nothing());
-    eq(S.dropLast(-0, 'abcde'), S.Nothing());
-    eq(S.dropLast(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing());
+  it('returns Nothing if n is negative', function() {
+    eq(S.dropLast(-3, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.dropLast(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.dropLast(-3, 'abcde'), S.Nothing);
+    eq(S.dropLast(-0, 'abcde'), S.Nothing);
+    eq(S.dropLast(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing);
   });
 
   it('returns a Just dropping the last n items for valid n; Nothing otherwise', function() {
-    eq(S.dropLast(4, ['a', 'b', 'c']), S.Nothing());
+    eq(S.dropLast(4, ['a', 'b', 'c']), S.Nothing);
     eq(S.dropLast(3, ['a', 'b', 'c']), S.Just([]));
     eq(S.dropLast(2, ['a', 'b', 'c']), S.Just(['a']));
     eq(S.dropLast(1, ['a', 'b', 'c']), S.Just(['a', 'b']));
     eq(S.dropLast(0, ['a', 'b', 'c']), S.Just(['a', 'b', 'c']));
-    eq(S.dropLast(4, 'abc'), S.Nothing());
+    eq(S.dropLast(4, 'abc'), S.Nothing);
     eq(S.dropLast(3, 'abc'), S.Just(''));
     eq(S.dropLast(2, 'abc'), S.Just('a'));
     eq(S.dropLast(1, 'abc'), S.Just('ab'));

--- a/test/eitherToMaybe.js
+++ b/test/eitherToMaybe.js
@@ -28,8 +28,8 @@ describe('eitherToMaybe', function() {
                    'The value at position 1 is not a member of ‘Either a b’.\n'));
   });
 
-  it('returns a Nothing when applied to a Left', function() {
-    eq(S.eitherToMaybe(S.Left('Cannot divide by zero')), S.Nothing());
+  it('returns Nothing when applied to a Left', function() {
+    eq(S.eitherToMaybe(S.Left('Cannot divide by zero')), S.Nothing);
   });
 
   it('returns a Just when applied to a Right', function() {

--- a/test/encase.js
+++ b/test/encase.js
@@ -33,8 +33,8 @@ describe('encase', function() {
     eq(S.encase(factorial, 5), S.Just(120));
   });
 
-  it('returns a Nothing on failure', function() {
-    eq(S.encase(factorial, -1), S.Nothing());
+  it('returns Nothing on failure', function() {
+    eq(S.encase(factorial, -1), S.Nothing);
   });
 
   it('can be applied to a function of arbitrary arity', function() {

--- a/test/encase2.js
+++ b/test/encase2.js
@@ -34,8 +34,8 @@ describe('encase2', function() {
     eq(S.encase2(rem, 42, 5), S.Just(2));
   });
 
-  it('returns a Nothing on failure', function() {
-    eq(S.encase2(rem, 42, 0), S.Nothing());
+  it('returns Nothing on failure', function() {
+    eq(S.encase2(rem, 42, 0), S.Nothing);
   });
 
   it('can be applied to a function of arbitrary arity', function() {

--- a/test/encase2_.js
+++ b/test/encase2_.js
@@ -15,8 +15,8 @@ describe('encase2_', function() {
     eq(S.encase2_(rem, 42, 5), S.Just(2));
   });
 
-  it('returns a Nothing on failure', function() {
-    eq(S.encase2_(rem, 42, 0), S.Nothing());
+  it('returns Nothing on failure', function() {
+    eq(S.encase2_(rem, 42, 0), S.Nothing);
   });
 
 });

--- a/test/encase3.js
+++ b/test/encase3.js
@@ -35,8 +35,8 @@ describe('encase3', function() {
     eq(S.encase3(area, 3, 4, 5), S.Just(6));
   });
 
-  it('returns a Nothing on failure', function() {
-    eq(S.encase3(area, 2, 2, 5), S.Nothing());
+  it('returns Nothing on failure', function() {
+    eq(S.encase3(area, 2, 2, 5), S.Nothing);
   });
 
   it('can be applied to a function of arbitrary arity', function() {

--- a/test/encase3_.js
+++ b/test/encase3_.js
@@ -14,8 +14,8 @@ describe('encase3_', function() {
     eq(S.encase3_(area, 3, 4, 5), S.Just(6));
   });
 
-  it('returns a Nothing on failure', function() {
-    eq(S.encase3_(area, 2, 2, 5), S.Nothing());
+  it('returns Nothing on failure', function() {
+    eq(S.encase3_(area, 2, 2, 5), S.Nothing);
   });
 
 });

--- a/test/find.js
+++ b/test/find.js
@@ -46,9 +46,9 @@ describe('find', function() {
     eq(S.find(function(n) { return n >= 0; }, [-1, 0, 1]), S.Just(0));
   });
 
-  it('returns a Nothing if no element satisfies the predicate', function() {
-    eq(S.find(R.T, []), S.Nothing());
-    eq(S.find(R.F, [1, 2, 3]), S.Nothing());
+  it('returns Nothing if no element satisfies the predicate', function() {
+    eq(S.find(R.T, []), S.Nothing);
+    eq(S.find(R.F, [1, 2, 3]), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/fromMaybe.js
+++ b/test/fromMaybe.js
@@ -28,8 +28,8 @@ describe('fromMaybe', function() {
                    'The value at position 1 is not a member of ‘Maybe a’.\n'));
   });
 
-  it('can be applied to a Nothing', function() {
-    eq(S.fromMaybe(0, S.Nothing()), 0);
+  it('can be applied to Nothing', function() {
+    eq(S.fromMaybe(0, S.Nothing), 0);
   });
 
   it('can be applied to a Just', function() {

--- a/test/get.js
+++ b/test/get.js
@@ -56,8 +56,8 @@ describe('get', function() {
     var obj = {x: 0, y: 42};
     eq(S.get(Number, 'x', obj), S.Just(0));
     eq(S.get(Number, 'y', obj), S.Just(42));
-    eq(S.get(Number, 'z', obj), S.Nothing());
-    eq(S.get(String, 'x', obj), S.Nothing());
+    eq(S.get(Number, 'z', obj), S.Nothing);
+    eq(S.get(String, 'x', obj), S.Nothing);
   });
 
   it('does not rely on constructor identity', function() {

--- a/test/gets.js
+++ b/test/gets.js
@@ -55,12 +55,12 @@ describe('gets', function() {
 
   it('returns a Maybe', function() {
     var obj = {x: {z: 0}, y: 42};
-    eq(S.gets(Number, ['x'], obj), S.Nothing());
+    eq(S.gets(Number, ['x'], obj), S.Nothing);
     eq(S.gets(Number, ['y'], obj), S.Just(42));
-    eq(S.gets(Number, ['z'], obj), S.Nothing());
+    eq(S.gets(Number, ['z'], obj), S.Nothing);
     eq(S.gets(Number, ['x', 'z'], obj), S.Just(0));
-    eq(S.gets(Number, ['a', 'b', 'c'], obj), S.Nothing());
-    eq(S.gets(Number, [], obj), S.Nothing());
+    eq(S.gets(Number, ['a', 'b', 'c'], obj), S.Nothing);
+    eq(S.gets(Number, [], obj), S.Nothing);
     eq(S.gets(Object, [], obj), S.Just({x: {z: 0}, y: 42}));
   });
 

--- a/test/head.js
+++ b/test/head.js
@@ -28,8 +28,8 @@ describe('head', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if applied to empty list', function() {
-    eq(S.head([]), S.Nothing());
+  it('returns Nothing if applied to empty list', function() {
+    eq(S.head([]), S.Nothing);
   });
 
   it('returns Just the head of a nonempty list', function() {

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -28,12 +28,12 @@ describe('indexOf', function() {
                    '‘indexOf’ requires ‘b’ to satisfy the ArrayLike type-class constraint; the value at position 1 does not.\n'));
   });
 
-  it('returns a Nothing for an empty list', function() {
-    eq(S.indexOf(10, []), S.Nothing());
+  it('returns Nothing for an empty list', function() {
+    eq(S.indexOf(10, []), S.Nothing);
   });
 
-  it('returns a Nothing if the element is not found', function() {
-    eq(S.indexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing());
+  it('returns Nothing if the element is not found', function() {
+    eq(S.indexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing);
   });
 
   it('returns Just the index of the element found', function() {
@@ -42,7 +42,7 @@ describe('indexOf', function() {
 
   it('can operate on strings', function() {
     eq(S.indexOf('an', 'banana'), S.Just(1));
-    eq(S.indexOf('ax', 'banana'), S.Nothing());
+    eq(S.indexOf('ax', 'banana'), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/init.js
+++ b/test/init.js
@@ -28,8 +28,8 @@ describe('init', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if applied to empty list', function() {
-    eq(S.init([]), S.Nothing());
+  it('returns Nothing if applied to empty list', function() {
+    eq(S.init([]), S.Nothing);
   });
 
   it('returns Just the initial elements of a nonempty list', function() {

--- a/test/isJust.js
+++ b/test/isJust.js
@@ -32,8 +32,8 @@ describe('isJust', function() {
     eq(S.isJust(S.Just(42)), true);
   });
 
-  it('returns false when applied to a Nothing', function() {
-    eq(S.isJust(S.Nothing()), false);
+  it('returns false when applied to Nothing', function() {
+    eq(S.isJust(S.Nothing), false);
   });
 
 });

--- a/test/isNothing.js
+++ b/test/isNothing.js
@@ -28,8 +28,8 @@ describe('isNothing', function() {
                    'The value at position 1 is not a member of ‘Maybe a’.\n'));
   });
 
-  it('returns true when applied to a Nothing', function() {
-    eq(S.isNothing(S.Nothing()), true);
+  it('returns true when applied to Nothing', function() {
+    eq(S.isNothing(S.Nothing), true);
   });
 
   it('returns false when applied to a Just', function() {

--- a/test/justs.js
+++ b/test/justs.js
@@ -31,9 +31,9 @@ describe('justs', function() {
 
   it('returns a list containing the value of each Just', function() {
     eq(S.justs([]), []);
-    eq(S.justs([S.Nothing(), S.Nothing()]), []);
-    eq(S.justs([S.Nothing(), S.Just('b')]), ['b']);
-    eq(S.justs([S.Just('a'), S.Nothing()]), ['a']);
+    eq(S.justs([S.Nothing, S.Nothing]), []);
+    eq(S.justs([S.Nothing, S.Just('b')]), ['b']);
+    eq(S.justs([S.Just('a'), S.Nothing]), ['a']);
     eq(S.justs([S.Just('a'), S.Just('b')]), ['a', 'b']);
   });
 

--- a/test/last.js
+++ b/test/last.js
@@ -28,8 +28,8 @@ describe('last', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if applied to empty list', function() {
-    eq(S.last([]), S.Nothing());
+  it('returns Nothing if applied to empty list', function() {
+    eq(S.last([]), S.Nothing);
   });
 
   it('returns Just the last element of a nonempty list', function() {

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -28,12 +28,12 @@ describe('lastIndexOf', function() {
                    '‘lastIndexOf’ requires ‘b’ to satisfy the ArrayLike type-class constraint; the value at position 1 does not.\n'));
   });
 
-  it('returns a Nothing for an empty list', function() {
-    eq(S.lastIndexOf('a', []), S.Nothing());
+  it('returns Nothing for an empty list', function() {
+    eq(S.lastIndexOf('a', []), S.Nothing);
   });
 
-  it('returns a Nothing if the element is not found', function() {
-    eq(S.lastIndexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing());
+  it('returns Nothing if the element is not found', function() {
+    eq(S.lastIndexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing);
   });
 
   it('returns Just the last index of the element found', function() {
@@ -42,7 +42,7 @@ describe('lastIndexOf', function() {
 
   it('can operate on strings', function() {
     eq(S.lastIndexOf('an', 'banana'), S.Just(3));
-    eq(S.lastIndexOf('ax', 'banana'), S.Nothing());
+    eq(S.lastIndexOf('ax', 'banana'), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/lift.js
+++ b/test/lift.js
@@ -33,7 +33,7 @@ describe('lift2', function() {
     var positive = function(n) { return n > 0; };
 
     eq(S.lift2(S.add, S.Just(3), S.Just(3)), S.Just(6));
-    eq(S.lift2(S.add, S.Nothing(), S.Just(3)), S.Nothing());
+    eq(S.lift2(S.add, S.Nothing, S.Just(3)), S.Nothing);
 
     eq(S.lift2(S.add, S.Right(3), S.Left(4)), S.Left(4));
     eq(S.lift2(S.add, S.Right(3), S.Right(4)), S.Right(7));

--- a/test/lift2.js
+++ b/test/lift2.js
@@ -30,7 +30,7 @@ describe('lift', function() {
 
   it('lifts a function into the context of Functors', function() {
     eq(S.lift(S.mult(2), S.Just(3)), S.Just(6));
-    eq(S.lift(S.mult(2), S.Nothing()), S.Nothing());
+    eq(S.lift(S.mult(2), S.Nothing), S.Nothing);
 
     eq(S.lift(S.mult(2), S.Left(3)), S.Left(3));
     eq(S.lift(S.mult(2), S.Right(3)), S.Right(6));

--- a/test/lift3.js
+++ b/test/lift3.js
@@ -32,7 +32,7 @@ describe('lift3', function() {
 
   it('lifts a function into the context of Applys', function() {
     eq(S.lift3(S.reduce, S.Just(S.add), S.Just(0), S.Just([1, 2, 3])), S.Just(6));
-    eq(S.lift3(S.reduce, S.Just(S.add), S.Just(0), S.Nothing()), S.Nothing());
+    eq(S.lift3(S.reduce, S.Just(S.add), S.Just(0), S.Nothing), S.Nothing);
 
     eq(S.lift3(S.reduce, S.Right(S.add), S.Right(0), S.Right([1, 2, 3])), S.Right(6));
     eq(S.lift3(S.reduce, S.Right(S.add), S.Right(0), S.Left('WHOOPS')), S.Left('WHOOPS'));

--- a/test/match.js
+++ b/test/match.js
@@ -53,11 +53,11 @@ describe('match', function() {
     eq(S.match(/(good)?bye/, 'goodbye'),
        S.Just([S.Just('goodbye'), S.Just('good')]));
     eq(S.match(/(good)?bye/, 'bye'),
-       S.Just([S.Just('bye'), S.Nothing()]));
+       S.Just([S.Just('bye'), S.Nothing]));
   });
 
-  it('returns a Nothing if no match', function() {
-    eq(S.match(/zzz/, 'abcdefg'), S.Nothing());
+  it('returns Nothing if no match', function() {
+    eq(S.match(/zzz/, 'abcdefg'), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -44,8 +44,8 @@ describe('maybe', function() {
                    'The value at position 1 is not a member of ‘Maybe a’.\n'));
   });
 
-  it('can be applied to a Nothing', function() {
-    eq(S.maybe(0, R.length, S.Nothing()), 0);
+  it('can be applied to Nothing', function() {
+    eq(S.maybe(0, R.length, S.Nothing), 0);
   });
 
   it('can be applied to a Just', function() {

--- a/test/maybeToEither.js
+++ b/test/maybeToEither.js
@@ -29,7 +29,7 @@ describe('maybeToEither', function() {
   });
 
   it('returns a Left of its first argument when the second is Nothing', function() {
-    eq(S.maybeToEither('error msg', S.Nothing()), S.Left('error msg'));
+    eq(S.maybeToEither('error msg', S.Nothing), S.Left('error msg'));
   });
 
   it('returns a Right of the value contained in the Just when the second argument is a Just', function() {

--- a/test/maybeToNullable.js
+++ b/test/maybeToNullable.js
@@ -28,8 +28,8 @@ describe('maybeToNullable', function() {
                    'The value at position 1 is not a member of ‘Maybe a’.\n'));
   });
 
-  it('can be applied to a Nothing', function() {
-    eq(S.maybeToNullable(S.Nothing()), null);
+  it('can be applied to Nothing', function() {
+    eq(S.maybeToNullable(S.Nothing), null);
   });
 
   it('can be applied to a Just', function() {

--- a/test/mean.js
+++ b/test/mean.js
@@ -59,17 +59,17 @@ describe('mean', function() {
     eq(S.mean([-0, 0]), S.Just(0));
   });
 
-  it('returns nothing when applied to an empty array', function() {
-    eq(S.mean([]), S.Nothing());
+  it('returns Nothing when applied to an empty array', function() {
+    eq(S.mean([]), S.Nothing);
   });
 
-  it('can be applied to Maybes', function() {
-    eq(S.mean(S.Nothing()), S.Nothing());
+  it('can be applied to maybes', function() {
+    eq(S.mean(S.Nothing), S.Nothing);
     eq(S.mean(S.Just(42)), S.Just(42));
   });
 
-  it('can be applied to Eithers', function() {
-    eq(S.mean(S.Left('xxx')), S.Nothing());
+  it('can be applied to eithers', function() {
+    eq(S.mean(S.Left('xxx')), S.Nothing);
     eq(S.mean(S.Right(42)), S.Just(42));
   });
 

--- a/test/or.js
+++ b/test/or.js
@@ -30,9 +30,9 @@ describe('or', function() {
   });
 
   it('can be applied to maybes', function() {
-    eq(S.or(S.Nothing(), S.Nothing()), S.Nothing());
-    eq(S.or(S.Nothing(), S.Just(42)), S.Just(42));
-    eq(S.or(S.Just(42), S.Nothing()), S.Just(42));
+    eq(S.or(S.Nothing, S.Nothing), S.Nothing);
+    eq(S.or(S.Nothing, S.Just(42)), S.Just(42));
+    eq(S.or(S.Just(42), S.Nothing), S.Just(42));
     eq(S.or(S.Just(42), S.Just(43)), S.Just(42));
   });
 

--- a/test/parseDate.js
+++ b/test/parseDate.js
@@ -33,8 +33,8 @@ describe('parseDate', function() {
        S.Just(new Date('2001-02-03T04:05:06Z')));
   });
 
-  it('returns a Nothing when applied to an invalid date string', function() {
-    eq(S.parseDate('today'), S.Nothing());
+  it('returns Nothing when applied to an invalid date string', function() {
+    eq(S.parseDate('today'), S.Nothing);
   });
 
 });

--- a/test/parseFloat.js
+++ b/test/parseFloat.js
@@ -50,15 +50,15 @@ describe('parseFloat', function() {
     eq(S.parseFloat('-.25'), S.Just(-0.25));
     eq(S.parseFloat('0.5 '), S.Just(0.5));
     eq(S.parseFloat(' 0.5'), S.Just(0.5));
-    eq(S.parseFloat('0.5x'), S.Nothing());  // parseFloat('0.5x') == 0.25
-    eq(S.parseFloat('x0.5'), S.Nothing());
+    eq(S.parseFloat('0.5x'), S.Nothing);  // parseFloat('0.5x') == 0.25
+    eq(S.parseFloat('x0.5'), S.Nothing);
     eq(S.parseFloat('-1e3'), S.Just(-1000));
     eq(S.parseFloat('-1e03'), S.Just(-1000));
     eq(S.parseFloat('-1e+3'), S.Just(-1000));
     eq(S.parseFloat('-1e+03'), S.Just(-1000));
     eq(S.parseFloat('-1e-3'), S.Just(-0.001));
     eq(S.parseFloat('-1e-03'), S.Just(-0.001));
-    eq(S.parseFloat('xxx'), S.Nothing());
+    eq(S.parseFloat('xxx'), S.Nothing);
   });
 
 });

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -43,81 +43,81 @@ describe('parseInt', function() {
   it('returns a Maybe', function() {
     eq(S.parseInt(10, '42'), S.Just(42));
     eq(S.parseInt(16, '2A'), S.Just(42));
-    eq(S.parseInt(10, 'NaN'), S.Nothing());
-    eq(S.parseInt(10, 'xxx'), S.Nothing());
+    eq(S.parseInt(10, 'NaN'), S.Nothing);
+    eq(S.parseInt(10, 'xxx'), S.Nothing);
   });
 
   it('accepts radix in [2 .. 36]', function() {
     eq(S.parseInt(2, '1'), S.Just(1));
-    eq(S.parseInt(2, '2'), S.Nothing());
+    eq(S.parseInt(2, '2'), S.Nothing);
     eq(S.parseInt(3, '2'), S.Just(2));
-    eq(S.parseInt(3, '3'), S.Nothing());
+    eq(S.parseInt(3, '3'), S.Nothing);
     eq(S.parseInt(4, '3'), S.Just(3));
-    eq(S.parseInt(4, '4'), S.Nothing());
+    eq(S.parseInt(4, '4'), S.Nothing);
     eq(S.parseInt(5, '4'), S.Just(4));
-    eq(S.parseInt(5, '5'), S.Nothing());
+    eq(S.parseInt(5, '5'), S.Nothing);
     eq(S.parseInt(6, '5'), S.Just(5));
-    eq(S.parseInt(6, '6'), S.Nothing());
+    eq(S.parseInt(6, '6'), S.Nothing);
     eq(S.parseInt(7, '6'), S.Just(6));
-    eq(S.parseInt(7, '7'), S.Nothing());
+    eq(S.parseInt(7, '7'), S.Nothing);
     eq(S.parseInt(8, '7'), S.Just(7));
-    eq(S.parseInt(8, '8'), S.Nothing());
+    eq(S.parseInt(8, '8'), S.Nothing);
     eq(S.parseInt(9, '8'), S.Just(8));
-    eq(S.parseInt(9, '9'), S.Nothing());
+    eq(S.parseInt(9, '9'), S.Nothing);
     eq(S.parseInt(10, '9'), S.Just(9));
-    eq(S.parseInt(10, 'A'), S.Nothing());
+    eq(S.parseInt(10, 'A'), S.Nothing);
     eq(S.parseInt(11, 'A'), S.Just(10));
-    eq(S.parseInt(11, 'B'), S.Nothing());
+    eq(S.parseInt(11, 'B'), S.Nothing);
     eq(S.parseInt(12, 'B'), S.Just(11));
-    eq(S.parseInt(12, 'C'), S.Nothing());
+    eq(S.parseInt(12, 'C'), S.Nothing);
     eq(S.parseInt(13, 'C'), S.Just(12));
-    eq(S.parseInt(13, 'D'), S.Nothing());
+    eq(S.parseInt(13, 'D'), S.Nothing);
     eq(S.parseInt(14, 'D'), S.Just(13));
-    eq(S.parseInt(14, 'E'), S.Nothing());
+    eq(S.parseInt(14, 'E'), S.Nothing);
     eq(S.parseInt(15, 'E'), S.Just(14));
-    eq(S.parseInt(15, 'F'), S.Nothing());
+    eq(S.parseInt(15, 'F'), S.Nothing);
     eq(S.parseInt(16, 'F'), S.Just(15));
-    eq(S.parseInt(16, 'G'), S.Nothing());
+    eq(S.parseInt(16, 'G'), S.Nothing);
     eq(S.parseInt(17, 'G'), S.Just(16));
-    eq(S.parseInt(17, 'H'), S.Nothing());
+    eq(S.parseInt(17, 'H'), S.Nothing);
     eq(S.parseInt(18, 'H'), S.Just(17));
-    eq(S.parseInt(18, 'I'), S.Nothing());
+    eq(S.parseInt(18, 'I'), S.Nothing);
     eq(S.parseInt(19, 'I'), S.Just(18));
-    eq(S.parseInt(19, 'J'), S.Nothing());
+    eq(S.parseInt(19, 'J'), S.Nothing);
     eq(S.parseInt(20, 'J'), S.Just(19));
-    eq(S.parseInt(20, 'K'), S.Nothing());
+    eq(S.parseInt(20, 'K'), S.Nothing);
     eq(S.parseInt(21, 'K'), S.Just(20));
-    eq(S.parseInt(21, 'L'), S.Nothing());
+    eq(S.parseInt(21, 'L'), S.Nothing);
     eq(S.parseInt(22, 'L'), S.Just(21));
-    eq(S.parseInt(22, 'M'), S.Nothing());
+    eq(S.parseInt(22, 'M'), S.Nothing);
     eq(S.parseInt(23, 'M'), S.Just(22));
-    eq(S.parseInt(23, 'N'), S.Nothing());
+    eq(S.parseInt(23, 'N'), S.Nothing);
     eq(S.parseInt(24, 'N'), S.Just(23));
-    eq(S.parseInt(24, 'O'), S.Nothing());
+    eq(S.parseInt(24, 'O'), S.Nothing);
     eq(S.parseInt(25, 'O'), S.Just(24));
-    eq(S.parseInt(25, 'P'), S.Nothing());
+    eq(S.parseInt(25, 'P'), S.Nothing);
     eq(S.parseInt(26, 'P'), S.Just(25));
-    eq(S.parseInt(26, 'Q'), S.Nothing());
+    eq(S.parseInt(26, 'Q'), S.Nothing);
     eq(S.parseInt(27, 'Q'), S.Just(26));
-    eq(S.parseInt(27, 'R'), S.Nothing());
+    eq(S.parseInt(27, 'R'), S.Nothing);
     eq(S.parseInt(28, 'R'), S.Just(27));
-    eq(S.parseInt(28, 'S'), S.Nothing());
+    eq(S.parseInt(28, 'S'), S.Nothing);
     eq(S.parseInt(29, 'S'), S.Just(28));
-    eq(S.parseInt(29, 'T'), S.Nothing());
+    eq(S.parseInt(29, 'T'), S.Nothing);
     eq(S.parseInt(30, 'T'), S.Just(29));
-    eq(S.parseInt(30, 'U'), S.Nothing());
+    eq(S.parseInt(30, 'U'), S.Nothing);
     eq(S.parseInt(31, 'U'), S.Just(30));
-    eq(S.parseInt(31, 'V'), S.Nothing());
+    eq(S.parseInt(31, 'V'), S.Nothing);
     eq(S.parseInt(32, 'V'), S.Just(31));
-    eq(S.parseInt(32, 'W'), S.Nothing());
+    eq(S.parseInt(32, 'W'), S.Nothing);
     eq(S.parseInt(33, 'W'), S.Just(32));
-    eq(S.parseInt(33, 'X'), S.Nothing());
+    eq(S.parseInt(33, 'X'), S.Nothing);
     eq(S.parseInt(34, 'X'), S.Just(33));
-    eq(S.parseInt(34, 'Y'), S.Nothing());
+    eq(S.parseInt(34, 'Y'), S.Nothing);
     eq(S.parseInt(35, 'Y'), S.Just(34));
-    eq(S.parseInt(35, 'Z'), S.Nothing());
+    eq(S.parseInt(35, 'Z'), S.Nothing);
     eq(S.parseInt(36, 'Z'), S.Just(35));
-    eq(S.parseInt(36, '['), S.Nothing());
+    eq(S.parseInt(36, '['), S.Nothing);
   });
 
   it('throws if radix is not in [2 .. 36]', function() {
@@ -145,26 +145,26 @@ describe('parseInt', function() {
   it('accepts optional "0x" or "0X" prefix when radix is 16', function() {
     eq(S.parseInt(16, '0xFF'), S.Just(255));
     eq(S.parseInt(16, '0XFF'), S.Just(255));
-    eq(S.parseInt(17, '0xFF'), S.Nothing());
-    eq(S.parseInt(17, '0XFF'), S.Nothing());
+    eq(S.parseInt(17, '0xFF'), S.Nothing);
+    eq(S.parseInt(17, '0XFF'), S.Nothing);
     eq(S.parseInt(16, '+0xFF'), S.Just(255));
     eq(S.parseInt(16, '+0XFF'), S.Just(255));
     eq(S.parseInt(16, '-0xFF'), S.Just(-255));
     eq(S.parseInt(16, '-0XFF'), S.Just(-255));
   });
 
-  it('returns a Nothing if one or more characters are invalid', function() {
-    eq(S.parseInt(10, '12.34'), S.Nothing());  // parseInt('12.34', 10) == 12
-    eq(S.parseInt(16, 'alice'), S.Nothing());  // parseInt('alice', 16) == 10
+  it('returns Nothing if one or more characters are invalid', function() {
+    eq(S.parseInt(10, '12.34'), S.Nothing);  // parseInt('12.34', 10) == 12
+    eq(S.parseInt(16, 'alice'), S.Nothing);  // parseInt('alice', 16) == 10
   });
 
   it('restricts to exactly representable range (-2^53 .. 2^53)', function() {
     eq(S.parseInt(10,  '9007199254740991'), S.Just(9007199254740991));
     eq(S.parseInt(10, '-9007199254740991'), S.Just(-9007199254740991));
-    eq(S.parseInt(10,  '9007199254740992'), S.Nothing());
-    eq(S.parseInt(10, '-9007199254740992'), S.Nothing());
-    eq(S.parseInt(10,  'Infinity'), S.Nothing());
-    eq(S.parseInt(10, '-Infinity'), S.Nothing());
+    eq(S.parseInt(10,  '9007199254740992'), S.Nothing);
+    eq(S.parseInt(10, '-9007199254740992'), S.Nothing);
+    eq(S.parseInt(10,  'Infinity'), S.Nothing);
+    eq(S.parseInt(10, '-Infinity'), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -44,12 +44,12 @@ describe('parseJson', function() {
     eq(S.parseJson(Array, '["foo","bar"]'), S.Just(['foo', 'bar']));
   });
 
-  it('returns a Nothing when applied to an invalid JSON string', function() {
-    eq(S.parseJson(Object, '[Invalid JSON]'), S.Nothing());
+  it('returns Nothing when applied to an invalid JSON string', function() {
+    eq(S.parseJson(Object, '[Invalid JSON]'), S.Nothing);
   });
 
-  it('returns a Nothing when the parsed result is not a member of the given type', function() {
-    eq(S.parseJson(Array, '{"foo":"bar"}'), S.Nothing());
+  it('returns Nothing when the parsed result is not a member of the given type', function() {
+    eq(S.parseJson(Array, '{"foo":"bar"}'), S.Nothing);
   });
 
 });

--- a/test/pluck.js
+++ b/test/pluck.js
@@ -57,7 +57,7 @@ describe('pluck', function() {
     var xs = [{x: '1'}, {x: 2}, {x: null}, {x: undefined}, {}];
     eq(S.pluck(Number, 'x', []), []);
     eq(S.pluck(Number, 'x', xs),
-       [S.Nothing(), S.Just(2), S.Nothing(), S.Nothing(), S.Nothing()]);
+       [S.Nothing, S.Just(2), S.Nothing, S.Nothing, S.Nothing]);
   });
 
   it('does not rely on constructor identity', function() {

--- a/test/product.js
+++ b/test/product.js
@@ -72,12 +72,12 @@ describe('product', function() {
     eq(S.product([1, 2, 3, 4, -5]), -120);
   });
 
-  it('can be applied to Maybes', function() {
-    eq(S.product(S.Nothing()), 1);
+  it('can be applied to maybes', function() {
+    eq(S.product(S.Nothing), 1);
     eq(S.product(S.Just(42)), 42);
   });
 
-  it('can be applied to Eithers', function() {
+  it('can be applied to eithers', function() {
     eq(S.product(S.Left('xxx')), 1);
     eq(S.product(S.Right(42)), 42);
   });

--- a/test/slice.js
+++ b/test/slice.js
@@ -52,20 +52,20 @@ describe('slice', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing with a positive end index greater than start index', function() {
-    eq(S.slice(6, 1, [1, 2, 3, 4, 5]), S.Nothing());
+  it('returns Nothing with a positive end index greater than start index', function() {
+    eq(S.slice(6, 1, [1, 2, 3, 4, 5]), S.Nothing);
   });
 
-  it('returns a Nothing with a positive end index greater than list length', function() {
-    eq(S.slice(1, 6, [1, 2, 3, 4, 5]), S.Nothing());
+  it('returns Nothing with a positive end index greater than list length', function() {
+    eq(S.slice(1, 6, [1, 2, 3, 4, 5]), S.Nothing);
   });
 
-  it('returns a Nothing with a negative end index greater than list length', function() {
-    eq(S.slice(1, -6, [1, 2, 3, 4, 5]), S.Nothing());
+  it('returns Nothing with a negative end index greater than list length', function() {
+    eq(S.slice(1, -6, [1, 2, 3, 4, 5]), S.Nothing);
   });
 
-  it('returns a Nothing with a negative start index greater than list length', function() {
-    eq(S.slice(-6, 1, [1, 2, 3, 4, 5]), S.Nothing());
+  it('returns Nothing with a negative start index greater than list length', function() {
+    eq(S.slice(-6, 1, [1, 2, 3, 4, 5]), S.Nothing);
   });
 
   it('returns a Just with an empty array when start index equals end index', function() {
@@ -106,7 +106,7 @@ describe('slice', function() {
     eq(S.slice(0, -0, 'ramda'), S.Just('ramda'));
     eq(S.slice(1, -3, 'ramda'), S.Just('a'));
     eq(S.slice(2, -3, 'ramda'), S.Just(''));
-    eq(S.slice(3, -3, 'ramda'), S.Nothing());
+    eq(S.slice(3, -3, 'ramda'), S.Nothing);
   });
 
   it('is curried', function() {

--- a/test/sum.js
+++ b/test/sum.js
@@ -72,12 +72,12 @@ describe('sum', function() {
     eq(S.sum([1, 2, 3, 4, -5]), 5);
   });
 
-  it('can be applied to Maybes', function() {
-    eq(S.sum(S.Nothing()), 0);
+  it('can be applied to maybes', function() {
+    eq(S.sum(S.Nothing), 0);
     eq(S.sum(S.Just(42)), 42);
   });
 
-  it('can be applied to Eithers', function() {
+  it('can be applied to eithers', function() {
     eq(S.sum(S.Left('xxx')), 0);
     eq(S.sum(S.Right(42)), 42);
   });

--- a/test/tail.js
+++ b/test/tail.js
@@ -28,8 +28,8 @@ describe('tail', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if applied to empty list', function() {
-    eq(S.tail([]), S.Nothing());
+  it('returns Nothing if applied to empty list', function() {
+    eq(S.tail([]), S.Nothing);
   });
 
   it('returns Just the tail of a nonempty list', function() {

--- a/test/take.js
+++ b/test/take.js
@@ -39,17 +39,17 @@ describe('take', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if n is greater than collection length', function() {
-    eq(S.take(6, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.take(6, 'abcde'), S.Nothing());
+  it('returns Nothing if n is greater than collection length', function() {
+    eq(S.take(6, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.take(6, 'abcde'), S.Nothing);
   });
 
-  it('returns a Nothing if n is negative', function() {
-    eq(S.take(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.take(-1, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.take(-0, 'abcdefg'), S.Nothing());
-    eq(S.take(-1, 'abcde'), S.Nothing());
-    eq(S.take(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing());
+  it('returns Nothing if n is negative', function() {
+    eq(S.take(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.take(-1, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.take(-0, 'abcdefg'), S.Nothing);
+    eq(S.take(-1, 'abcde'), S.Nothing);
+    eq(S.take(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing);
   });
 
   it('returns an empty collection if n is 0', function() {

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -39,21 +39,21 @@ describe('takeLast', function() {
                    'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
-  it('returns a Nothing if n is negative', function() {
-    eq(S.takeLast(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.takeLast(-1, ['a', 'b', 'c', 'd', 'e']), S.Nothing());
-    eq(S.takeLast(-0, 'abcde'), S.Nothing());
-    eq(S.takeLast(-1, 'abcde'), S.Nothing());
-    eq(S.takeLast(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing());
+  it('returns Nothing if n is negative', function() {
+    eq(S.takeLast(-0, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.takeLast(-1, ['a', 'b', 'c', 'd', 'e']), S.Nothing);
+    eq(S.takeLast(-0, 'abcde'), S.Nothing);
+    eq(S.takeLast(-1, 'abcde'), S.Nothing);
+    eq(S.takeLast(new Number(-0), ['a', 'b', 'c', 'd', 'e']), S.Nothing);
   });
 
   it('returns a Just with the last n elements for valid n; Nothing otherwise', function() {
-    eq(S.takeLast(4, ['a', 'b', 'c']), S.Nothing());
+    eq(S.takeLast(4, ['a', 'b', 'c']), S.Nothing);
     eq(S.takeLast(3, ['a', 'b', 'c']), S.Just(['a', 'b', 'c']));
     eq(S.takeLast(2, ['a', 'b', 'c']), S.Just(['b', 'c']));
     eq(S.takeLast(1, ['a', 'b', 'c']), S.Just(['c']));
     eq(S.takeLast(0, ['a', 'b', 'c']), S.Just([]));
-    eq(S.takeLast(4, 'abc'), S.Nothing());
+    eq(S.takeLast(4, 'abc'), S.Nothing);
     eq(S.takeLast(3, 'abc'), S.Just('abc'));
     eq(S.takeLast(2, 'abc'), S.Just('bc'));
     eq(S.takeLast(1, 'abc'), S.Just('c'));

--- a/test/toMaybe.js
+++ b/test/toMaybe.js
@@ -11,9 +11,9 @@ describe('toMaybe', function() {
     eq(S.toMaybe.length, 1);
   });
 
-  it('returns a Nothing when applied to null/undefined', function() {
-    eq(S.toMaybe(null), S.Nothing());
-    eq(S.toMaybe(undefined), S.Nothing());
+  it('returns Nothing when applied to null/undefined', function() {
+    eq(S.toMaybe(null), S.Nothing);
+    eq(S.toMaybe(undefined), S.Nothing);
   });
 
   it('returns a Just when applied to any other value', function() {

--- a/test/type.js
+++ b/test/type.js
@@ -34,7 +34,7 @@ describe('type', function() {
   it('operates on values of Sanctuary types', function() {
     eq(S.type(S.Left(42)),  'sanctuary/Either');
     eq(S.type(S.Right(42)), 'sanctuary/Either');
-    eq(S.type(S.Nothing()), 'sanctuary/Maybe');
+    eq(S.type(S.Nothing), 'sanctuary/Maybe');
     eq(S.type(S.Just(42)),  'sanctuary/Maybe');
   });
 

--- a/test/unfolr.js
+++ b/test/unfolr.js
@@ -30,7 +30,7 @@ describe('unfoldr', function() {
 
   it('correctly unfolds a value into a list', function() {
     var f = function(n) {
-      return n >= 5 ? S.Nothing() : S.Just([n, n + 1]);
+      return n >= 5 ? S.Nothing : S.Just([n, n + 1]);
     };
     eq(S.unfoldr(f, 5), []);
     eq(S.unfoldr(f, 4), [4]);

--- a/test/xor.js
+++ b/test/xor.js
@@ -30,10 +30,10 @@ describe('xor', function() {
   });
 
   it('can be applied to maybes', function() {
-    eq(S.xor(S.Nothing(), S.Nothing()), S.Nothing());
-    eq(S.xor(S.Nothing(), S.Just(42)), S.Just(42));
-    eq(S.xor(S.Just(42), S.Nothing()), S.Just(42));
-    eq(S.xor(S.Just(42), S.Just(43)), S.Nothing());
+    eq(S.xor(S.Nothing, S.Nothing), S.Nothing);
+    eq(S.xor(S.Nothing, S.Just(42)), S.Just(42));
+    eq(S.xor(S.Just(42), S.Nothing), S.Just(42));
+    eq(S.xor(S.Just(42), S.Just(43)), S.Nothing);
   });
 
   it('cannot be applied to eithers', function() {


### PR DESCRIPTION
Initially, `S.Nothing` existed both to create the `Nothing` value and to support `R.is(S.Nothing)`. `S.Nothing` is no longer a constructor function, and we now have [`S.isNothing`][1] to answer the question of whether a given value of type `Maybe a` is `Nothing`. This means `S.Nothing` can now be the `Nothing` value, improving Haskell correspondence:

|                   | Nothing           | Just              |
| ----------------- | ----------------- | ----------------- |
| Sanctuary, before | `S.Nothing()`     | `S.Just(42)`      |
| Sanctuary, after  | `S.Nothing`       | `S.Just(42)`      |
| Haskell           | `Nothing`         | `Just 42`         |

Can anyone think of a problem with this change?

---

_This evening I realized for the first time that “nothing” is comprised of “no” and “thing”. I now think Haskell should have gone with `data Maybe a = Thing a | Nothing`. ;)_


[1]: http://sanctuary.js.org/#isNothing
