### PR TITLE
doctest: remove vestigial --harmony flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCTEST = node_modules/.bin/doctest --nodejs '--harmony' --module commonjs --prefix .
+DOCTEST = node_modules/.bin/doctest --module commonjs --prefix .
 ESLINT = node_modules/.bin/eslint --config node_modules/sanctuary-style/eslint-es3.json --env es3
 ISTANBUL = node_modules/.bin/istanbul
 NPM = npm


### PR DESCRIPTION
As a result of #250 it's no longer necessary to provide the `--harmony` flag.
