### PR TITLE
Upgrade to version 3 of Mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "2.9.x",
     "istanbul": "0.4.x",
     "jsverify": "0.7.x",
-    "mocha": "2.x.x",
+    "mocha": "3.x.x",
     "sanctuary-style": "0.1.x",
     "transcribe": "0.4.x",
     "xyz": "0.5.x"


### PR DESCRIPTION
This is just to get rid of that annoying warning message:

```
npm WARN deprecated to-iso-string@0.0.2: to-iso-string has been deprecated, use @segment/to-iso-string instead.
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```