### PR TITLE
define vanilla version of each exported function for internal use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lint:
 	  --global module \
 	  --global require \
 	  --global self \
+	  --rule 'func-style: [off]' \
 	  -- index.js
 	$(ESLINT) \
 	  --env node \
@@ -60,7 +61,7 @@ setup:
 
 .PHONY: test
 test:
-	$(ISTANBUL) cover node_modules/.bin/_mocha -- --recursive --timeout 10000
+	$(ISTANBUL) cover node_modules/.bin/_mocha -- --recursive --timeout 20000
 	$(ISTANBUL) check-coverage --branches 100
 ifeq ($(shell node --version | cut -d . -f 1),v6)
 	$(DOCTEST) -- index.js

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -166,10 +166,10 @@ describe('Left', function() {
   });
 
   it('provides a "reduce" method', function() {
-    eq(S.Left().reduce.length, 2);
-    eq(S.Left().reduce(function(xs, x) { return xs.concat([x]); }, [42]), [42]);
+    eq(S.Left('abc').reduce.length, 2);
+    eq(S.Left('abc').reduce(function(xs, x) { return xs.concat([x]); }, [42]), [42]);
 
-    throws(function() { S.Left().reduce(null, null); },
+    throws(function() { S.Left('abc').reduce(null, null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -169,7 +169,7 @@ describe('Right', function() {
     eq(S.Right(5).reduce.length, 2);
     eq(S.Right(5).reduce(function(xs, x) { return xs.concat([x]); }, [42]), [42, 5]);
 
-    throws(function() { S.Right().reduce(null, null); },
+    throws(function() { S.Right(5).reduce(null, null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +

--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -197,7 +197,7 @@ describe('Just', function() {
     eq(S.Just(5).reduce.length, 2);
     eq(S.Just(5).reduce(function(a, b) { return a + b; }, 10), 15);
 
-    throws(function() { S.Just().reduce(null, null); },
+    throws(function() { S.Just(5).reduce(null, null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +


### PR DESCRIPTION
It's nice to be able to define exported functions in terms of other exported functions without worrying about the performance cost of the additional type checking. The solution is to define a vanilla version of each exported function. By leveraging function hoisting we no longer need to consider the order of the function definitions, allowing `function(x) { return Just(x); }`, for example, to be replaced with `Just`.

`Just`, `Left`, and `Right` now perform type checking. This makes the property-based tests slower, so I increased the `--timeout` in the makefile's `test` target.

:icecream:
