### PR TITLE
test: remove unnecessary "is curried" assertions

### DIFF
--- a/test/A.js
+++ b/test/A.js
@@ -18,9 +18,4 @@ describe('A', function() {
     eq(R.map(S.A(R.__, 100), [S.inc, Math.sqrt]), [101, 10]);
   });
 
-  it('is curried', function() {
-    eq(S.A(S.inc).length, 1);
-    eq(S.A(S.inc)(1), 2);
-  });
-
 });

--- a/test/C.js
+++ b/test/C.js
@@ -18,10 +18,4 @@ describe('C', function() {
     eq(R.map(S.C(S.concat, '!'), ['BAM', 'POW', 'KA-POW']), ['BAM!', 'POW!', 'KA-POW!']);
   });
 
-  it('is curried', function() {
-    eq(S.C(S.concat).length, 2);
-    eq(S.C(S.concat)('foo').length, 1);
-    eq(S.C(S.concat)('foo')('bar'), 'barfoo');
-  });
-
 });

--- a/test/K.js
+++ b/test/K.js
@@ -17,9 +17,4 @@ describe('K', function() {
     eq(S.K(84, undefined), 84);
   });
 
-  it('is curried', function() {
-    eq(S.K(42).length, 1);
-    eq(S.K(42)(null), 42);
-  });
-
 });

--- a/test/S.js
+++ b/test/S.js
@@ -15,10 +15,4 @@ describe('S', function() {
     eq(S.S(S.add, Math.sqrt, 100), 110);
   });
 
-  it('is curried', function() {
-    eq(S.S(S.add).length, 2);
-    eq(S.S(S.add)(Math.sqrt).length, 1);
-    eq(S.S(S.add)(Math.sqrt)(100), 110);
-  });
-
 });

--- a/test/T.js
+++ b/test/T.js
@@ -18,9 +18,4 @@ describe('T', function() {
     eq(R.map(S.T(100), [S.inc, Math.sqrt]), [101, 10]);
   });
 
-  it('is curried', function() {
-    eq(S.T(42).length, 1);
-    eq(S.T(42)(S.inc), 43);
-  });
-
 });

--- a/test/add.js
+++ b/test/add.js
@@ -71,9 +71,4 @@ describe('add', function() {
     eq(S.add(-1.5, -1), -2.5);
   });
 
-  it('is curried', function() {
-    eq(S.add(1).length, 1);
-    eq(S.add(1)(1), 2);
-  });
-
 });

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -86,9 +86,4 @@ describe('allPass', function() {
     eq(evaluated, false);
   });
 
-  it('is curried', function() {
-    eq(S.allPass([S.test(/q/)]).length, 1);
-    eq(S.allPass([S.test(/q/)])('quiessence'), true);
-  });
-
 });

--- a/test/and.js
+++ b/test/and.js
@@ -87,9 +87,4 @@ describe('and', function() {
                    '‘and’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n'));
   });
 
-  it('is curried', function() {
-    eq(S.and([]).length, 1);
-    eq(S.and([])([42]), []);
-  });
-
 });

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -86,9 +86,4 @@ describe('anyPass', function() {
     eq(evaluated, false);
   });
 
-  it('is curried', function() {
-    eq(S.anyPass([S.test(/q/)]).length, 1);
-    eq(S.anyPass([S.test(/q/)])('quiessence'), true);
-  });
-
 });

--- a/test/append.js
+++ b/test/append.js
@@ -49,9 +49,4 @@ describe('append', function() {
     eq(S.append([5, 6], [[1, 2], [3, 4]]), [[1, 2], [3, 4], [5, 6]]);
   });
 
-  it('is curried', function() {
-    eq(S.append(3).length, 1);
-    eq(S.append(3)([1, 2]), [1, 2, 3]);
-  });
-
 });

--- a/test/at.js
+++ b/test/at.js
@@ -54,9 +54,4 @@ describe('at', function() {
     eq(S.at(-0, ['foo', 'bar', 'baz']), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.at(1).length, 1);
-    eq(S.at(1)(['foo', 'bar', 'baz']), S.Just('bar'));
-  });
-
 });

--- a/test/concat.js
+++ b/test/concat.js
@@ -70,9 +70,4 @@ describe('concat', function() {
     eq(S.concat(S.Right([1, 2, 3]), S.Right([4, 5, 6])), S.Right([1, 2, 3, 4, 5, 6]));
   });
 
-  it('is curried', function() {
-    eq(S.concat([1, 2, 3]).length, 1);
-    eq(S.concat([1, 2, 3])([4, 5, 6]), [1, 2, 3, 4, 5, 6]);
-  });
-
 });

--- a/test/div.js
+++ b/test/div.js
@@ -73,9 +73,4 @@ describe('div', function() {
     eq(S.div(-1.5, -2), 0.75);
   });
 
-  it('is curried', function() {
-    eq(S.div(4).length, 1);
-    eq(S.div(8)(2), 4);
-  });
-
 });

--- a/test/drop.js
+++ b/test/drop.js
@@ -68,9 +68,4 @@ describe('drop', function() {
     eq(S.drop(0, 'abcdefg'), S.Just('abcdefg'));
   });
 
-  it('is curried', function() {
-    eq(S.drop(3).length, 1);
-    eq(S.drop(3)(['a', 'b', 'c', 'd', 'e']), S.Just(['d', 'e']));
-  });
-
 });

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -61,9 +61,4 @@ describe('dropLast', function() {
     eq(S.dropLast(0, 'abc'), S.Just('abc'));
   });
 
-  it('is curried', function() {
-    eq(S.dropLast(3).length, 1);
-    eq(S.dropLast(3)(['a', 'b', 'c', 'd', 'e']), S.Just(['a', 'b']));
-  });
-
 });

--- a/test/either.js
+++ b/test/either.js
@@ -98,38 +98,4 @@ describe('either', function() {
     eq(S.either(R.length, square, S.Right(42)), 1764);
   });
 
-  it('is curried', function() {
-    var f = R.length;
-    var g = square;
-    var x = S.Left('abc');
-    var _ = R.__;
-
-    eq(S.either(f).length, 2);
-    eq(S.either(f)(g).length, 1);
-
-    eq(S.either(f)(g)(x), 3);
-    eq(S.either(f)(g, x), 3);
-    eq(S.either(f, g)(x), 3);
-    eq(S.either(f, g, x), 3);
-
-    eq(S.either(_, g, x)(f), 3);
-    eq(S.either(f, _, x)(g), 3);
-    eq(S.either(f, g, _)(x), 3);
-
-    eq(S.either(f, _, _)(g)(x), 3);
-    eq(S.either(_, g, _)(f)(x), 3);
-    eq(S.either(_, _, x)(f)(g), 3);
-
-    eq(S.either(f, _, _)(g, x), 3);
-    eq(S.either(_, g, _)(f, x), 3);
-    eq(S.either(_, _, x)(f, g), 3);
-
-    eq(S.either(f, _, _)(_, x)(g), 3);
-    eq(S.either(_, g, _)(_, x)(f), 3);
-    eq(S.either(_, _, x)(_, g)(f), 3);
-
-    eq(S.either(_, _, _)(_, _)(_)(f, g, x), 3);
-    eq(S.either(_, _, _)(f, _, _)(_, _)(g, _)(_)(x), 3);
-  });
-
 });

--- a/test/encase.js
+++ b/test/encase.js
@@ -41,9 +41,4 @@ describe('encase', function() {
     eq(S.encase(function(a, b, c, d) { return a; }, 42), S.Just(42));
   });
 
-  it('is curried', function() {
-    eq(S.encase(factorial).length, 1);
-    eq(S.encase(factorial)(5), S.Just(120));
-  });
-
 });

--- a/test/encase2.js
+++ b/test/encase2.js
@@ -42,10 +42,4 @@ describe('encase2', function() {
     eq(S.encase2(highArity, 0, 42), S.Just(42));
   });
 
-  it('is curried', function() {
-    eq(S.encase2(rem).length, 2);
-    eq(S.encase2(rem)(42).length, 1);
-    eq(S.encase2(rem)(42)(5), S.Just(2));
-  });
-
 });

--- a/test/encase3.js
+++ b/test/encase3.js
@@ -43,11 +43,4 @@ describe('encase3', function() {
     eq(S.encase3(S.K(highArity), 0, 0, 42), S.Just(42));
   });
 
-  it('is curried', function() {
-    eq(S.encase3(area).length, 3);
-    eq(S.encase3(area)(3).length, 2);
-    eq(S.encase3(area)(3)(4).length, 1);
-    eq(S.encase3(area)(3)(4)(5), S.Just(6));
-  });
-
 });

--- a/test/encaseEither.js
+++ b/test/encaseEither.js
@@ -61,10 +61,4 @@ describe('encaseEither', function() {
        S.Right(42));
   });
 
-  it('is curried', function() {
-    eq(S.encaseEither(S.I).length, 2);
-    eq(S.encaseEither(S.I)(factorial).length, 1);
-    eq(S.encaseEither(S.I)(factorial)(5), S.Right(120));
-  });
-
 });

--- a/test/encaseEither2.js
+++ b/test/encaseEither2.js
@@ -61,11 +61,4 @@ describe('encaseEither2', function() {
        S.Right(42));
   });
 
-  it('is curried', function() {
-    eq(S.encaseEither2(S.I).length, 3);
-    eq(S.encaseEither2(S.I)(rem).length, 2);
-    eq(S.encaseEither2(S.I)(rem)(42).length, 1);
-    eq(S.encaseEither2(S.I)(rem)(42)(5), S.Right(2));
-  });
-
 });

--- a/test/encaseEither3.js
+++ b/test/encaseEither3.js
@@ -61,12 +61,4 @@ describe('encaseEither3', function() {
        S.Right(42));
   });
 
-  it('is curried', function() {
-    eq(S.encaseEither3(S.I).length, 4);
-    eq(S.encaseEither3(S.I)(area).length, 3);
-    eq(S.encaseEither3(S.I)(area)(3).length, 2);
-    eq(S.encaseEither3(S.I)(area)(3)(4).length, 1);
-    eq(S.encaseEither3(S.I)(area)(3)(4)(5), S.Right(6));
-  });
-
 });

--- a/test/find.js
+++ b/test/find.js
@@ -51,9 +51,4 @@ describe('find', function() {
     eq(S.find(R.F, [1, 2, 3]), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.find(R.T).length, 1);
-    eq(S.find(R.T)([null]), S.Just(null));
-  });
-
 });

--- a/test/flip.js
+++ b/test/flip.js
@@ -34,10 +34,4 @@ describe('flip', function() {
     eq(S.flip(S.indexOf, ['a', 'b', 'c', 'd'], 'c'), S.Just(2));
   });
 
-  it('is curried', function() {
-    eq(S.flip(S.indexOf).length, 2);
-    eq(S.flip(S.indexOf)(['a', 'b', 'c', 'd']).length, 1);
-    eq(S.flip(S.indexOf)(['a', 'b', 'c', 'd'])('c'), S.Just(2));
-  });
-
 });

--- a/test/fromEither.js
+++ b/test/fromEither.js
@@ -33,9 +33,4 @@ describe('fromEither', function() {
     eq(S.fromEither(0, S.Left(42)), 0);
   });
 
-  it('is curried', function() {
-    eq(S.fromEither(0).length, 1);
-    eq(S.fromEither(0)(S.Right(42)), 42);
-  });
-
 });

--- a/test/fromMaybe.js
+++ b/test/fromMaybe.js
@@ -36,9 +36,4 @@ describe('fromMaybe', function() {
     eq(S.fromMaybe(0, S.Just(42)), 42);
   });
 
-  it('is curried', function() {
-    eq(S.fromMaybe(0).length, 1);
-    eq(S.fromMaybe(0)(S.Just(42)), 42);
-  });
-
 });

--- a/test/get.js
+++ b/test/get.js
@@ -65,10 +65,4 @@ describe('get', function() {
     eq(S.get(vm.runInNewContext('RegExp'), 'x', {x: /.*/}), S.Just(/.*/));
   });
 
-  it('is curried', function() {
-    eq(S.get(Number).length, 2);
-    eq(S.get(Number)('x').length, 1);
-    eq(S.get(Number)('x')({x: 42}), S.Just(42));
-  });
-
 });

--- a/test/gets.js
+++ b/test/gets.js
@@ -69,10 +69,4 @@ describe('gets', function() {
     eq(S.gets(vm.runInNewContext('RegExp'), ['x'], {x: /.*/}), S.Just(/.*/));
   });
 
-  it('is curried', function() {
-    eq(S.gets(Number).length, 2);
-    eq(S.gets(Number)(['x']).length, 1);
-    eq(S.gets(Number)(['x'])({x: 42}), S.Just(42));
-  });
-
 });

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -62,11 +62,4 @@ describe('ifElse', function() {
     eq(S.ifElse(lt0, Math.abs, Math.sqrt, 16), 4);
   });
 
-  it('is curried', function() {
-    eq(S.ifElse(lt0).length, 3);
-    eq(S.ifElse(lt0)(Math.abs).length, 2);
-    eq(S.ifElse(lt0)(Math.abs)(Math.sqrt).length, 1);
-    eq(S.ifElse(lt0)(Math.abs)(Math.sqrt)(-1), 1);
-  });
-
 });

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -45,9 +45,4 @@ describe('indexOf', function() {
     eq(S.indexOf('ax', 'banana'), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.indexOf('c').length, 1);
-    eq(S.indexOf('c')(['a', 'b', 'c', 'd', 'e']), S.Just(2));
-  });
-
 });

--- a/test/is.js
+++ b/test/is.js
@@ -63,9 +63,4 @@ describe('is', function() {
     eq(S.is(vm.runInNewContext('Array'), [1, 2, 3]), true);
   });
 
-  it('is curried', function() {
-    eq(S.is(Array).length, 1);
-    eq(S.is(Array)([]), true);
-  });
-
 });

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -45,9 +45,4 @@ describe('lastIndexOf', function() {
     eq(S.lastIndexOf('ax', 'banana'), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.lastIndexOf('c').length, 1);
-    eq(S.lastIndexOf('c')(['a', 'b', 'c', 'd', 'e']), S.Just(2));
-  });
-
 });

--- a/test/mapMaybe.js
+++ b/test/mapMaybe.js
@@ -48,9 +48,4 @@ describe('mapMaybe', function() {
     eq(S.mapMaybe(S.head, [[1], [], [3], [], [5], []]), [1, 3, 5]);
   });
 
-  it('is curried', function() {
-    eq(S.mapMaybe(S.head).length, 1);
-    eq(S.mapMaybe(S.head)(['foo', '', 'bar', '', 'baz']), ['f', 'b', 'b']);
-  });
-
 });

--- a/test/match.js
+++ b/test/match.js
@@ -60,9 +60,4 @@ describe('match', function() {
     eq(S.match(/zzz/, 'abcdefg'), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.match(/x/).length, 1);
-    eq(S.match(/x/)('xyz'), S.Just([S.Just('x')]));
-  });
-
 });

--- a/test/max.js
+++ b/test/max.js
@@ -75,9 +75,4 @@ describe('max', function() {
     eq(S.max('a', 'A'), 'a');
   });
 
-  it('is curried', function() {
-    eq(S.max(10).length, 1);
-    eq(S.max(10)(2), 10);
-  });
-
 });

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -8,7 +8,6 @@ var R = require('ramda');
 var eq = require('./utils').eq;
 var errorEq = require('./utils').errorEq;
 var S = require('..');
-var square = require('./utils').square;
 
 
 describe('maybe', function() {
@@ -50,12 +49,6 @@ describe('maybe', function() {
 
   it('can be applied to a Just', function() {
     eq(S.maybe(0, R.length, S.Just([1, 2, 3])), 3);
-  });
-
-  it('is curried', function() {
-    eq(S.maybe(NaN).length, 2);
-    eq(S.maybe(NaN)(square).length, 1);
-    eq(S.maybe(NaN)(square)(S.Just(5)), 25);
   });
 
 });

--- a/test/maybeToEither.js
+++ b/test/maybeToEither.js
@@ -36,9 +36,4 @@ describe('maybeToEither', function() {
     eq(S.maybeToEither('error msg', S.Just(42)), S.Right(42));
   });
 
-  it('is curried', function() {
-    eq(S.maybeToEither(0).length, 1);
-    eq(S.maybeToEither(0)(S.Just(42)), S.Right(42));
-  });
-
 });

--- a/test/min.js
+++ b/test/min.js
@@ -75,9 +75,4 @@ describe('min', function() {
     eq(S.min('a', 'A'), 'A');
   });
 
-  it('is curried', function() {
-    eq(S.min(10).length, 1);
-    eq(S.min(10)(2), 2);
-  });
-
 });

--- a/test/mult.js
+++ b/test/mult.js
@@ -73,9 +73,4 @@ describe('mult', function() {
     eq(S.mult(-1.5, -3), 4.5);
   });
 
-  it('is curried', function() {
-    eq(S.mult(1).length, 1);
-    eq(S.mult(2)(2), 4);
-  });
-
 });

--- a/test/or.js
+++ b/test/or.js
@@ -87,9 +87,4 @@ describe('or', function() {
                    '‘or’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n'));
   });
 
-  it('is curried', function() {
-    eq(S.or([]).length, 1);
-    eq(S.or([])([42]), [42]);
-  });
-
 });

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -167,9 +167,4 @@ describe('parseInt', function() {
     eq(S.parseInt(10, '-Infinity'), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.parseInt(10).length, 1);
-    eq(S.parseInt(10)('42'), S.Just(42));
-  });
-
 });

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -19,9 +19,4 @@ describe('pipe', function() {
     eq(S.pipe([parseInt, S.inc, Math.sqrt, S.dec], '99'), 9);
   });
 
-  it('is curried', function() {
-    eq(S.pipe([parseInt, S.inc, Math.sqrt, S.dec]).length, 1);
-    eq(S.pipe([parseInt, S.inc, Math.sqrt, S.dec])('99'), 9);
-  });
-
 });

--- a/test/pluck.js
+++ b/test/pluck.js
@@ -65,10 +65,4 @@ describe('pluck', function() {
     eq(S.pluck(vm.runInNewContext('Array'), 'x', [{x: [0]}]), [S.Just([0])]);
   });
 
-  it('is curried', function() {
-    eq(S.pluck(Number).length, 2);
-    eq(S.pluck(Number)('x').length, 1);
-    eq(S.pluck(Number)('x')([{x: 42}]), [S.Just(42)]);
-  });
-
 });

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -49,9 +49,4 @@ describe('prepend', function() {
     eq(S.prepend([1, 2], [[3, 4], [5, 6]]), [[1, 2], [3, 4], [5, 6]]);
   });
 
-  it('is curried', function() {
-    eq(S.prepend(1).length, 1);
-    eq(S.prepend(1)([2, 3]), [1, 2, 3]);
-  });
-
 });

--- a/test/prop.js
+++ b/test/prop.js
@@ -70,9 +70,4 @@ describe('prop', function() {
     eq(S.prop('global', /x/g), true);
   });
 
-  it('is curried', function() {
-    eq(S.prop('a').length, 1);
-    eq(S.prop('a')({a: 0, b: 1}), 0);
-  });
-
 });

--- a/test/range.js
+++ b/test/range.js
@@ -48,9 +48,4 @@ describe('range', function() {
     eq(S.range(-2, 3), [-2, -1, 0, 1, 2]);
   });
 
-  it('is curried', function() {
-    eq(S.range(0).length, 1);
-    eq(S.range(0)(10), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  });
-
 });

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -50,10 +50,4 @@ describe('reduce', function() {
     eq(S.reduce(unaryAdd, 10, UnaryFoldable), 11);
   });
 
-  it('is curried', function() {
-    eq(S.reduce(S.add).length, 2);
-    eq(S.reduce(S.add)(0).length, 1);
-    eq(S.reduce(S.add)(0)([1, 2, 3, 4, 5]), 15);
-  });
-
 });

--- a/test/regex.js
+++ b/test/regex.js
@@ -91,9 +91,4 @@ describe('regex', function() {
     eq(S.regex('gim', '\\d'), /\d/gim);
   });
 
-  it('is curried', function() {
-    eq(S.regex('').length, 1);
-    eq(S.regex('')('\\d'), /\d/);
-  });
-
 });

--- a/test/slice.js
+++ b/test/slice.js
@@ -109,10 +109,4 @@ describe('slice', function() {
     eq(S.slice(3, -3, 'ramda'), S.Nothing);
   });
 
-  it('is curried', function() {
-    eq(S.slice(1).length, 2);
-    eq(S.slice(1)(-1).length, 1);
-    eq(S.slice(1)(-1)(['a', 'b', 'c', 'd', 'e']), S.Just(['b', 'c', 'd']));
-  });
-
 });

--- a/test/sub.js
+++ b/test/sub.js
@@ -71,9 +71,4 @@ describe('sub', function() {
     eq(S.sub(-7.5, -2), -5.5);
   });
 
-  it('is curried', function() {
-    eq(S.sub(1).length, 1);
-    eq(S.sub(1)(1), 0);
-  });
-
 });

--- a/test/take.js
+++ b/test/take.js
@@ -67,9 +67,4 @@ describe('take', function() {
     eq(S.take(7, 'abcdefg'), S.Just('abcdefg'));
   });
 
-  it('is curried', function() {
-    eq(S.take(3).length, 1);
-    eq(S.take(3)(['a', 'b', 'c', 'd', 'e']), S.Just(['a', 'b', 'c']));
-  });
-
 });

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -60,9 +60,4 @@ describe('takeLast', function() {
     eq(S.takeLast(0, 'abc'), S.Just(''));
   });
 
-  it('is curried', function() {
-    eq(S.takeLast(3).length, 1);
-    eq(S.takeLast(3)(['a', 'b', 'c', 'd', 'e']), S.Just(['c', 'd', 'e']));
-  });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -56,9 +56,4 @@ describe('test', function() {
     eq(S.test(pattern, 'xyz'), true);
   });
 
-  it('is curried', function() {
-    eq(S.test(/^a/).length, 1);
-    eq(S.test(/^a/)('abacus'), true);
-  });
-
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -77,12 +77,6 @@ exports.runCompositionTests = function(compose) {
     eq(compose(R.map(Math.sqrt), JSON.parse, '[1, 4, 9]'), [1, 2, 3]);
   });
 
-  it('is curried', function() {
-    eq(compose(R.map(Math.sqrt)).length, 2);
-    eq(compose(R.map(Math.sqrt))(JSON.parse).length, 1);
-    eq(compose(R.map(Math.sqrt))(JSON.parse)('[1, 4, 9]'), [1, 2, 3]);
-  });
-
 };
 
 //      square :: Number -> Number

--- a/test/xor.js
+++ b/test/xor.js
@@ -130,9 +130,4 @@ describe('xor', function() {
                    '‘xor’ requires ‘a’ to satisfy the Alternative type-class constraint; the value at position 1 does not.\n'));
   });
 
-  it('is curried', function() {
-    eq(S.xor([]).length, 1);
-    eq(S.xor([])([42]), [42]);
-  });
-
 });


### PR DESCRIPTION
We can rely on [__test/invariants.js__][1] to ensure that exported functions are defined via `def`.


[1]: https://github.com/sanctuary-js/sanctuary/blob/master/test/invariants.js
