### PR TITLE
apply: add apFirst, apSecond

### DIFF
--- a/index.js
+++ b/index.js
@@ -2224,6 +2224,46 @@
         return toBoolean(x) === toBoolean(y) ? empty(x) : or(x, y);
       });
 
+  //. ### Apply
+  //.
+  //# apFirst :: (Apply a, Apply b) => a -> b -> a
+  //.
+  //. Combine two effectful actions, keeping only the result of the first.
+  //. ```javascript
+  //. > S.apFirst(S.Nothing, S.Nothing)
+  //. Nothing
+  //.
+  //. > S.apFirst(S.Just(1), S.Nothing)
+  //. Nothing
+  //.
+  //. > S.apFirst(S.Just(1), S.Just('2'))
+  //. Just(1)
+  //. ```
+  S.apFirst =
+  def('apFirst',
+    {a: [Apply], b: [Apply]},
+    [a, b, a],
+    S.lift2(S.K));
+
+  //# apSecond :: (Apply a, Apply b) => a -> b -> b
+  //.
+  //. Combine two effectful actions, keeping only the result of the second.
+  //. ```javascript
+  //. > S.apSecond(S.Nothing, S.Nothing)
+  //. Nothing
+  //.
+  //. > S.apSecond(S.Just(1), S.Nothing)
+  //. Nothing
+  //.
+  //. > S.apSecond(S.Just(1), S.Just('2'))
+  //. Just('2')
+  //. ```
+  S.apSecond =
+  def('apSecond',
+    {a: [Apply], b: [Apply]},
+    [a, b, b],
+    S.lift2(S.K(S.I)));
+
   //. ### Logic
 
   //# not :: Boolean -> Boolean

--- a/test/apFirst.js
+++ b/test/apFirst.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var throws = require('assert').throws;
+
+var eq = require('./utils').eq;
+var errorEq = require('./utils').errorEq;
+var S = require('..');
+
+
+describe('apFirst', function() {
+
+  it('is a binary function', function() {
+    eq(typeof S.apFirst, 'function');
+    eq(S.apFirst.length, 2);
+  });
+
+  it('type checks its arguments', function() {
+    throws(function() { S.apFirst(S.Just(1), 2); },
+           errorEq(TypeError,
+                   'Type-class constraint violation\n' +
+                   '\n' +
+                   'apFirst :: (Apply a, Apply b) => a -> b -> a\n' +
+                   '                     ^^^^^^^          ^\n' +
+                   '                                      1\n' +
+                   '\n' +
+                   '1)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+                   '\n' +
+                   '‘apFirst’ requires ‘b’ to satisfy the Apply type-class constraint; the value at position 1 does not.\n'));
+  });
+
+  it('can be applied to maybes', function() {
+    eq(S.apFirst(S.Nothing, S.Nothing), S.Nothing);
+    eq(S.apFirst(S.Nothing, S.Just(1)), S.Nothing);
+    eq(S.apFirst(S.Just(1), S.Just('2')), S.Just(1));
+  });
+
+  it('can be applied to eithers', function() {
+    eq(S.apFirst(S.Left('foo'), S.Left('bar')), S.Left('foo'));
+    eq(S.apFirst(S.Left('foo'), S.Right('bar')), S.Left('foo'));
+    eq(S.apFirst(S.Right('foo'), S.Left('bar')), S.Left('bar'));
+    eq(S.apFirst(S.Right('foo'), S.Right(2)), S.Right('foo'));
+  });
+
+  it('throws if applied to different types', function() {
+    throws(function() { S.apFirst(S.Just(1), S.Left('foo')); },
+           errorEq(TypeError,
+                   'Invalid value\n' +
+                   '\n' +
+                   'Maybe#ap :: Maybe Function -> Maybe a -> Maybe b\n' +
+                   '                              ^^^^^^^\n' +
+                   '                                 1\n' +
+                   '\n' +
+                   '1)  Left("foo") :: Either String ???\n' +
+                   '\n' +
+                   'The value at position 1 is not a member of ‘Maybe a’.\n'));
+  });
+
+  it('is curried', function() {
+    eq(S.apFirst(S.Just(1)).length, 1);
+    eq(S.apFirst(S.Just(1))(S.Just('2')), S.Just(1));
+  });
+
+});

--- a/test/apSecond.js
+++ b/test/apSecond.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var throws = require('assert').throws;
+
+var eq = require('./utils').eq;
+var errorEq = require('./utils').errorEq;
+var S = require('..');
+
+
+describe('apSecond', function() {
+
+  it('is a binary function', function() {
+    eq(typeof S.apSecond, 'function');
+    eq(S.apSecond.length, 2);
+  });
+
+  it('type checks its arguments', function() {
+    throws(function() { S.apSecond(S.Just(1), 2); },
+           errorEq(TypeError,
+                   'Type-class constraint violation\n' +
+                   '\n' +
+                   'apSecond :: (Apply a, Apply b) => a -> b -> b\n' +
+                   '                      ^^^^^^^          ^\n' +
+                   '                                       1\n' +
+                   '\n' +
+                   '1)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+                   '\n' +
+                   '‘apSecond’ requires ‘b’ to satisfy the Apply type-class constraint; the value at position 1 does not.\n'));
+  });
+
+  it('can be applied to maybes', function() {
+    eq(S.apSecond(S.Nothing, S.Nothing), S.Nothing);
+    eq(S.apSecond(S.Nothing, S.Just(1)), S.Nothing);
+    eq(S.apSecond(S.Just(1), S.Just('2')), S.Just('2'));
+  });
+
+  it('can be applied to eithers', function() {
+    eq(S.apSecond(S.Left('foo'), S.Left('bar')), S.Left('foo'));
+    eq(S.apSecond(S.Left('foo'), S.Right('bar')), S.Left('foo'));
+    eq(S.apSecond(S.Right('foo'), S.Left('bar')), S.Left('bar'));
+    eq(S.apSecond(S.Right('foo'), S.Right(2)), S.Right(2));
+  });
+
+  it('throws if applied to different types', function() {
+    throws(function() { S.apSecond(S.Just(1), S.Left('foo')); },
+           errorEq(TypeError,
+                   'Invalid value\n' +
+                   '\n' +
+                   'Maybe#ap :: Maybe Function -> Maybe a -> Maybe b\n' +
+                   '                              ^^^^^^^\n' +
+                   '                                 1\n' +
+                   '\n' +
+                   '1)  Left("foo") :: Either String ???\n' +
+                   '\n' +
+                   'The value at position 1 is not a member of ‘Maybe a’.\n'));
+  });
+
+  it('is curried', function() {
+    eq(S.apSecond(S.Just(1)).length, 1);
+    eq(S.apSecond(S.Just(1))(S.Just('2')), S.Just('2'));
+  });
+
+});


### PR DESCRIPTION
This PR will add two functions `apFirst` and `apSecond`, and a new section `Apply` with these two functions in the document.

Please see the discussion here https://github.com/sanctuary-js/sanctuary/issues/269

Ready for review