### PR TITLE
switch from Node v5.x.x to Node v6.x.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ setup:
 test:
 	$(ISTANBUL) cover node_modules/.bin/_mocha -- --recursive --timeout 10000
 	$(ISTANBUL) check-coverage --branches 100
-ifneq ($(shell node --version | sed 's/[.][^.]*$$//'),v0.10)
+ifeq ($(shell node --version | cut -d . -f 1),v6)
 	$(DOCTEST) -- index.js
+else
+	@echo '[WARN] Doctests are only run in Node v6.x.x (current version is $(shell node --version))' >&2
 endif

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,8 @@
 dependencies:
   override:
+    - printf '%s\n' color=false progress=false >.npmrc
     - rm -rf node_modules
-    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 0.12.7 make setup ;; 2) nvm exec 4 make setup ;; 3) nvm exec 5 make setup ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 0.12.7 make setup ;; 2) nvm exec 4 make setup ;; 3) nvm install 6 && nvm exec 6 make setup ;; esac:
         parallel: true
 
 machine:
@@ -11,5 +12,5 @@ machine:
 test:
   override:
     - make lint
-    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 0.12.7 make test ;; 2) nvm exec 4 make test ;; 3) nvm exec 5 make test ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 0.12.7 make test ;; 2) nvm exec 4 make test ;; 3) nvm exec 6 make test ;; esac:
         parallel: true

--- a/index.js
+++ b/index.js
@@ -1983,10 +1983,10 @@
   //. Right(['foo', 'bar', 'baz'])
   //.
   //. > S.encaseEither(S.I, JSON.parse, '[')
-  //. Left(new SyntaxError('Unexpected end of input'))
+  //. Left(new SyntaxError('Unexpected end of JSON input'))
   //.
   //. > S.encaseEither(S.prop('message'), JSON.parse, '[')
-  //. Left('Unexpected end of input')
+  //. Left('Unexpected end of JSON input')
   //. ```
   S.encaseEither =
   def('encaseEither',


### PR DESCRIPTION
This addresses the test failure noted in #248.

As can be seen in the diff, we currently have a guard which prevents doctests from being run in Node v0.10.x (which doesn't support arrow functions). It's completely reasonable to run doctests in just one environment, since their purpose is to keep the documentation up to date rather than guarantee compatibility across Node versions. I suggest the latest stable version if we're to choose just one.

I hope these changes obviate the need to mention a version in __CONTRIBUTING.md__, as it would be easy for such a note to become out of date. Let's merge this pull request then discuss in #248 whether to add a note.
