### PR TITLE
list: remove ArrayLike type class

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@
              x.length >= 0;
     },
     function(list) {
-      return list.length > 0 && R.type(list) !== 'String' ? [list[0]] : [];
+      return R.type(list) === 'String' ? [] : Array.prototype.slice.call(list);
     }
   );
 
@@ -2609,21 +2609,10 @@
         return result;
       });
 
-  //  ArrayLike :: TypeClass
-  var ArrayLike = $.TypeClass(
-    'ArrayLike',
-    function(x) {
-      return x != null &&
-             typeof x !== 'function' &&
-             $.Integer._test(x.length) &&
-             x.length >= 0;
-    }
-  );
-
   var sanctifyIndexOf = function(name) {
     return def(name,
-               {b: [ArrayLike]},
-               [a, b, $Maybe($.Integer)],
+               {},
+               [a, List(a), $Maybe($.Integer)],
                R.pipe(R[name], Just, R.filter(R.gte(_, 0))));
   };
 

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -17,15 +17,15 @@ describe('indexOf', function() {
   it('type checks its arguments', function() {
     throws(function() { S.indexOf('x', null); },
            errorEq(TypeError,
-                   'Type-class constraint violation\n' +
+                   'Invalid value\n' +
                    '\n' +
-                   'indexOf :: ArrayLike b => a -> b -> Maybe Integer\n' +
-                   '           ^^^^^^^^^^^         ^\n' +
-                   '                               1\n' +
+                   'indexOf :: a -> List a -> Maybe Integer\n' +
+                   '                ^^^^^^\n' +
+                   '                  1\n' +
                    '\n' +
                    '1)  null :: Null\n' +
                    '\n' +
-                   '‘indexOf’ requires ‘b’ to satisfy the ArrayLike type-class constraint; the value at position 1 does not.\n'));
+                   'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
   it('returns Nothing for an empty list', function() {

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -17,15 +17,15 @@ describe('lastIndexOf', function() {
   it('type checks its arguments', function() {
     throws(function() { S.lastIndexOf('x', null); },
            errorEq(TypeError,
-                   'Type-class constraint violation\n' +
+                   'Invalid value\n' +
                    '\n' +
-                   'lastIndexOf :: ArrayLike b => a -> b -> Maybe Integer\n' +
-                   '               ^^^^^^^^^^^         ^\n' +
-                   '                                   1\n' +
+                   'lastIndexOf :: a -> List a -> Maybe Integer\n' +
+                   '                    ^^^^^^\n' +
+                   '                      1\n' +
                    '\n' +
                    '1)  null :: Null\n' +
                    '\n' +
-                   '‘lastIndexOf’ requires ‘b’ to satisfy the ArrayLike type-class constraint; the value at position 1 does not.\n'));
+                   'The value at position 1 is not a member of ‘List a’.\n'));
   });
 
   it('returns Nothing for an empty list', function() {


### PR DESCRIPTION
Commit message:

> This commit also fixes a bug in the List type's "extractor" which prevented it from returning list elements beyond the first.
