### PR TITLE
regexp: revise S.match and add S.matchAll

### DIFF
--- a/test/match.js
+++ b/test/match.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var jsc = require('jsverify');
+var Z = require('sanctuary-type-classes');
+
 var S = require('..');
 
 var eq = require('./internal/eq');
@@ -9,12 +12,30 @@ test('match', function() {
 
   eq(typeof S.match, 'function');
   eq(S.match.length, 2);
-  eq(S.match.toString(), 'match :: RegExp -> String -> Maybe (Array (Maybe String))');
+  eq(S.match.toString(), 'match :: NonGlobalRegExp -> String -> Maybe { groups :: Array (Maybe String), match :: String }');
 
-  eq(S.match(/abcd/, 'abcdefg'), S.Just([S.Just('abcd')]));
-  eq(S.match(/[a-z]a/g, 'bananas'), S.Just([S.Just('ba'), S.Just('na'), S.Just('na')]));
-  eq(S.match(/(good)?bye/, 'goodbye'), S.Just([S.Just('goodbye'), S.Just('good')]));
-  eq(S.match(/(good)?bye/, 'bye'), S.Just([S.Just('bye'), S.Nothing]));
-  eq(S.match(/zzz/, 'abcdefg'), S.Nothing);
+  var scheme = '([a-z][a-z0-9+.-]*)';
+  var authentication = '(.*?):(.*?)@';
+  var hostname = '(.*?)';
+  var port = ':([0-9]*)';
+  var pattern = S.regex('', scheme + '://(?:' + authentication + ')?' + hostname + '(?:' + port + ')?(?!\\S)');
+
+  eq(S.match(pattern, 'URL: N/A'),
+     S.Nothing);
+
+  eq(S.match(pattern, 'URL: http://example.com'),
+     S.Just({match: 'http://example.com',
+             groups: [S.Just('http'), S.Nothing, S.Nothing, S.Just('example.com'), S.Nothing]}));
+
+  eq(S.match(pattern, 'URL: http://user:pass@example.com:80'),
+     S.Just({match: 'http://user:pass@example.com:80',
+             groups: [S.Just('http'), S.Just('user'), S.Just('pass'), S.Just('example.com'), S.Just('80')]}));
+
+  jsc.assert(jsc.forall(jsc.string, function(s) {
+    var p = '([A-Za-z]+)';
+    var lhs = S.head(S.matchAll(S.regex('g', p), s));
+    var rhs = S.match(S.regex('', p), s);
+    return Z.equals(lhs, rhs);
+  }), {tests: 1000});
 
 });

--- a/test/matchAll.js
+++ b/test/matchAll.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('matchAll', function() {
+
+  eq(typeof S.matchAll, 'function');
+  eq(S.matchAll.length, 2);
+  eq(S.matchAll.toString(), 'matchAll :: GlobalRegExp -> String -> Array { groups :: Array (Maybe String), match :: String }');
+
+  var pattern = S.regex('g', '<(h[1-6])(?: id="([^"]*)")?>([^<]*)</\\1>');
+
+  eq(S.matchAll(pattern, ''), []);
+
+  eq(S.matchAll(pattern, '<h1>Foo</h1>\n<h2 id="bar">Bar</h2>\n<h2 id="baz">Baz</h2>\n'),
+     [{match: '<h1>Foo</h1>', groups: [S.Just('h1'), S.Nothing, S.Just('Foo')]},
+      {match: '<h2 id="bar">Bar</h2>', groups: [S.Just('h2'), S.Just('bar'), S.Just('Bar')]},
+      {match: '<h2 id="baz">Baz</h2>', groups: [S.Just('h2'), S.Just('baz'), S.Just('Baz')]}]);
+
+  eq(pattern.lastIndex, 0);
+
+});


### PR DESCRIPTION
Closes #253; closes #260

[`String#match`][1] performs one of two very different operations depending on whether the provided regexp has `global` set to `true`:

```javascript
> 'xxx'.match(/x/)
['x', index: 0, input: 'xxx']

> 'xxx'.match(/x/g)
['x', 'x', 'x']
```

Typical JavaScript nonsense! The sane approach, of course, is to provide two functions:

```purescript
match :: NonGlobalRegExp -> String -> Maybe { match :: String, groups :: Array (Maybe String) }
matchAll :: GlobalRegExp -> String -> Array { match :: String, groups :: Array (Maybe String) }
```

Ideally `RegExp` values would not have `global`-ness baked in. One could then use a pattern in different ways depending on one's requirements. Alas, this is not the case. As a result, `match` requires a `RegExp` value with `global` set to `false`, while `matchAll` requires a `RegExp` value with `global` set to `true`. Having to state that we'd like all the matches in two different ways is unfortunate, but I don't like the idea of ignoring the `global` flag of the provided regexp.

This commit introduces two new types, GlobalRegExp and NonGlobalRegExp. These seem quite useful, so could one day be defined in sanctuary-def instead.

I look forward to feedback on this pull request. It's not often that we make breaking changes, but this change seems worthwhile.

:two_men_holding_hands: :couple: :two_women_holding_hands:


[1]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/match
