### PR TITLE
test: replace ‘errorEq’ with ‘throws’

### DIFF
--- a/test/Either/Either.js
+++ b/test/Either/Either.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var jsc = require('jsverify');
 var R = require('ramda');
 
 var S = require('../..');
 
-var errorEq = require('../internal/errorEq');
+var throws = require('../internal/throws');
 
 
 //  Identity :: a -> Identity a
@@ -82,8 +80,7 @@ var Compose = function(F, G) {
 suite('Either', function() {
 
   test('throws if called', function() {
-    throws(function() { S.Either(); },
-           errorEq(Error, 'Cannot instantiate Either'));
+    throws(function() { S.Either(); }, Error, 'Cannot instantiate Either');
   });
 
   suite('Traversable laws', function() {

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('../..');
 
 var eq = require('../internal/eq');
-var errorEq = require('../internal/errorEq');
 var parseHex = require('../internal/parseHex');
 var squareRoot = require('../internal/squareRoot');
+var throws = require('../internal/throws');
 
 
 suite('Left', function() {
@@ -26,16 +24,16 @@ suite('Left', function() {
     eq(S.Left('abc').ap(S.Right(42)), S.Left('abc'));
 
     throws(function() { S.Left('abc').ap([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#ap :: Either a Function -> Either a b -> Either a c\n' +
-                   '                                  ^^^^^^^^^^\n' +
-                   '                                      1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Either a b’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#ap :: Either a Function -> Either a b -> Either a c\n' +
+           '                                  ^^^^^^^^^^\n' +
+           '                                      1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Either a b’.\n');
   });
 
   test('"chain" method', function() {
@@ -43,16 +41,16 @@ suite('Left', function() {
     eq(S.Left('abc').chain(squareRoot), S.Left('abc'));
 
     throws(function() { S.Left('abc').chain([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#chain :: Either a b -> Function -> Either a c\n' +
-                   '                              ^^^^^^^^\n' +
-                   '                                 1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#chain :: Either a b -> Function -> Either a c\n' +
+           '                              ^^^^^^^^\n' +
+           '                                 1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"concat" method', function() {
@@ -61,52 +59,52 @@ suite('Left', function() {
     eq(S.Left('abc').concat(S.Right('xyz')), S.Right('xyz'));
 
     throws(function() { S.Left('abc').concat([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                                                             ^^^^^^^^^^\n' +
-                   '                                                                 1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Either a b’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                                                             ^^^^^^^^^^\n' +
+           '                                                                 1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Either a b’.\n');
 
     throws(function() { S.Left(/xxx/).concat(null); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                  ^^^^^^^^^^^                         ^\n' +
-                   '                                                      1\n' +
-                   '\n' +
-                   '1)  /xxx/ :: RegExp\n' +
-                   '\n' +
-                   '‘Either#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                  ^^^^^^^^^^^                         ^\n' +
+           '                                                      1\n' +
+           '\n' +
+           '1)  /xxx/ :: RegExp\n' +
+           '\n' +
+           '‘Either#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
     throws(function() { S.Left([1, 2, 3]).concat(S.Left(/xxx/)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                  ^^^^^^^^^^^                                       ^\n' +
-                   '                                                                    1\n' +
-                   '\n' +
-                   '1)  /xxx/ :: RegExp\n' +
-                   '\n' +
-                   '‘Either#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                  ^^^^^^^^^^^                                       ^\n' +
+           '                                                                    1\n' +
+           '\n' +
+           '1)  /xxx/ :: RegExp\n' +
+           '\n' +
+           '‘Either#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
     throws(function() { S.Left([1, 2, 3]).concat(S.Right(/xxx/)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                               ^^^^^^^^^^^                            ^\n' +
-                   '                                                                      1\n' +
-                   '\n' +
-                   '1)  /xxx/ :: RegExp\n' +
-                   '\n' +
-                   '‘Either#concat’ requires ‘b’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                               ^^^^^^^^^^^                            ^\n' +
+           '                                                                      1\n' +
+           '\n' +
+           '1)  /xxx/ :: RegExp\n' +
+           '\n' +
+           '‘Either#concat’ requires ‘b’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
   });
 
   test('"equals" method', function() {
@@ -136,16 +134,16 @@ suite('Left', function() {
     eq(w.extend(g).extend(f), w.extend(function(_w) { return f(_w.extend(g)); }));
 
     throws(function() { S.Left('abc').extend(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#extend :: Either a b -> Function -> Either a b\n' +
-                   '                               ^^^^^^^^\n' +
-                   '                                  1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#extend :: Either a b -> Function -> Either a b\n' +
+           '                               ^^^^^^^^\n' +
+           '                                  1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"map" method', function() {
@@ -153,16 +151,16 @@ suite('Left', function() {
     eq(S.Left('abc').map(Math.sqrt), S.Left('abc'));
 
     throws(function() { S.Left('abc').map([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#map :: Either a b -> Function -> Either a c\n' +
-                   '                            ^^^^^^^^\n' +
-                   '                               1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#map :: Either a b -> Function -> Either a c\n' +
+           '                            ^^^^^^^^\n' +
+           '                               1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"reduce" method', function() {
@@ -170,16 +168,16 @@ suite('Left', function() {
     eq(S.Left('abc').reduce(function(xs, x) { return xs.concat([x]); }, [42]), [42]);
 
     throws(function() { S.Left('abc').reduce(null, null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#reduce :: Either a b -> Function -> c -> c\n' +
-                   '                               ^^^^^^^^\n' +
-                   '                                  1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#reduce :: Either a b -> Function -> c -> c\n' +
+           '                               ^^^^^^^^\n' +
+           '                                  1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"sequence" method', function() {

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('../..');
 
 var eq = require('../internal/eq');
-var errorEq = require('../internal/errorEq');
 var parseHex = require('../internal/parseHex');
 var squareRoot = require('../internal/squareRoot');
+var throws = require('../internal/throws');
 
 
 suite('Right', function() {
@@ -26,16 +24,16 @@ suite('Right', function() {
     eq(S.Right(S.inc).ap(S.Right(42)), S.Right(43));
 
     throws(function() { S.Right(S.inc).ap([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#ap :: Either a Function -> Either a b -> Either a c\n' +
-                   '                                  ^^^^^^^^^^\n' +
-                   '                                      1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Either a b’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#ap :: Either a Function -> Either a b -> Either a c\n' +
+           '                                  ^^^^^^^^^^\n' +
+           '                                      1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Either a b’.\n');
   });
 
   test('"chain" method', function() {
@@ -43,16 +41,16 @@ suite('Right', function() {
     eq(S.Right(25).chain(squareRoot), S.Right(5));
 
     throws(function() { S.Right(25).chain(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#chain :: Either a b -> Function -> Either a c\n' +
-                   '                              ^^^^^^^^\n' +
-                   '                                 1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#chain :: Either a b -> Function -> Either a c\n' +
+           '                              ^^^^^^^^\n' +
+           '                                 1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"concat" method', function() {
@@ -61,52 +59,52 @@ suite('Right', function() {
     eq(S.Right('abc').concat(S.Right('def')), S.Right('abcdef'));
 
     throws(function() { S.Right('abc').concat([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                                                             ^^^^^^^^^^\n' +
-                   '                                                                 1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Either a b’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                                                             ^^^^^^^^^^\n' +
+           '                                                                 1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Either a b’.\n');
 
     throws(function() { S.Right(/xxx/).concat(null); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                               ^^^^^^^^^^^              ^\n' +
-                   '                                                        1\n' +
-                   '\n' +
-                   '1)  /xxx/ :: RegExp\n' +
-                   '\n' +
-                   '‘Either#concat’ requires ‘b’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                               ^^^^^^^^^^^              ^\n' +
+           '                                                        1\n' +
+           '\n' +
+           '1)  /xxx/ :: RegExp\n' +
+           '\n' +
+           '‘Either#concat’ requires ‘b’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
     throws(function() { S.Right([1, 2, 3]).concat(S.Left(/xxx/)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                  ^^^^^^^^^^^                                       ^\n' +
-                   '                                                                    1\n' +
-                   '\n' +
-                   '1)  /xxx/ :: RegExp\n' +
-                   '\n' +
-                   '‘Either#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                  ^^^^^^^^^^^                                       ^\n' +
+           '                                                                    1\n' +
+           '\n' +
+           '1)  /xxx/ :: RegExp\n' +
+           '\n' +
+           '‘Either#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
     throws(function() { S.Right([1, 2, 3]).concat(S.Right(/xxx/)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
-                   '                               ^^^^^^^^^^^                            ^\n' +
-                   '                                                                      1\n' +
-                   '\n' +
-                   '1)  /xxx/ :: RegExp\n' +
-                   '\n' +
-                   '‘Either#concat’ requires ‘b’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Either#concat :: (Semigroup a, Semigroup b) => Either a b -> Either a b -> Either a b\n' +
+           '                               ^^^^^^^^^^^                            ^\n' +
+           '                                                                      1\n' +
+           '\n' +
+           '1)  /xxx/ :: RegExp\n' +
+           '\n' +
+           '‘Either#concat’ requires ‘b’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
   });
 
   test('"equals" method', function() {
@@ -136,16 +134,16 @@ suite('Right', function() {
     eq(w.extend(g).extend(f), w.extend(function(_w) { return f(_w.extend(g)); }));
 
     throws(function() { S.Right('abc').extend(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#extend :: Either a b -> Function -> Either a b\n' +
-                   '                               ^^^^^^^^\n' +
-                   '                                  1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#extend :: Either a b -> Function -> Either a b\n' +
+           '                               ^^^^^^^^\n' +
+           '                                  1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"map" method', function() {
@@ -153,16 +151,16 @@ suite('Right', function() {
     eq(S.Right(9).map(Math.sqrt), S.Right(3));
 
     throws(function() { S.Right(9).map([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#map :: Either a b -> Function -> Either a c\n' +
-                   '                            ^^^^^^^^\n' +
-                   '                               1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#map :: Either a b -> Function -> Either a c\n' +
+           '                            ^^^^^^^^\n' +
+           '                               1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"reduce" method', function() {
@@ -170,16 +168,16 @@ suite('Right', function() {
     eq(S.Right(5).reduce(function(xs, x) { return xs.concat([x]); }, [42]), [42, 5]);
 
     throws(function() { S.Right(5).reduce(null, null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Either#reduce :: Either a b -> Function -> c -> c\n' +
-                   '                               ^^^^^^^^\n' +
-                   '                                  1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Either#reduce :: Either a b -> Function -> c -> c\n' +
+           '                               ^^^^^^^^\n' +
+           '                                  1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"sequence" method', function() {

--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('../..');
 
 var eq = require('../internal/eq');
-var errorEq = require('../internal/errorEq');
+var throws = require('../internal/throws');
 
 
 suite('Just', function() {
@@ -26,16 +24,16 @@ suite('Just', function() {
     eq(S.Just(S.inc).ap(S.Just(42)), S.Just(43));
 
     throws(function() { S.Just(S.inc).ap([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#ap :: Maybe Function -> Maybe a -> Maybe b\n' +
-                   '                              ^^^^^^^\n' +
-                   '                                 1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Maybe a’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#ap :: Maybe Function -> Maybe a -> Maybe b\n' +
+           '                              ^^^^^^^\n' +
+           '                                 1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Maybe a’.\n');
   });
 
   test('"chain" method', function() {
@@ -43,16 +41,16 @@ suite('Just', function() {
     eq(S.Just([1, 2, 3]).chain(S.head), S.Just(1));
 
     throws(function() { S.Just([1, 2, 3]).chain([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#chain :: Maybe a -> Function -> Maybe b\n' +
-                   '                          ^^^^^^^^\n' +
-                   '                             1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#chain :: Maybe a -> Function -> Maybe b\n' +
+           '                          ^^^^^^^^\n' +
+           '                             1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"concat" method', function() {
@@ -61,52 +59,52 @@ suite('Just', function() {
     eq(S.Just('foo').concat(S.Just('bar')), S.Just('foobar'));
 
     throws(function() { S.Just('foo').concat([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                                          ^^^^^^^\n' +
-                   '                                             1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Maybe a’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
+           '                                          ^^^^^^^\n' +
+           '                                             1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Maybe a’.\n');
 
     throws(function() { S.Just(1).concat(S.Just(0)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                ^^^^^^^^^^^          ^\n' +
-                   '                                     1\n' +
-                   '\n' +
-                   '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                   '\n' +
-                   '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
+           '                ^^^^^^^^^^^          ^\n' +
+           '                                     1\n' +
+           '\n' +
+           '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+           '\n' +
+           '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
     throws(function() { S.Just(2).concat(S.Just([1, 2, 3])); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                ^^^^^^^^^^^          ^\n' +
-                   '                                     1\n' +
-                   '\n' +
-                   '1)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                   '\n' +
-                   '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
+           '                ^^^^^^^^^^^          ^\n' +
+           '                                     1\n' +
+           '\n' +
+           '1)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+           '\n' +
+           '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
     throws(function() { S.Just([1, 2, 3]).concat(S.Just(3)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                ^^^^^^^^^^^                     ^\n' +
-                   '                                                1\n' +
-                   '\n' +
-                   '1)  3 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                   '\n' +
-                   '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
+           '                ^^^^^^^^^^^                     ^\n' +
+           '                                                1\n' +
+           '\n' +
+           '1)  3 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+           '\n' +
+           '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
   });
 
   test('"equals" method', function() {
@@ -136,16 +134,16 @@ suite('Just', function() {
     eq(w.extend(g).extend(f), w.extend(function(_w) { return f(_w.extend(g)); }));
 
     throws(function() { S.Just(42).extend(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#extend :: Maybe a -> Function -> Maybe a\n' +
-                   '                           ^^^^^^^^\n' +
-                   '                              1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#extend :: Maybe a -> Function -> Maybe a\n' +
+           '                           ^^^^^^^^\n' +
+           '                              1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"filter" method', function() {
@@ -164,16 +162,16 @@ suite('Just', function() {
     eq(m.map(f).filter(q).equals(m.filter(function(x) { return q(f(x)); }).map(f)), true);
 
     throws(function() { S.Just(42).filter(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#filter :: Maybe a -> Function -> Maybe a\n' +
-                   '                           ^^^^^^^^\n' +
-                   '                              1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#filter :: Maybe a -> Function -> Maybe a\n' +
+           '                           ^^^^^^^^\n' +
+           '                              1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"map" method', function() {
@@ -181,16 +179,16 @@ suite('Just', function() {
     eq(S.Just(42).map(function(x) { return x / 2; }), S.Just(21));
 
     throws(function() { S.Just(42).map([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#map :: Maybe a -> Function -> Maybe b\n' +
-                   '                        ^^^^^^^^\n' +
-                   '                           1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#map :: Maybe a -> Function -> Maybe b\n' +
+           '                        ^^^^^^^^\n' +
+           '                           1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"reduce" method', function() {
@@ -198,16 +196,16 @@ suite('Just', function() {
     eq(S.Just(5).reduce(function(a, b) { return a + b; }, 10), 15);
 
     throws(function() { S.Just(5).reduce(null, null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#reduce :: Maybe a -> Function -> b -> b\n' +
-                   '                           ^^^^^^^^\n' +
-                   '                              1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#reduce :: Maybe a -> Function -> b -> b\n' +
+           '                           ^^^^^^^^\n' +
+           '                              1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"sequence" method', function() {

--- a/test/Maybe/Maybe.js
+++ b/test/Maybe/Maybe.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var jsc = require('jsverify');
 var R = require('ramda');
 
 var S = require('../..');
 
-var errorEq = require('../internal/errorEq');
+var throws = require('../internal/throws');
 
 
 //  Identity :: a -> Identity a
@@ -87,8 +85,7 @@ var Compose = function(F, G) {
 suite('Maybe', function() {
 
   test('throws if called', function() {
-    throws(function() { S.Maybe(); },
-           errorEq(Error, 'Cannot instantiate Maybe'));
+    throws(function() { S.Maybe(); }, Error, 'Cannot instantiate Maybe');
   });
 
   suite('Traversable laws', function() {

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('../..');
 
 var eq = require('../internal/eq');
-var errorEq = require('../internal/errorEq');
+var throws = require('../internal/throws');
 
 
 suite('Nothing', function() {
@@ -24,16 +22,16 @@ suite('Nothing', function() {
     eq(S.Nothing.ap(S.Just(42)), S.Nothing);
 
     throws(function() { S.Nothing.ap([1, 2, 3]); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#ap :: Maybe Function -> Maybe a -> Maybe b\n' +
-                   '                              ^^^^^^^\n' +
-                   '                                 1\n' +
-                   '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Maybe a’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#ap :: Maybe Function -> Maybe a -> Maybe b\n' +
+           '                              ^^^^^^^\n' +
+           '                                 1\n' +
+           '\n' +
+           '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Maybe a’.\n');
   });
 
   test('"chain" method', function() {
@@ -41,16 +39,16 @@ suite('Nothing', function() {
     eq(S.Nothing.chain(S.head), S.Nothing);
 
     throws(function() { S.Nothing.chain(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#chain :: Maybe a -> Function -> Maybe b\n' +
-                   '                          ^^^^^^^^\n' +
-                   '                             1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#chain :: Maybe a -> Function -> Maybe b\n' +
+           '                          ^^^^^^^^\n' +
+           '                             1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"concat" method', function() {
@@ -59,28 +57,28 @@ suite('Nothing', function() {
     eq(S.Nothing.concat(S.Just('foo')), S.Just('foo'));
 
     throws(function() { S.Nothing.concat(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                                          ^^^^^^^\n' +
-                   '                                             1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Maybe a’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
+           '                                          ^^^^^^^\n' +
+           '                                             1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Maybe a’.\n');
 
     throws(function() { S.Nothing.concat(S.Just(1)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                ^^^^^^^^^^^                     ^\n' +
-                   '                                                1\n' +
-                   '\n' +
-                   '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                   '\n' +
-                   '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+           TypeError,
+           'Type-class constraint violation\n' +
+           '\n' +
+           'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
+           '                ^^^^^^^^^^^                     ^\n' +
+           '                                                1\n' +
+           '\n' +
+           '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+           '\n' +
+           '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
   });
 
   test('"equals" method', function() {
@@ -101,16 +99,16 @@ suite('Nothing', function() {
     eq(w.extend(g).extend(f), w.extend(function(_w) { return f(_w.extend(g)); }));
 
     throws(function() { S.Nothing.extend(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#extend :: Maybe a -> Function -> Maybe a\n' +
-                   '                           ^^^^^^^^\n' +
-                   '                              1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#extend :: Maybe a -> Function -> Maybe a\n' +
+           '                           ^^^^^^^^\n' +
+           '                              1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"filter" method', function() {
@@ -127,16 +125,16 @@ suite('Nothing', function() {
     eq(m.map(f).filter(q).equals(m.filter(function(x) { return q(f(x)); }).map(f)), true);
 
     throws(function() { S.Nothing.filter(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#filter :: Maybe a -> Function -> Maybe a\n' +
-                   '                           ^^^^^^^^\n' +
-                   '                              1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#filter :: Maybe a -> Function -> Maybe a\n' +
+           '                           ^^^^^^^^\n' +
+           '                              1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"map" method', function() {
@@ -144,16 +142,16 @@ suite('Nothing', function() {
     eq(S.Nothing.map(function() { return 42; }), S.Nothing);
 
     throws(function() { S.Nothing.map(null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#map :: Maybe a -> Function -> Maybe b\n' +
-                   '                        ^^^^^^^^\n' +
-                   '                           1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#map :: Maybe a -> Function -> Maybe b\n' +
+           '                        ^^^^^^^^\n' +
+           '                           1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"reduce" method', function() {
@@ -161,16 +159,16 @@ suite('Nothing', function() {
     eq(S.Nothing.reduce(function(a, b) { return a + b; }, 10), 10);
 
     throws(function() { S.Nothing.reduce(null, null); },
-           errorEq(TypeError,
-                   'Invalid value\n' +
-                   '\n' +
-                   'Maybe#reduce :: Maybe a -> Function -> b -> b\n' +
-                   '                           ^^^^^^^^\n' +
-                   '                              1\n' +
-                   '\n' +
-                   '1)  null :: Null\n' +
-                   '\n' +
-                   'The value at position 1 is not a member of ‘Function’.\n'));
+           TypeError,
+           'Invalid value\n' +
+           '\n' +
+           'Maybe#reduce :: Maybe a -> Function -> b -> b\n' +
+           '                           ^^^^^^^^\n' +
+           '                              1\n' +
+           '\n' +
+           '1)  null :: Null\n' +
+           '\n' +
+           'The value at position 1 is not a member of ‘Function’.\n');
   });
 
   test('"sequence" method', function() {

--- a/test/add.js
+++ b/test/add.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('add', function() {
@@ -14,52 +12,52 @@ test('add', function() {
   eq(S.add.length, 2);
 
   throws(function() { S.add('xxx', 1); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.add(1, 'xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.add(1, Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.add(1, -Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'add :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.add(1, 1), 2);
   eq(S.add(-1, -1), -2);

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('allPass', function() {
@@ -14,16 +12,16 @@ test('allPass', function() {
   eq(S.allPass.length, 2);
 
   throws(function() { S.allPass('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'allPass :: Array Function -> a -> Boolean\n' +
-                 '           ^^^^^^^^^^^^^^\n' +
-                 '                 1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'allPass :: Array Function -> a -> Boolean\n' +
+         '           ^^^^^^^^^^^^^^\n' +
+         '                 1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array Function’.\n');
 
   eq(S.allPass([], 'abacus'), true);
   eq(S.allPass([S.test(/a/), S.test(/b/), S.test(/c/)], 'abacus'), true);

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('anyPass', function() {
@@ -14,16 +12,16 @@ test('anyPass', function() {
   eq(S.anyPass.length, 2);
 
   throws(function() { S.anyPass('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'anyPass :: Array Function -> a -> Boolean\n' +
-                 '           ^^^^^^^^^^^^^^\n' +
-                 '                 1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'anyPass :: Array Function -> a -> Boolean\n' +
+         '           ^^^^^^^^^^^^^^\n' +
+         '                 1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array Function’.\n');
 
   eq(S.anyPass([], 'narwhal'), false);
   eq(S.anyPass([S.test(/a/), S.test(/b/), S.test(/c/)], 'narwhal'), true);

--- a/test/append.js
+++ b/test/append.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('append', function() {
@@ -14,31 +12,31 @@ test('append', function() {
   eq(S.append.length, 2);
 
   throws(function() { S.append('c', 'ab'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'append :: a -> Array a -> Array a\n' +
-                 '               ^^^^^^^\n' +
-                 '                  1\n' +
-                 '\n' +
-                 '1)  "ab" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'append :: a -> Array a -> Array a\n' +
+         '               ^^^^^^^\n' +
+         '                  1\n' +
+         '\n' +
+         '1)  "ab" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array a’.\n');
 
   throws(function() { S.append('3', [1, 2]); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'append :: a -> Array a -> Array a\n' +
-                 '          ^          ^\n' +
-                 '          1          2\n' +
-                 '\n' +
-                 '1)  "3" :: String\n' +
-                 '\n' +
-                 '2)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'append :: a -> Array a -> Array a\n' +
+         '          ^          ^\n' +
+         '          1          2\n' +
+         '\n' +
+         '1)  "3" :: String\n' +
+         '\n' +
+         '2)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(S.append(3, []), [3]);
   eq(S.append(3, [1, 2]), [1, 2, 3]);

--- a/test/at.js
+++ b/test/at.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('at', function() {
@@ -14,28 +12,28 @@ test('at', function() {
   eq(S.at.length, 2);
 
   throws(function() { S.at(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'at :: Integer -> List a -> Maybe a\n' +
-                 '      ^^^^^^^\n' +
-                 '         1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'at :: Integer -> List a -> Maybe a\n' +
+         '      ^^^^^^^\n' +
+         '         1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.at(0, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'at :: Integer -> List a -> Maybe a\n' +
-                 '                 ^^^^^^\n' +
-                 '                   1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'at :: Integer -> List a -> Maybe a\n' +
+         '                 ^^^^^^\n' +
+         '                   1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.at(-4, ['foo', 'bar', 'baz']), S.Nothing);
   eq(S.at(-3, ['foo', 'bar', 'baz']), S.Just('foo'));

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('concat', function() {
@@ -14,30 +12,30 @@ test('concat', function() {
   eq(S.concat.length, 2);
 
   throws(function() { S.concat(/XXX/); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'concat :: Semigroup a => a -> a -> a\n' +
-                 '          ^^^^^^^^^^^    ^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  /XXX/ :: RegExp\n' +
-                 '\n' +
-                 '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'concat :: Semigroup a => a -> a -> a\n' +
+         '          ^^^^^^^^^^^    ^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  /XXX/ :: RegExp\n' +
+         '\n' +
+         '‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.concat('abc', [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'concat :: Semigroup a => a -> a -> a\n' +
-                 '                         ^    ^\n' +
-                 '                         1    2\n' +
-                 '\n' +
-                 '1)  "abc" :: String\n' +
-                 '\n' +
-                 '2)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'concat :: Semigroup a => a -> a -> a\n' +
+         '                         ^    ^\n' +
+         '                         1    2\n' +
+         '\n' +
+         '1)  "abc" :: String\n' +
+         '\n' +
+         '2)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(S.concat([], []), []);
   eq(S.concat([1, 2, 3], []), [1, 2, 3]);

--- a/test/create.js
+++ b/test/create.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var $ = require('sanctuary-def');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 //  customEnv :: Array Type
@@ -25,28 +23,28 @@ test('create', function() {
   eq(S.create.length, 1);
 
   throws(function() { S.create({}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'create :: { checkTypes :: Boolean, env :: Array Any } -> Object\n' +
-                 '          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                 '                               1\n' +
-                 '\n' +
-                 '1)  {} :: Object, StrMap ???\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘{ checkTypes :: Boolean, env :: Array Any }’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'create :: { checkTypes :: Boolean, env :: Array Any } -> Object\n' +
+         '          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+         '                               1\n' +
+         '\n' +
+         '1)  {} :: Object, StrMap ???\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘{ checkTypes :: Boolean, env :: Array Any }’.\n');
 
   throws(function() { S.create({checkTypes: 'true', env: []}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'create :: { checkTypes :: Boolean, env :: Array Any } -> Object\n' +
-                 '                          ^^^^^^^\n' +
-                 '                             1\n' +
-                 '\n' +
-                 '1)  "true" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Boolean’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'create :: { checkTypes :: Boolean, env :: Array Any } -> Object\n' +
+         '                          ^^^^^^^\n' +
+         '                             1\n' +
+         '\n' +
+         '1)  "true" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Boolean’.\n');
 
   var expected = Object.keys(S).sort();
   eq(Object.keys(checkedDefaultEnv).sort(), expected);
@@ -58,16 +56,16 @@ test('create', function() {
   eq(uncheckedDefaultEnv.inc('XXX'), 'XXX1');
 
   throws(function() { S.I(['foo', 'foo', 42]); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'I :: a -> a\n' +
-                 '     ^\n' +
-                 '     1\n' +
-                 '\n' +
-                 '1)  ["foo", "foo", 42] :: Array ???\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'I :: a -> a\n' +
+         '     ^\n' +
+         '     1\n' +
+         '\n' +
+         '1)  ["foo", "foo", 42] :: Array ???\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(checkedCustomEnv.I(['foo', 'foo', 42]), ['foo', 'foo', 42]);
 

--- a/test/dec.js
+++ b/test/dec.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('dec', function() {
@@ -14,40 +12,40 @@ test('dec', function() {
   eq(S.dec.length, 1);
 
   throws(function() { S.dec('xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'dec :: FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'dec :: FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.dec(Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'dec :: FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'dec :: FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.dec(-Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'dec :: FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'dec :: FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.dec(2), 1);
   eq(S.dec(-1), -2);

--- a/test/div.js
+++ b/test/div.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('div', function() {
@@ -14,52 +12,52 @@ test('div', function() {
   eq(S.div.length, 2);
 
   throws(function() { S.div('xxx', 1); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.div(1, 'xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘NonZeroFiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^^^^^^^^\n' +
+         '                                1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘NonZeroFiniteNumber’.\n');
 
   throws(function() { S.div(1, 0); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                1\n' +
-                 '\n' +
-                 '1)  0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘NonZeroFiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^^^^^^^^\n' +
+         '                                1\n' +
+         '\n' +
+         '1)  0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘NonZeroFiniteNumber’.\n');
 
   throws(function() { S.div(1, -0); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                1\n' +
-                 '\n' +
-                 '1)  -0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘NonZeroFiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'div :: FiniteNumber -> NonZeroFiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^^^^^^^^\n' +
+         '                                1\n' +
+         '\n' +
+         '1)  -0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘NonZeroFiniteNumber’.\n');
 
   eq(S.div(8, 2), 4);
   eq(S.div(8, -2), -4);

--- a/test/drop.js
+++ b/test/drop.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('drop', function() {
@@ -14,28 +12,28 @@ test('drop', function() {
   eq(S.drop.length, 2);
 
   throws(function() { S.drop(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'drop :: Integer -> List a -> Maybe (List a)\n' +
-                 '        ^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'drop :: Integer -> List a -> Maybe (List a)\n' +
+         '        ^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.drop(0, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'drop :: Integer -> List a -> Maybe (List a)\n' +
-                 '                   ^^^^^^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'drop :: Integer -> List a -> Maybe (List a)\n' +
+         '                   ^^^^^^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.drop(0, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
   eq(S.drop(1, [1, 2, 3, 4, 5]), S.Just([2, 3, 4, 5]));

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('dropLast', function() {
@@ -14,28 +12,28 @@ test('dropLast', function() {
   eq(S.dropLast.length, 2);
 
   throws(function() { S.dropLast(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'dropLast :: Integer -> List a -> Maybe (List a)\n' +
-                 '            ^^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'dropLast :: Integer -> List a -> Maybe (List a)\n' +
+         '            ^^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.dropLast(0, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'dropLast :: Integer -> List a -> Maybe (List a)\n' +
-                 '                       ^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'dropLast :: Integer -> List a -> Maybe (List a)\n' +
+         '                       ^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.dropLast(0, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
   eq(S.dropLast(1, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4]));

--- a/test/either.js
+++ b/test/either.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('either', function() {
@@ -16,76 +14,76 @@ test('either', function() {
   eq(S.either.length, 3);
 
   throws(function() { S.either([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'either :: Function -> Function -> Either a b -> c\n' +
-                 '          ^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'either :: Function -> Function -> Either a b -> c\n' +
+         '          ^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.either(R.__, Math.sqrt)([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'either :: Function -> Function -> Either a b -> c\n' +
-                 '          ^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'either :: Function -> Function -> Either a b -> c\n' +
+         '          ^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.either(R.length, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'either :: Function -> Function -> Either a b -> c\n' +
-                 '                      ^^^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'either :: Function -> Function -> Either a b -> c\n' +
+         '                      ^^^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.either(R.length)([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'either :: Function -> Function -> Either a b -> c\n' +
-                 '                      ^^^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'either :: Function -> Function -> Either a b -> c\n' +
+         '                      ^^^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.either(R.length, Math.sqrt, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'either :: Function -> Function -> Either a b -> c\n' +
-                 '                                  ^^^^^^^^^^\n' +
-                 '                                      1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'either :: Function -> Function -> Either a b -> c\n' +
+         '                                  ^^^^^^^^^^\n' +
+         '                                      1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   throws(function() { S.either(R.length)(Math.sqrt)([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'either :: Function -> Function -> Either a b -> c\n' +
-                 '                                  ^^^^^^^^^^\n' +
-                 '                                      1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'either :: Function -> Function -> Either a b -> c\n' +
+         '                                  ^^^^^^^^^^\n' +
+         '                                      1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   eq(S.either(R.length, Math.sqrt, S.Left('abc')), 3);
   eq(S.either(R.length, Math.sqrt, S.Right(256)), 16);

--- a/test/eitherToMaybe.js
+++ b/test/eitherToMaybe.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('eitherToMaybe', function() {
@@ -14,16 +12,16 @@ test('eitherToMaybe', function() {
   eq(S.eitherToMaybe.length, 1);
 
   throws(function() { S.eitherToMaybe(/XXX/); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'eitherToMaybe :: Either a b -> Maybe b\n' +
-                 '                 ^^^^^^^^^^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  /XXX/ :: RegExp\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'eitherToMaybe :: Either a b -> Maybe b\n' +
+         '                 ^^^^^^^^^^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  /XXX/ :: RegExp\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   eq(S.eitherToMaybe(S.Left('Cannot divide by zero')), S.Nothing);
   eq(S.eitherToMaybe(S.Right(42)), S.Just(42));

--- a/test/encase.js
+++ b/test/encase.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
 var factorial = require('./internal/factorial');
+var throws = require('./internal/throws');
 
 
 test('encase', function() {
@@ -15,16 +13,16 @@ test('encase', function() {
   eq(S.encase.length, 2);
 
   throws(function() { S.encase([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encase :: Function -> a -> Maybe b\n' +
-                 '          ^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encase :: Function -> a -> Maybe b\n' +
+         '          ^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.encase(factorial, 5), S.Just(120));
   eq(S.encase(factorial, -1), S.Nothing);

--- a/test/encase2.js
+++ b/test/encase2.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
 var rem = require('./internal/rem');
+var throws = require('./internal/throws');
 
 
 test('encase2', function() {
@@ -15,16 +13,16 @@ test('encase2', function() {
   eq(S.encase2.length, 3);
 
   throws(function() { S.encase2([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encase2 :: Function -> a -> b -> Maybe c\n' +
-                 '           ^^^^^^^^\n' +
-                 '              1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encase2 :: Function -> a -> b -> Maybe c\n' +
+         '           ^^^^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.encase2(rem, 42, 5), S.Just(2));
   eq(S.encase2(rem, 42, 0), S.Nothing);

--- a/test/encase3.js
+++ b/test/encase3.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var area = require('./internal/area');
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('encase3', function() {
@@ -15,16 +13,16 @@ test('encase3', function() {
   eq(S.encase3.length, 4);
 
   throws(function() { S.encase3([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encase3 :: Function -> a -> b -> c -> Maybe d\n' +
-                 '           ^^^^^^^^\n' +
-                 '              1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encase3 :: Function -> a -> b -> c -> Maybe d\n' +
+         '           ^^^^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.encase3(area, 3, 4, 5), S.Just(6));
   eq(S.encase3(area, 2, 2, 5), S.Nothing);

--- a/test/encaseEither.js
+++ b/test/encaseEither.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
 var factorial = require('./internal/factorial');
+var throws = require('./internal/throws');
 
 
 test('encaseEither', function() {
@@ -15,28 +13,28 @@ test('encaseEither', function() {
   eq(S.encaseEither.length, 3);
 
   throws(function() { S.encaseEither(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encaseEither :: Function -> Function -> a -> Either l r\n' +
-                 '                ^^^^^^^^\n' +
-                 '                   1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encaseEither :: Function -> Function -> a -> Either l r\n' +
+         '                ^^^^^^^^\n' +
+         '                   1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.encaseEither(S.I, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encaseEither :: Function -> Function -> a -> Either l r\n' +
-                 '                            ^^^^^^^^\n' +
-                 '                               1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encaseEither :: Function -> Function -> a -> Either l r\n' +
+         '                            ^^^^^^^^\n' +
+         '                               1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.encaseEither(S.I, factorial, 5), S.Right(120));
   eq(S.encaseEither(S.I, factorial, -1), S.Left(new Error('Cannot determine factorial of negative number')));

--- a/test/encaseEither2.js
+++ b/test/encaseEither2.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
 var rem = require('./internal/rem');
+var throws = require('./internal/throws');
 
 
 test('encaseEither2', function() {
@@ -15,28 +13,28 @@ test('encaseEither2', function() {
   eq(S.encaseEither2.length, 4);
 
   throws(function() { S.encaseEither2(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encaseEither2 :: Function -> Function -> a -> b -> Either l r\n' +
-                 '                 ^^^^^^^^\n' +
-                 '                    1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encaseEither2 :: Function -> Function -> a -> b -> Either l r\n' +
+         '                 ^^^^^^^^\n' +
+         '                    1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.encaseEither2(S.I, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encaseEither2 :: Function -> Function -> a -> b -> Either l r\n' +
-                 '                             ^^^^^^^^\n' +
-                 '                                1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encaseEither2 :: Function -> Function -> a -> b -> Either l r\n' +
+         '                             ^^^^^^^^\n' +
+         '                                1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.encaseEither2(S.I, rem, 42, 5), S.Right(2));
   eq(S.encaseEither2(S.I, rem, 42, 0), S.Left(new Error('Cannot divide by zero')));

--- a/test/encaseEither3.js
+++ b/test/encaseEither3.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var area = require('./internal/area');
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('encaseEither3', function() {
@@ -15,28 +13,28 @@ test('encaseEither3', function() {
   eq(S.encaseEither3.length, 5);
 
   throws(function() { S.encaseEither3(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encaseEither3 :: Function -> Function -> a -> b -> c -> Either l r\n' +
-                 '                 ^^^^^^^^\n' +
-                 '                    1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encaseEither3 :: Function -> Function -> a -> b -> c -> Either l r\n' +
+         '                 ^^^^^^^^\n' +
+         '                    1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.encaseEither3(S.I, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'encaseEither3 :: Function -> Function -> a -> b -> c -> Either l r\n' +
-                 '                             ^^^^^^^^\n' +
-                 '                                1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'encaseEither3 :: Function -> Function -> a -> b -> c -> Either l r\n' +
+         '                             ^^^^^^^^\n' +
+         '                                1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.encaseEither3(S.I, area, 3, 4, 5), S.Right(6));
   eq(S.encaseEither3(S.I, area, 2, 2, 5), S.Left(new Error('Impossible triangle')));

--- a/test/even.js
+++ b/test/even.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('even', function() {
@@ -14,28 +12,28 @@ test('even', function() {
   eq(S.even.length, 1);
 
   throws(function() { S.even(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'even :: Integer -> Boolean\n' +
-                 '        ^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'even :: Integer -> Boolean\n' +
+         '        ^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.even(Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'even :: Integer -> Boolean\n' +
-                 '        ^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'even :: Integer -> Boolean\n' +
+         '        ^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   eq(S.even(0), true);
   eq(S.even(-0), true);

--- a/test/find.js
+++ b/test/find.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('find', function() {
@@ -16,28 +14,28 @@ test('find', function() {
   eq(S.find.length, 2);
 
   throws(function() { S.find([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'find :: Function -> Array a -> Maybe a\n' +
-                 '        ^^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'find :: Function -> Array a -> Maybe a\n' +
+         '        ^^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.find(R.T, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'find :: Function -> Array a -> Maybe a\n' +
-                 '                    ^^^^^^^\n' +
-                 '                       1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'find :: Function -> Array a -> Maybe a\n' +
+         '                    ^^^^^^^\n' +
+         '                       1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array a’.\n');
 
   eq(S.find(S.even, []), S.Nothing);
   eq(S.find(S.even, [1, 3, 5, 7, 9]), S.Nothing);

--- a/test/flip.js
+++ b/test/flip.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('flip', function() {
@@ -16,16 +14,16 @@ test('flip', function() {
   eq(S.flip.length, 3);
 
   throws(function() { S.flip('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'flip :: Function -> b -> a -> c\n' +
-                 '        ^^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'flip :: Function -> b -> a -> c\n' +
+         '        ^^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(R.map(S.flip(Math.pow)(2), [1, 2, 3, 4, 5]), [1, 4, 9, 16, 25]);
   eq(S.flip(S.indexOf, ['a', 'b', 'c', 'd'], 'c'), S.Just(2));

--- a/test/fromEither.js
+++ b/test/fromEither.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
+var throws = require('./internal/throws');
 
 
 test('fromEither', function() {
@@ -13,11 +12,12 @@ test('fromEither', function() {
   eq(S.fromEither.length, 2);
 
   throws(function() { S.fromEither(0, [1, 2, 3]); },
+         TypeError,
          'Invalid value\n' +
          '\n' +
          'fromEither :: b -> Either a b -> b\n' +
-         '                   ^^^^^^^^^^n' +
-         '                        1\n' +
+         '                   ^^^^^^^^^^\n' +
+         '                       1\n' +
          '\n' +
          '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
          '\n' +

--- a/test/fromMaybe.js
+++ b/test/fromMaybe.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('fromMaybe', function() {
@@ -14,16 +12,16 @@ test('fromMaybe', function() {
   eq(S.fromMaybe.length, 2);
 
   throws(function() { S.fromMaybe(0, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'fromMaybe :: a -> Maybe a -> a\n' +
-                 '                  ^^^^^^^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'fromMaybe :: a -> Maybe a -> a\n' +
+         '                  ^^^^^^^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe a’.\n');
 
   eq(S.fromMaybe(0, S.Nothing), 0);
   eq(S.fromMaybe(0, S.Just(42)), 42);

--- a/test/get.js
+++ b/test/get.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
 var vm = require('vm');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('get', function() {
@@ -15,40 +14,40 @@ test('get', function() {
   eq(S.get.length, 3);
 
   throws(function() { S.get([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
-                 '                       ^^^^^^^\n' +
-                 '                          1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘TypeRep’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
+         '                       ^^^^^^^\n' +
+         '                          1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘TypeRep’.\n');
 
   throws(function() { S.get(Number, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
-                 '                                  ^^^^^^\n' +
-                 '                                    1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
+         '                                  ^^^^^^\n' +
+         '                                    1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   throws(function() { S.get(Number, 'x', null); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
-                 '       ^^^^^^^^^^^^                         ^\n' +
-                 '                                            1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 '‘get’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'get :: Accessible a => TypeRep -> String -> a -> Maybe b\n' +
+         '       ^^^^^^^^^^^^                         ^\n' +
+         '                                            1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         '‘get’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n');
 
   eq(S.get(Number, 'x', {x: 0, y: 42}), S.Just(0));
   eq(S.get(Number, 'y', {x: 0, y: 42}), S.Just(42));

--- a/test/gets.js
+++ b/test/gets.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
 var vm = require('vm');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('gets', function() {
@@ -15,40 +14,40 @@ test('gets', function() {
   eq(S.gets.length, 3);
 
   throws(function() { S.gets([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
-                 '                        ^^^^^^^\n' +
-                 '                           1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘TypeRep’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
+         '                        ^^^^^^^\n' +
+         '                           1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘TypeRep’.\n');
 
   throws(function() { S.gets(Number, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
-                 '                                   ^^^^^^^^^^^^\n' +
-                 '                                        1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
+         '                                   ^^^^^^^^^^^^\n' +
+         '                                        1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array String’.\n');
 
   throws(function() { S.gets(Number, [], null); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
-                 '        ^^^^^^^^^^^^                               ^\n' +
-                 '                                                   1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 '‘gets’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'gets :: Accessible a => TypeRep -> Array String -> a -> Maybe b\n' +
+         '        ^^^^^^^^^^^^                               ^\n' +
+         '                                                   1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         '‘gets’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n');
 
   eq(S.gets(Number, ['x'], {x: {z: 0}, y: 42}), S.Nothing);
   eq(S.gets(Number, ['y'], {x: {z: 0}, y: 42}), S.Just(42));

--- a/test/head.js
+++ b/test/head.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('head', function() {
@@ -14,16 +12,16 @@ test('head', function() {
   eq(S.head.length, 1);
 
   throws(function() { S.head({length: -1}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'head :: List a -> Maybe a\n' +
-                 '        ^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'head :: List a -> Maybe a\n' +
+         '        ^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.head([]), S.Nothing);
   eq(S.head(['foo']), S.Just('foo'));

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('ifElse', function() {
@@ -14,40 +12,40 @@ test('ifElse', function() {
   eq(S.ifElse.length, 4);
 
   throws(function() { S.ifElse('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'ifElse :: Function -> Function -> Function -> a -> b\n' +
-                 '          ^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'ifElse :: Function -> Function -> Function -> a -> b\n' +
+         '          ^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.ifElse(S.odd, 'wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'ifElse :: Function -> Function -> Function -> a -> b\n' +
-                 '                      ^^^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'ifElse :: Function -> Function -> Function -> a -> b\n' +
+         '                      ^^^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.ifElse(S.odd, S.dec, 'wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'ifElse :: Function -> Function -> Function -> a -> b\n' +
-                 '                                  ^^^^^^^^\n' +
-                 '                                     1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'ifElse :: Function -> Function -> Function -> a -> b\n' +
+         '                                  ^^^^^^^^\n' +
+         '                                     1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.ifElse(S.odd, S.dec, S.inc, 9), 8);
   eq(S.ifElse(S.odd, S.dec, S.inc, 0), 1);

--- a/test/inc.js
+++ b/test/inc.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('inc', function() {
@@ -14,40 +12,40 @@ test('inc', function() {
   eq(S.inc.length, 1);
 
   throws(function() { S.inc('xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'inc :: FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'inc :: FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.inc(Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'inc :: FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'inc :: FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.inc(-Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'inc :: FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'inc :: FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.inc(1), 2);
   eq(S.inc(-1), 0);

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('indexOf', function() {
@@ -14,16 +12,16 @@ test('indexOf', function() {
   eq(S.indexOf.length, 2);
 
   throws(function() { S.indexOf('x', null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'indexOf :: a -> List a -> Maybe Integer\n' +
-                 '                ^^^^^^\n' +
-                 '                  1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'indexOf :: a -> List a -> Maybe Integer\n' +
+         '                ^^^^^^\n' +
+         '                  1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.indexOf('x', []), S.Nothing);
   eq(S.indexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing);

--- a/test/init.js
+++ b/test/init.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('init', function() {
@@ -14,16 +12,16 @@ test('init', function() {
   eq(S.init.length, 1);
 
   throws(function() { S.init({length: -1}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'init :: List a -> Maybe (List a)\n' +
-                 '        ^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'init :: List a -> Maybe (List a)\n' +
+         '        ^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.init([]), S.Nothing);
   eq(S.init(['foo']), S.Just([]));

--- a/test/internal/errorEq.js
+++ b/test/internal/errorEq.js
@@ -1,8 +1,0 @@
-'use strict';
-
-//  errorEq :: (TypeRep a, String) -> Error -> Boolean
-module.exports = function errorEq(type, message) {
-  return function(error) {
-    return error.constructor === type && error.message === message;
-  };
-};

--- a/test/internal/throws.js
+++ b/test/internal/throws.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var assert = require('assert');
+
+//  throws :: (Function, TypeRep a, String) -> Undefined
+module.exports = function throws(f, type, message) {
+  assert.strictEqual(arguments.length, 3);
+  assert.throws(f, function(err) {
+    return err.constructor === type && err.message === message;
+  });
+};

--- a/test/invariants.js
+++ b/test/invariants.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 suite('invariants', function() {
@@ -34,20 +32,20 @@ suite('invariants', function() {
 
   test('exported functions throw if applied to too many arguments', function() {
     throws(function() { S.I(1, 2); },
-           errorEq(TypeError,
-                   '‘I’ requires one argument; received two arguments'));
+           TypeError,
+           '‘I’ requires one argument; received two arguments');
 
     throws(function() { S.K(1, 2, 3); },
-           errorEq(TypeError,
-                   '‘K’ requires two arguments; received three arguments'));
+           TypeError,
+           '‘K’ requires two arguments; received three arguments');
 
     throws(function() { S.K(1)(2, 3); },
-           errorEq(TypeError,
-                   '‘K’ requires two arguments; received three arguments'));
+           TypeError,
+           '‘K’ requires two arguments; received three arguments');
 
     throws(function() { S.K(1, 2, 3, 4, 5, 6, 7, 8, 9, 10); },
-           errorEq(TypeError,
-                   '‘K’ requires two arguments; received 10 arguments'));
+           TypeError,
+           '‘K’ requires two arguments; received 10 arguments');
   });
 
 });

--- a/test/is.js
+++ b/test/is.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
 var vm = require('vm');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('is', function() {
@@ -15,16 +14,16 @@ test('is', function() {
   eq(S.is.length, 2);
 
   throws(function() { S.is([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'is :: TypeRep -> Any -> Boolean\n' +
-                 '      ^^^^^^^\n' +
-                 '         1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘TypeRep’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'is :: TypeRep -> Any -> Boolean\n' +
+         '      ^^^^^^^\n' +
+         '         1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘TypeRep’.\n');
 
   eq(S.is(Array,    []),                  true);
   eq(S.is(Boolean,  false),               true);

--- a/test/isJust.js
+++ b/test/isJust.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('isJust', function() {
@@ -14,16 +12,16 @@ test('isJust', function() {
   eq(S.isJust.length, 1);
 
   throws(function() { S.isJust([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'isJust :: Maybe a -> Boolean\n' +
-                 '          ^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'isJust :: Maybe a -> Boolean\n' +
+         '          ^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe a’.\n');
 
   eq(S.isJust(S.Nothing), false);
   eq(S.isJust(S.Just(42)), true);

--- a/test/isLeft.js
+++ b/test/isLeft.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('isLeft', function() {
@@ -14,16 +12,16 @@ test('isLeft', function() {
   eq(S.isLeft.length, 1);
 
   throws(function() { S.isLeft([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'isLeft :: Either a b -> Boolean\n' +
-                 '          ^^^^^^^^^^\n' +
-                 '              1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'isLeft :: Either a b -> Boolean\n' +
+         '          ^^^^^^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   eq(S.isLeft(S.Left(42)), true);
   eq(S.isLeft(S.Right(42)), false);

--- a/test/isNothing.js
+++ b/test/isNothing.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('isNothing', function() {
@@ -14,16 +12,16 @@ test('isNothing', function() {
   eq(S.isNothing.length, 1);
 
   throws(function() { S.isNothing([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'isNothing :: Maybe a -> Boolean\n' +
-                 '             ^^^^^^^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'isNothing :: Maybe a -> Boolean\n' +
+         '             ^^^^^^^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe a’.\n');
 
   eq(S.isNothing(S.Nothing), true);
   eq(S.isNothing(S.Just(42)), false);

--- a/test/isRight.js
+++ b/test/isRight.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('isRight', function() {
@@ -14,16 +12,16 @@ test('isRight', function() {
   eq(S.isRight.length, 1);
 
   throws(function() { S.isRight([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'isRight :: Either a b -> Boolean\n' +
-                 '           ^^^^^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'isRight :: Either a b -> Boolean\n' +
+         '           ^^^^^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   eq(S.isRight(S.Left(42)), false);
   eq(S.isRight(S.Right(42)), true);

--- a/test/joinWith.js
+++ b/test/joinWith.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('joinWith', function() {
@@ -14,28 +12,28 @@ test('joinWith', function() {
   eq(S.joinWith.length, 2);
 
   throws(function() { S.joinWith(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'joinWith :: String -> Array String -> String\n' +
-                 '            ^^^^^^\n' +
-                 '              1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'joinWith :: String -> Array String -> String\n' +
+         '            ^^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   throws(function() { S.joinWith('', [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'joinWith :: String -> Array String -> String\n' +
-                 '                            ^^^^^^\n' +
-                 '                              1\n' +
-                 '\n' +
-                 '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'joinWith :: String -> Array String -> String\n' +
+         '                            ^^^^^^\n' +
+         '                              1\n' +
+         '\n' +
+         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.joinWith('', ['a', 'b', 'c']), 'abc');
   eq(S.joinWith(':', []), '');

--- a/test/justs.js
+++ b/test/justs.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('justs', function() {
@@ -14,16 +12,16 @@ test('justs', function() {
   eq(S.justs.length, 1);
 
   throws(function() { S.justs({length: 0}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'justs :: Array (Maybe a) -> Array a\n' +
-                 '         ^^^^^^^^^^^^^^^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  {"length": 0} :: Object, StrMap Number, StrMap FiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array (Maybe a)’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'justs :: Array (Maybe a) -> Array a\n' +
+         '         ^^^^^^^^^^^^^^^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  {"length": 0} :: Object, StrMap Number, StrMap FiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array (Maybe a)’.\n');
 
   eq(S.justs([]), []);
   eq(S.justs([S.Nothing, S.Nothing]), []);

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('keys', function() {
@@ -14,30 +12,30 @@ test('keys', function() {
   eq(S.keys.length, 1);
 
   throws(function() { S.keys('xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'keys :: StrMap a -> Array String\n' +
-                 '        ^^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘StrMap a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'keys :: StrMap a -> Array String\n' +
+         '        ^^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘StrMap a’.\n');
 
   throws(function() { S.keys({a: '1', b: 2, c: '3'}); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'keys :: StrMap a -> Array String\n' +
-                 '               ^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  "1" :: String\n' +
-                 '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '    "3" :: String\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'keys :: StrMap a -> Array String\n' +
+         '               ^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  "1" :: String\n' +
+         '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '    "3" :: String\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(S.keys({}), []);
   eq(S.keys({a: 1, b: 2, c: 3}).sort(), ['a', 'b', 'c']);

--- a/test/last.js
+++ b/test/last.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('last', function() {
@@ -14,16 +12,16 @@ test('last', function() {
   eq(S.last.length, 1);
 
   throws(function() { S.last({length: -1}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'last :: List a -> Maybe a\n' +
-                 '        ^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'last :: List a -> Maybe a\n' +
+         '        ^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.last([]), S.Nothing);
   eq(S.last(['foo']), S.Just('foo'));

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('lastIndexOf', function() {
@@ -14,16 +12,16 @@ test('lastIndexOf', function() {
   eq(S.lastIndexOf.length, 2);
 
   throws(function() { S.lastIndexOf('x', null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'lastIndexOf :: a -> List a -> Maybe Integer\n' +
-                 '                    ^^^^^^\n' +
-                 '                      1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'lastIndexOf :: a -> List a -> Maybe Integer\n' +
+         '                    ^^^^^^\n' +
+         '                      1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.lastIndexOf('x', []), S.Nothing);
   eq(S.lastIndexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing);

--- a/test/lefts.js
+++ b/test/lefts.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('lefts', function() {
@@ -14,16 +12,16 @@ test('lefts', function() {
   eq(S.lefts.length, 1);
 
   throws(function() { S.lefts([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'lefts :: Array (Either a b) -> Array a\n' +
-                 '               ^^^^^^^^^^^^\n' +
-                 '                    1\n' +
-                 '\n' +
-                 '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'lefts :: Array (Either a b) -> Array a\n' +
+         '               ^^^^^^^^^^^^\n' +
+         '                    1\n' +
+         '\n' +
+         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   eq(S.lefts([]), []);
   eq(S.lefts([S.Right(2), S.Right(1)]), []);

--- a/test/lift.js
+++ b/test/lift.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('lift', function() {
@@ -14,16 +12,16 @@ test('lift', function() {
   eq(S.lift.length, 2);
 
   throws(function() { S.lift('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'lift :: (Functor a, Functor b) => Function -> a -> b\n' +
-                 '                                  ^^^^^^^^\n' +
-                 '                                     1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'lift :: (Functor a, Functor b) => Function -> a -> b\n' +
+         '                                  ^^^^^^^^\n' +
+         '                                     1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.lift(S.mult(2), S.Just(3)), S.Just(6));
   eq(S.lift(S.mult(2), S.Nothing), S.Nothing);

--- a/test/lift2.js
+++ b/test/lift2.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('lift2', function() {
@@ -14,16 +12,16 @@ test('lift2', function() {
   eq(S.lift2.length, 3);
 
   throws(function() { S.lift2('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'lift2 :: (Apply a, Apply b, Apply c) => Function -> a -> b -> c\n' +
-                 '                                        ^^^^^^^^\n' +
-                 '                                           1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'lift2 :: (Apply a, Apply b, Apply c) => Function -> a -> b -> c\n' +
+         '                                        ^^^^^^^^\n' +
+         '                                           1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   //  positive :: Number -> Boolean
   var positive = function(n) { return n > 0; };

--- a/test/lift3.js
+++ b/test/lift3.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var area = require('./internal/area');
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('lift3', function() {
@@ -15,16 +13,16 @@ test('lift3', function() {
   eq(S.lift3.length, 4);
 
   throws(function() { S.lift3('wrong'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'lift3 :: (Apply a, Apply b, Apply c, Apply d) => Function -> a -> b -> c -> d\n' +
-                 '                                                 ^^^^^^^^\n' +
-                 '                                                    1\n' +
-                 '\n' +
-                 '1)  "wrong" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'lift3 :: (Apply a, Apply b, Apply c, Apply d) => Function -> a -> b -> c -> d\n' +
+         '                                                 ^^^^^^^^\n' +
+         '                                                    1\n' +
+         '\n' +
+         '1)  "wrong" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.lift3(S.reduce, S.Just(S.add), S.Just(0), S.Just([1, 2, 3])), S.Just(6));
   eq(S.lift3(S.reduce, S.Just(S.add), S.Just(0), S.Nothing), S.Nothing);

--- a/test/lines.js
+++ b/test/lines.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('lines', function() {
@@ -14,16 +12,16 @@ test('lines', function() {
   eq(S.lines.length, 1);
 
   throws(function() { S.lines(['foo']); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'lines :: String -> Array String\n' +
-                 '         ^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  ["foo"] :: Array String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'lines :: String -> Array String\n' +
+         '         ^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  ["foo"] :: Array String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.lines(''), []);
   eq(S.lines('\n'), ['']);

--- a/test/mapMaybe.js
+++ b/test/mapMaybe.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('mapMaybe', function() {
@@ -14,28 +12,28 @@ test('mapMaybe', function() {
   eq(S.mapMaybe.length, 2);
 
   throws(function() { S.mapMaybe([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mapMaybe :: Function -> Array a -> Array b\n' +
-                 '            ^^^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mapMaybe :: Function -> Array a -> Array b\n' +
+         '            ^^^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.mapMaybe(S.head, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mapMaybe :: Function -> Array a -> Array b\n' +
-                 '                        ^^^^^^^\n' +
-                 '                           1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mapMaybe :: Function -> Array a -> Array b\n' +
+         '                        ^^^^^^^\n' +
+         '                           1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array a’.\n');
 
   eq(S.mapMaybe(S.head, []), []);
   eq(S.mapMaybe(S.head, [[], [], []]), []);

--- a/test/match.js
+++ b/test/match.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('match', function() {
@@ -14,28 +12,28 @@ test('match', function() {
   eq(S.match.length, 2);
 
   throws(function() { S.match([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'match :: RegExp -> String -> Maybe (Array (Maybe String))\n' +
-                 '         ^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘RegExp’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'match :: RegExp -> String -> Maybe (Array (Maybe String))\n' +
+         '         ^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘RegExp’.\n');
 
   throws(function() { S.match(/(?:)/, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'match :: RegExp -> String -> Maybe (Array (Maybe String))\n' +
-                 '                   ^^^^^^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'match :: RegExp -> String -> Maybe (Array (Maybe String))\n' +
+         '                   ^^^^^^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.match(/abcd/, 'abcdefg'), S.Just([S.Just('abcd')]));
   eq(S.match(/[a-z]a/g, 'bananas'), S.Just([S.Just('ba'), S.Just('na'), S.Just('na')]));

--- a/test/max.js
+++ b/test/max.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('max', function() {
@@ -14,40 +12,40 @@ test('max', function() {
   eq(S.max.length, 2);
 
   throws(function() { S.max(/x/); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'max :: Ord a => a -> a -> a\n' +
-                 '       ^^^^^    ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  /x/ :: RegExp\n' +
-                 '\n' +
-                 '‘max’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'max :: Ord a => a -> a -> a\n' +
+         '       ^^^^^    ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  /x/ :: RegExp\n' +
+         '\n' +
+         '‘max’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.max(NaN); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'max :: Ord a => a -> a -> a\n' +
-                 '       ^^^^^    ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  NaN :: Number\n' +
-                 '\n' +
-                 '‘max’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'max :: Ord a => a -> a -> a\n' +
+         '       ^^^^^    ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  NaN :: Number\n' +
+         '\n' +
+         '‘max’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.max(new Date('XXX')); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'max :: Ord a => a -> a -> a\n' +
-                 '       ^^^^^    ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  new Date(NaN) :: Date\n' +
-                 '\n' +
-                 '‘max’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'max :: Ord a => a -> a -> a\n' +
+         '       ^^^^^    ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  new Date(NaN) :: Date\n' +
+         '\n' +
+         '‘max’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
 
   eq(S.max(10, 2), 10);
   eq(S.max(2, 10), 10);

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('maybe', function() {
@@ -16,28 +14,28 @@ test('maybe', function() {
   eq(S.maybe.length, 3);
 
   throws(function() { S.maybe(0, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybe :: b -> Function -> Maybe a -> b\n' +
-                 '              ^^^^^^^^\n' +
-                 '                 1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybe :: b -> Function -> Maybe a -> b\n' +
+         '              ^^^^^^^^\n' +
+         '                 1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.maybe(0, R.length, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybe :: b -> Function -> Maybe a -> b\n' +
-                 '                          ^^^^^^^\n' +
-                 '                             1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybe :: b -> Function -> Maybe a -> b\n' +
+         '                          ^^^^^^^\n' +
+         '                             1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe a’.\n');
 
   eq(S.maybe(0, R.length, S.Nothing), 0);
   eq(S.maybe(0, R.length, S.Just([1, 2, 3])), 3);

--- a/test/maybeToEither.js
+++ b/test/maybeToEither.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('maybeToEither', function() {
@@ -14,16 +12,16 @@ test('maybeToEither', function() {
   eq(S.maybeToEither.length, 2);
 
   throws(function() { S.maybeToEither('left', 1); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybeToEither :: a -> Maybe b -> Either a b\n' +
-                 '                      ^^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybeToEither :: a -> Maybe b -> Either a b\n' +
+         '                      ^^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe b’.\n');
 
   eq(S.maybeToEither('error msg', S.Nothing), S.Left('error msg'));
   eq(S.maybeToEither('error msg', S.Just(42)), S.Right(42));

--- a/test/maybeToNullable.js
+++ b/test/maybeToNullable.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('maybeToNullable', function() {
@@ -14,16 +12,16 @@ test('maybeToNullable', function() {
   eq(S.maybeToNullable.length, 1);
 
   throws(function() { S.maybeToNullable(/XXX/); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybeToNullable :: Maybe a -> Nullable a\n' +
-                 '                   ^^^^^^^\n' +
-                 '                      1\n' +
-                 '\n' +
-                 '1)  /XXX/ :: RegExp\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybeToNullable :: Maybe a -> Nullable a\n' +
+         '                   ^^^^^^^\n' +
+         '                      1\n' +
+         '\n' +
+         '1)  /XXX/ :: RegExp\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe a’.\n');
 
   eq(S.maybeToNullable(S.Nothing), null);
   eq(S.maybeToNullable(S.Just(42)), 42);

--- a/test/maybe_.js
+++ b/test/maybe_.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('maybe_', function() {
@@ -16,40 +14,40 @@ test('maybe_', function() {
   eq(S.maybe_.length, 3);
 
   throws(function() { S.maybe_(0, R.length); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybe_ :: Function -> Function -> Maybe a -> b\n' +
-                 '          ^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybe_ :: Function -> Function -> Maybe a -> b\n' +
+         '          ^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.maybe_(R.always(0), [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybe_ :: Function -> Function -> Maybe a -> b\n' +
-                 '                      ^^^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybe_ :: Function -> Function -> Maybe a -> b\n' +
+         '                      ^^^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   throws(function() { S.maybe_(R.always(0), R.length, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'maybe_ :: Function -> Function -> Maybe a -> b\n' +
-                 '                                  ^^^^^^^\n' +
-                 '                                     1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Maybe a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'maybe_ :: Function -> Function -> Maybe a -> b\n' +
+         '                                  ^^^^^^^\n' +
+         '                                     1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Maybe a’.\n');
 
   eq(S.maybe_(R.always(0), R.length, S.Nothing), 0);
   eq(S.maybe_(R.always(0), R.length, S.Just([1, 2, 3])), 3);

--- a/test/mean.js
+++ b/test/mean.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('mean', function() {
@@ -14,40 +12,40 @@ test('mean', function() {
   eq(S.mean.length, 1);
 
   throws(function() { S.mean('xxx'); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'mean :: Foldable f => f -> Maybe FiniteNumber\n' +
-                 '        ^^^^^^^^^^    ^\n' +
-                 '                      1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 '‘mean’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'mean :: Foldable f => f -> Maybe FiniteNumber\n' +
+         '        ^^^^^^^^^^    ^\n' +
+         '                      1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         '‘mean’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.mean([1, 2, 'xxx']); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'mean :: Foldable f => f -> Maybe FiniteNumber\n' +
-                 '                      ^\n' +
-                 '                      1\n' +
-                 '\n' +
-                 '1)  [1, 2, "xxx"] :: Array ???\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'mean :: Foldable f => f -> Maybe FiniteNumber\n' +
+         '                      ^\n' +
+         '                      1\n' +
+         '\n' +
+         '1)  [1, 2, "xxx"] :: Array ???\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   throws(function() { S.mean([1, Infinity]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mean :: Foldable f => f -> Maybe FiniteNumber\n' +
-                 '                                 ^^^^^^^^^^^^\n' +
-                 '                                      1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mean :: Foldable f => f -> Maybe FiniteNumber\n' +
+         '                                 ^^^^^^^^^^^^\n' +
+         '                                      1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.mean([]), S.Nothing);
   eq(S.mean([1, 2, 3]), S.Just(2));

--- a/test/min.js
+++ b/test/min.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('min', function() {
@@ -14,40 +12,40 @@ test('min', function() {
   eq(S.min.length, 2);
 
   throws(function() { S.min(/x/); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'min :: Ord a => a -> a -> a\n' +
-                 '       ^^^^^    ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  /x/ :: RegExp\n' +
-                 '\n' +
-                 '‘min’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'min :: Ord a => a -> a -> a\n' +
+         '       ^^^^^    ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  /x/ :: RegExp\n' +
+         '\n' +
+         '‘min’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.min(NaN); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'min :: Ord a => a -> a -> a\n' +
-                 '       ^^^^^    ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  NaN :: Number\n' +
-                 '\n' +
-                 '‘min’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'min :: Ord a => a -> a -> a\n' +
+         '       ^^^^^    ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  NaN :: Number\n' +
+         '\n' +
+         '‘min’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.min(new Date('XXX')); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'min :: Ord a => a -> a -> a\n' +
-                 '       ^^^^^    ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  new Date(NaN) :: Date\n' +
-                 '\n' +
-                 '‘min’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'min :: Ord a => a -> a -> a\n' +
+         '       ^^^^^    ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  new Date(NaN) :: Date\n' +
+         '\n' +
+         '‘min’ requires ‘a’ to satisfy the Ord type-class constraint; the value at position 1 does not.\n');
 
   eq(S.min(10, 2), 2);
   eq(S.min(2, 10), 2);

--- a/test/mult.js
+++ b/test/mult.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('mult', function() {
@@ -14,52 +12,52 @@ test('mult', function() {
   eq(S.mult.length, 2);
 
   throws(function() { S.mult('xxx', 2); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '        ^^^^^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '        ^^^^^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.mult(2, 'xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                        ^^^^^^^^^^^^\n' +
-                 '                             1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                        ^^^^^^^^^^^^\n' +
+         '                             1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.mult(2, Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                        ^^^^^^^^^^^^\n' +
-                 '                             1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                        ^^^^^^^^^^^^\n' +
+         '                             1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.mult(2, -Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                        ^^^^^^^^^^^^\n' +
-                 '                             1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'mult :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                        ^^^^^^^^^^^^\n' +
+         '                             1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.mult(4, 2), 8);
   eq(S.mult(4, -2), -8);

--- a/test/negate.js
+++ b/test/negate.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('negate', function() {
@@ -14,16 +12,16 @@ test('negate', function() {
   eq(S.negate.length, 1);
 
   throws(function() { S.negate(NaN); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'negate :: ValidNumber -> ValidNumber\n' +
-                 '          ^^^^^^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  NaN :: Number\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘ValidNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'negate :: ValidNumber -> ValidNumber\n' +
+         '          ^^^^^^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  NaN :: Number\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘ValidNumber’.\n');
 
   eq(S.negate(0.5), -0.5);
   eq(S.negate(-0.5), 0.5);

--- a/test/not.js
+++ b/test/not.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('not', function() {
@@ -19,15 +17,15 @@ test('not', function() {
   eq(S.not(new Boolean(true)), false);
 
   throws(function() { S.not(0); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'not :: Boolean -> Boolean\n' +
-                 '       ^^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Boolean’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'not :: Boolean -> Boolean\n' +
+         '       ^^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  0 :: Number, FiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Boolean’.\n');
 
 });

--- a/test/odd.js
+++ b/test/odd.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('odd', function() {
@@ -14,28 +12,28 @@ test('odd', function() {
   eq(S.odd.length, 1);
 
   throws(function() { S.odd(-0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'odd :: Integer -> Boolean\n' +
-                 '       ^^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  -0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'odd :: Integer -> Boolean\n' +
+         '       ^^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  -0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.odd(-Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'odd :: Integer -> Boolean\n' +
-                 '       ^^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'odd :: Integer -> Boolean\n' +
+         '       ^^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   eq(S.odd(1), true);
   eq(S.odd(-1), true);

--- a/test/pairs.js
+++ b/test/pairs.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('pairs', function() {
@@ -18,30 +16,30 @@ test('pairs', function() {
   eq(S.pairs.length, 1);
 
   throws(function() { S.pairs('xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'pairs :: StrMap a -> Array (Pair String a)\n' +
-                 '         ^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘StrMap a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'pairs :: StrMap a -> Array (Pair String a)\n' +
+         '         ^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘StrMap a’.\n');
 
   throws(function() { S.pairs({a: '1', b: 2, c: '3'}); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'pairs :: StrMap a -> Array (Pair String a)\n' +
-                 '                ^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  "1" :: String\n' +
-                 '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '    "3" :: String\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'pairs :: StrMap a -> Array (Pair String a)\n' +
+         '                ^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  "1" :: String\n' +
+         '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '    "3" :: String\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(S.pairs({}), []);
   eq(S.pairs({a: 1, b: 2, c: 3}).sort(comparePairsAsc), [['a', 1], ['b', 2], ['c', 3]]);

--- a/test/parseDate.js
+++ b/test/parseDate.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('parseDate', function() {
@@ -14,16 +12,16 @@ test('parseDate', function() {
   eq(S.parseDate.length, 1);
 
   throws(function() { S.parseDate([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'parseDate :: String -> Maybe Date\n' +
-                 '             ^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseDate :: String -> Maybe Date\n' +
+         '             ^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.parseDate('2001-02-03T04:05:06Z'), S.Just(new Date('2001-02-03T04:05:06Z')));
   eq(S.parseDate('today'), S.Nothing);

--- a/test/parseFloat.js
+++ b/test/parseFloat.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('parseFloat', function() {
@@ -14,16 +12,16 @@ test('parseFloat', function() {
   eq(S.parseFloat.length, 1);
 
   throws(function() { S.parseFloat([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'parseFloat :: String -> Maybe Number\n' +
-                 '              ^^^^^^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseFloat :: String -> Maybe Number\n' +
+         '              ^^^^^^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.parseFloat('12.34'), S.Just(12.34));
   eq(S.parseFloat('Infinity'), S.Just(Infinity));

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('parseInt', function() {
@@ -14,28 +12,28 @@ test('parseInt', function() {
   eq(S.parseInt.length, 2);
 
   throws(function() { S.parseInt(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'parseInt :: Integer -> String -> Maybe Integer\n' +
-                 '            ^^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseInt :: Integer -> String -> Maybe Integer\n' +
+         '            ^^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.parseInt(10, 42); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'parseInt :: Integer -> String -> Maybe Integer\n' +
-                 '                       ^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  42 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseInt :: Integer -> String -> Maybe Integer\n' +
+         '                       ^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  42 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.parseInt(10, '42'), S.Just(42));
   eq(S.parseInt(16, '2A'), S.Just(42));
@@ -115,11 +113,8 @@ test('parseInt', function() {
   eq(S.parseInt(36, '['), S.Nothing);
 
   // Throws if radix is not in [2 .. 36]
-  throws(function() { S.parseInt(1, ''); },
-         errorEq(RangeError, 'Radix not in [2 .. 36]'));
-
-  throws(function() { S.parseInt(37, ''); },
-         errorEq(RangeError, 'Radix not in [2 .. 36]'));
+  throws(function() { S.parseInt(1, ''); }, RangeError, 'Radix not in [2 .. 36]');
+  throws(function() { S.parseInt(37, ''); }, RangeError, 'Radix not in [2 .. 36]');
 
   // Is not case-sensitive
   eq(S.parseInt(16, 'FF'), S.Just(255));

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('parseJson', function() {
@@ -14,28 +12,28 @@ test('parseJson', function() {
   eq(S.parseJson.length, 2);
 
   throws(function() { S.parseJson('String'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'parseJson :: TypeRep -> String -> Maybe a\n' +
-                 '             ^^^^^^^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  "String" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘TypeRep’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseJson :: TypeRep -> String -> Maybe a\n' +
+         '             ^^^^^^^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  "String" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘TypeRep’.\n');
 
   throws(function() { S.parseJson(Array, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'parseJson :: TypeRep -> String -> Maybe a\n' +
-                 '                        ^^^^^^\n' +
-                 '                          1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseJson :: TypeRep -> String -> Maybe a\n' +
+         '                        ^^^^^^\n' +
+         '                          1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.parseJson(Object, '[Invalid JSON]'), S.Nothing);
   eq(S.parseJson(Array, '{"foo":"bar"}'), S.Nothing);

--- a/test/pluck.js
+++ b/test/pluck.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
 var vm = require('vm');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('pluck', function() {
@@ -15,40 +14,40 @@ test('pluck', function() {
   eq(S.pluck.length, 3);
 
   throws(function() { S.pluck([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'pluck :: Accessible a => TypeRep -> String -> Array a -> Array (Maybe b)\n' +
-                 '                         ^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘TypeRep’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'pluck :: Accessible a => TypeRep -> String -> Array a -> Array (Maybe b)\n' +
+         '                         ^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘TypeRep’.\n');
 
   throws(function() { S.pluck(Number, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'pluck :: Accessible a => TypeRep -> String -> Array a -> Array (Maybe b)\n' +
-                 '                                    ^^^^^^\n' +
-                 '                                      1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'pluck :: Accessible a => TypeRep -> String -> Array a -> Array (Maybe b)\n' +
+         '                                    ^^^^^^\n' +
+         '                                      1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   throws(function() { S.pluck(Number, 'x', {length: 0}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'pluck :: Accessible a => TypeRep -> String -> Array a -> Array (Maybe b)\n' +
-                 '                                              ^^^^^^^\n' +
-                 '                                                 1\n' +
-                 '\n' +
-                 '1)  {"length": 0} :: Object, StrMap Number, StrMap FiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'pluck :: Accessible a => TypeRep -> String -> Array a -> Array (Maybe b)\n' +
+         '                                              ^^^^^^^\n' +
+         '                                                 1\n' +
+         '\n' +
+         '1)  {"length": 0} :: Object, StrMap Number, StrMap FiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array a’.\n');
 
   eq(S.pluck(Number, 'x', []), []);
   eq(S.pluck(Number, 'x', [{x: '1'}, {x: 2}, {x: null}, {x: undefined}, {}]), [S.Nothing, S.Just(2), S.Nothing, S.Nothing, S.Nothing]);

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('prepend', function() {
@@ -14,31 +12,31 @@ test('prepend', function() {
   eq(S.prepend.length, 2);
 
   throws(function() { S.prepend('a', 'bc'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'prepend :: a -> Array a -> Array a\n' +
-                 '                ^^^^^^^\n' +
-                 '                   1\n' +
-                 '\n' +
-                 '1)  "bc" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'prepend :: a -> Array a -> Array a\n' +
+         '                ^^^^^^^\n' +
+         '                   1\n' +
+         '\n' +
+         '1)  "bc" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array a’.\n');
 
   throws(function() { S.prepend('1', [2, 3]); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'prepend :: a -> Array a -> Array a\n' +
-                 '           ^          ^\n' +
-                 '           1          2\n' +
-                 '\n' +
-                 '1)  "1" :: String\n' +
-                 '\n' +
-                 '2)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '    3 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'prepend :: a -> Array a -> Array a\n' +
+         '           ^          ^\n' +
+         '           1          2\n' +
+         '\n' +
+         '1)  "1" :: String\n' +
+         '\n' +
+         '2)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '    3 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(S.prepend(1, []), [1]);
   eq(S.prepend(1, [2, 3]), [1, 2, 3]);

--- a/test/product.js
+++ b/test/product.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('product', function() {
@@ -14,52 +12,52 @@ test('product', function() {
   eq(S.product.length, 1);
 
   throws(function() { S.product('xxx'); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'product :: Foldable f => f -> FiniteNumber\n' +
-                 '           ^^^^^^^^^^    ^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 '‘product’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'product :: Foldable f => f -> FiniteNumber\n' +
+         '           ^^^^^^^^^^    ^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         '‘product’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.product([1, 2, 'xxx']); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'product :: Foldable f => f -> FiniteNumber\n' +
-                 '                         ^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  [1, 2, "xxx"] :: Array ???\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'product :: Foldable f => f -> FiniteNumber\n' +
+         '                         ^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  [1, 2, "xxx"] :: Array ???\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   throws(function() { S.product([1, Infinity]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'product :: Foldable f => f -> FiniteNumber\n' +
-                 '                              ^^^^^^^^^^^^\n' +
-                 '                                   1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'product :: Foldable f => f -> FiniteNumber\n' +
+         '                              ^^^^^^^^^^^^\n' +
+         '                                   1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.product([1, -Infinity]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'product :: Foldable f => f -> FiniteNumber\n' +
-                 '                              ^^^^^^^^^^^^\n' +
-                 '                                   1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'product :: Foldable f => f -> FiniteNumber\n' +
+         '                              ^^^^^^^^^^^^\n' +
+         '                                   1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.product([]), 1);
   eq(S.product([0, 1, 2, 3]), 0);

--- a/test/prop.js
+++ b/test/prop.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('prop', function() {
@@ -14,48 +12,48 @@ test('prop', function() {
   eq(S.prop.length, 2);
 
   throws(function() { S.prop(1); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'prop :: Accessible a => String -> a -> b\n' +
-                 '                        ^^^^^^\n' +
-                 '                          1\n' +
-                 '\n' +
-                 '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'prop :: Accessible a => String -> a -> b\n' +
+         '                        ^^^^^^\n' +
+         '                          1\n' +
+         '\n' +
+         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   throws(function() { S.prop('a', null); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'prop :: Accessible a => String -> a -> b\n' +
-                 '        ^^^^^^^^^^^^              ^\n' +
-                 '                                  1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 '‘prop’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'prop :: Accessible a => String -> a -> b\n' +
+         '        ^^^^^^^^^^^^              ^\n' +
+         '                                  1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         '‘prop’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.prop('a', true); },
-         errorEq(TypeError,
-                 '‘prop’ expected object to have a property named ‘a’; true does not'));
+         TypeError,
+         '‘prop’ expected object to have a property named ‘a’; true does not');
 
   throws(function() { S.prop('a', 1); },
-         errorEq(TypeError,
-                 '‘prop’ expected object to have a property named ‘a’; 1 does not'));
+         TypeError,
+         '‘prop’ expected object to have a property named ‘a’; 1 does not');
 
   throws(function() { S.prop('map', 'abcd'); },
-         errorEq(TypeError,
-                 '‘prop’ expected object to have a property named ‘map’; "abcd" does not'));
+         TypeError,
+         '‘prop’ expected object to have a property named ‘map’; "abcd" does not');
 
   throws(function() { S.prop('c', {a: 0, b: 1}); },
-         errorEq(TypeError,
-                 '‘prop’ expected object to have a property named ‘c’; {"a": 0, "b": 1} does not'));
+         TypeError,
+         '‘prop’ expected object to have a property named ‘c’; {"a": 0, "b": 1} does not');
 
   throws(function() { S.prop('xxx', [1, 2, 3]); },
-         errorEq(TypeError,
-                 '‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not'));
+         TypeError,
+         '‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not');
 
   eq(S.prop('a', {a: 0, b: 1}), 0);
   eq(S.prop('0', [1, 2, 3]), 1);

--- a/test/range.js
+++ b/test/range.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('range', function() {
@@ -14,28 +12,28 @@ test('range', function() {
   eq(S.range.length, 2);
 
   throws(function() { S.range(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'range :: Integer -> Integer -> Array Integer\n' +
-                 '         ^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'range :: Integer -> Integer -> Array Integer\n' +
+         '         ^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.range(0, 0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'range :: Integer -> Integer -> Array Integer\n' +
-                 '                    ^^^^^^^\n' +
-                 '                       1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'range :: Integer -> Integer -> Array Integer\n' +
+         '                    ^^^^^^^\n' +
+         '                       1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   eq(S.range(0, 0), []);
   eq(S.range(0, 10), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('reduce', function() {
@@ -14,16 +12,16 @@ test('reduce', function() {
   eq(S.reduce.length, 3);
 
   throws(function() { S.reduce('xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'reduce :: Foldable b => Function -> a -> b -> a\n' +
-                 '                        ^^^^^^^^\n' +
-                 '                           1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'reduce :: Foldable b => Function -> a -> b -> a\n' +
+         '                        ^^^^^^^^\n' +
+         '                           1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   eq(S.reduce(S.add, 0, []), 0);
   eq(S.reduce(S.add, 0, [1, 2, 3, 4, 5]), 15);

--- a/test/regex.js
+++ b/test/regex.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var R = require('ramda');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('regex', function() {
@@ -16,67 +14,67 @@ test('regex', function() {
   eq(S.regex.length, 2);
 
   throws(function() { S.regex('y'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
-                 '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                  1\n' +
-                 '\n' +
-                 '1)  "y" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
+         '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+         '                                  1\n' +
+         '\n' +
+         '1)  "y" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n');
 
   throws(function() { S.regex('G'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
-                 '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                  1\n' +
-                 '\n' +
-                 '1)  "G" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
+         '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+         '                                  1\n' +
+         '\n' +
+         '1)  "G" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n');
 
   throws(function() { S.regex('ig'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
-                 '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                  1\n' +
-                 '\n' +
-                 '1)  "ig" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
+         '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+         '                                  1\n' +
+         '\n' +
+         '1)  "ig" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n');
 
   var G = function G() {};
   G.prototype.toString = R.always('g');
 
   throws(function() { S.regex(new G()); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
-                 '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
-                 '                                  1\n' +
-                 '\n' +
-                 '1)  g :: Object, StrMap ???\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
+         '         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n' +
+         '                                  1\n' +
+         '\n' +
+         '1)  g :: Object, StrMap ???\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim")’.\n');
 
   throws(function() { S.regex('', /(?:)/); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
-                 '                                                                ^^^^^^\n' +
-                 '                                                                  1\n' +
-                 '\n' +
-                 '1)  /(?:)/ :: RegExp\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp\n' +
+         '                                                                ^^^^^^\n' +
+         '                                                                  1\n' +
+         '\n' +
+         '1)  /(?:)/ :: RegExp\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.regex('', '\\d'), /\d/);
   eq(S.regex('g', '\\d'), /\d/g);

--- a/test/regexEscape.js
+++ b/test/regexEscape.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var jsc = require('jsverify');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('regexEscape', function() {
@@ -16,16 +14,16 @@ test('regexEscape', function() {
   eq(S.regexEscape.length, 1);
 
   throws(function() { S.regexEscape(/(?:)/); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'regexEscape :: String -> String\n' +
-                 '               ^^^^^^\n' +
-                 '                 1\n' +
-                 '\n' +
-                 '1)  /(?:)/ :: RegExp\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'regexEscape :: String -> String\n' +
+         '               ^^^^^^\n' +
+         '                 1\n' +
+         '\n' +
+         '1)  /(?:)/ :: RegExp\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.regexEscape('-=*{XYZ}*=-'), '\\-=\\*\\{XYZ\\}\\*=\\-');
 

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('reverse', function() {
@@ -14,16 +12,16 @@ test('reverse', function() {
   eq(S.reverse.length, 1);
 
   throws(function() { S.reverse({answer: 42}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'reverse :: List a -> List a\n' +
-                 '           ^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  {"answer": 42} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'reverse :: List a -> List a\n' +
+         '           ^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  {"answer": 42} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.reverse([]), []);
   eq(S.reverse([1, 2, 3]), [3, 2, 1]);

--- a/test/rights.js
+++ b/test/rights.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('rights', function() {
@@ -14,16 +12,16 @@ test('rights', function() {
   eq(S.rights.length, 1);
 
   throws(function() { S.rights([1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'rights :: Array (Either a b) -> Array b\n' +
-                 '                ^^^^^^^^^^^^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Either a b’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'rights :: Array (Either a b) -> Array b\n' +
+         '                ^^^^^^^^^^^^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Either a b’.\n');
 
   eq(S.rights([]), []);
   eq(S.rights([S.Left('a'), S.Left('b')]), []);

--- a/test/slice.js
+++ b/test/slice.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('slice', function() {
@@ -14,40 +12,40 @@ test('slice', function() {
   eq(S.slice.length, 3);
 
   throws(function() { S.slice(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'slice :: Integer -> Integer -> List a -> Maybe (List a)\n' +
-                 '         ^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'slice :: Integer -> Integer -> List a -> Maybe (List a)\n' +
+         '         ^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.slice(0, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'slice :: Integer -> Integer -> List a -> Maybe (List a)\n' +
-                 '                    ^^^^^^^\n' +
-                 '                       1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'slice :: Integer -> Integer -> List a -> Maybe (List a)\n' +
+         '                    ^^^^^^^\n' +
+         '                       1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.slice(0, 0, {length: -1}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'slice :: Integer -> Integer -> List a -> Maybe (List a)\n' +
-                 '                               ^^^^^^\n' +
-                 '                                 1\n' +
-                 '\n' +
-                 '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'slice :: Integer -> Integer -> List a -> Maybe (List a)\n' +
+         '                               ^^^^^^\n' +
+         '                                 1\n' +
+         '\n' +
+         '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.slice(6, 1, [1, 2, 3, 4, 5]), S.Nothing);
   eq(S.slice(1, 6, [1, 2, 3, 4, 5]), S.Nothing);

--- a/test/splitOn.js
+++ b/test/splitOn.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var jsc = require('jsverify');
 
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('splitOn', function() {
@@ -16,28 +14,28 @@ test('splitOn', function() {
   eq(S.splitOn.length, 2);
 
   throws(function() { S.splitOn(/x/); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'splitOn :: String -> String -> Array String\n' +
-                 '           ^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  /x/ :: RegExp\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'splitOn :: String -> String -> Array String\n' +
+         '           ^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  /x/ :: RegExp\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   throws(function() { S.splitOn('', null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'splitOn :: String -> String -> Array String\n' +
-                 '                     ^^^^^^\n' +
-                 '                       1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'splitOn :: String -> String -> Array String\n' +
+         '                     ^^^^^^\n' +
+         '                       1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.splitOn('', 'abc'), ['a', 'b', 'c']);
   eq(S.splitOn(':', ''), ['']);

--- a/test/sub.js
+++ b/test/sub.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('sub', function() {
@@ -14,52 +12,52 @@ test('sub', function() {
   eq(S.sub.length, 2);
 
   throws(function() { S.sub('xxx', 1); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^^^\n' +
-                 '            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '       ^^^^^^^^^^^^\n' +
+         '            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.sub(1, 'xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.sub(1, Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.sub(1, -Infinity); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
-                 '                       ^^^^^^^^^^^^\n' +
-                 '                            1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'sub :: FiniteNumber -> FiniteNumber -> FiniteNumber\n' +
+         '                       ^^^^^^^^^^^^\n' +
+         '                            1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.sub(1, 1), 0);
   eq(S.sub(-1, -1), 0);

--- a/test/sum.js
+++ b/test/sum.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('sum', function() {
@@ -14,52 +12,52 @@ test('sum', function() {
   eq(S.sum.length, 1);
 
   throws(function() { S.sum('xxx'); },
-         errorEq(TypeError,
-                 'Type-class constraint violation\n' +
-                 '\n' +
-                 'sum :: Foldable f => f -> FiniteNumber\n' +
-                 '       ^^^^^^^^^^    ^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 '‘sum’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n'));
+         TypeError,
+         'Type-class constraint violation\n' +
+         '\n' +
+         'sum :: Foldable f => f -> FiniteNumber\n' +
+         '       ^^^^^^^^^^    ^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         '‘sum’ requires ‘f’ to satisfy the Foldable type-class constraint; the value at position 1 does not.\n');
 
   throws(function() { S.sum([1, 2, 'xxx']); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'sum :: Foldable f => f -> FiniteNumber\n' +
-                 '                     ^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  [1, 2, "xxx"] :: Array ???\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'sum :: Foldable f => f -> FiniteNumber\n' +
+         '                     ^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  [1, 2, "xxx"] :: Array ???\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   throws(function() { S.sum([1, Infinity]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'sum :: Foldable f => f -> FiniteNumber\n' +
-                 '                          ^^^^^^^^^^^^\n' +
-                 '                               1\n' +
-                 '\n' +
-                 '1)  Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'sum :: Foldable f => f -> FiniteNumber\n' +
+         '                          ^^^^^^^^^^^^\n' +
+         '                               1\n' +
+         '\n' +
+         '1)  Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   throws(function() { S.sum([1, -Infinity]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'sum :: Foldable f => f -> FiniteNumber\n' +
-                 '                          ^^^^^^^^^^^^\n' +
-                 '                               1\n' +
-                 '\n' +
-                 '1)  -Infinity :: Number, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘FiniteNumber’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'sum :: Foldable f => f -> FiniteNumber\n' +
+         '                          ^^^^^^^^^^^^\n' +
+         '                               1\n' +
+         '\n' +
+         '1)  -Infinity :: Number, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘FiniteNumber’.\n');
 
   eq(S.sum([]), 0);
   eq(S.sum([0, 1, 2, 3]), 6);

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('tail', function() {
@@ -14,16 +12,16 @@ test('tail', function() {
   eq(S.tail.length, 1);
 
   throws(function() { S.tail({length: -1}); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'tail :: List a -> Maybe (List a)\n' +
-                 '        ^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'tail :: List a -> Maybe (List a)\n' +
+         '        ^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  {"length": -1} :: Object, StrMap Number, StrMap FiniteNumber, StrMap NonZeroFiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.tail([]), S.Nothing);
   eq(S.tail(['foo']), S.Just([]));

--- a/test/take.js
+++ b/test/take.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('take', function() {
@@ -14,28 +12,28 @@ test('take', function() {
   eq(S.take.length, 2);
 
   throws(function() { S.take(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'take :: Integer -> List a -> Maybe (List a)\n' +
-                 '        ^^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'take :: Integer -> List a -> Maybe (List a)\n' +
+         '        ^^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.take(0, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'take :: Integer -> List a -> Maybe (List a)\n' +
-                 '                   ^^^^^^\n' +
-                 '                     1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'take :: Integer -> List a -> Maybe (List a)\n' +
+         '                   ^^^^^^\n' +
+         '                     1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.take(0, [1, 2, 3, 4, 5]), S.Just([]));
   eq(S.take(1, [1, 2, 3, 4, 5]), S.Just([1]));

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('takeLast', function() {
@@ -14,28 +12,28 @@ test('takeLast', function() {
   eq(S.takeLast.length, 2);
 
   throws(function() { S.takeLast(0.5); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'takeLast :: Integer -> List a -> Maybe (List a)\n' +
-                 '            ^^^^^^^\n' +
-                 '               1\n' +
-                 '\n' +
-                 '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Integer’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'takeLast :: Integer -> List a -> Maybe (List a)\n' +
+         '            ^^^^^^^\n' +
+         '               1\n' +
+         '\n' +
+         '1)  0.5 :: Number, FiniteNumber, NonZeroFiniteNumber, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Integer’.\n');
 
   throws(function() { S.takeLast(0, null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'takeLast :: Integer -> List a -> Maybe (List a)\n' +
-                 '                       ^^^^^^\n' +
-                 '                         1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘List a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'takeLast :: Integer -> List a -> Maybe (List a)\n' +
+         '                       ^^^^^^\n' +
+         '                         1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘List a’.\n');
 
   eq(S.takeLast(0, [1, 2, 3, 4, 5]), S.Just([]));
   eq(S.takeLast(1, [1, 2, 3, 4, 5]), S.Just([5]));

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('test', function() {
@@ -14,28 +12,28 @@ test('test', function() {
   eq(S.test.length, 2);
 
   throws(function() { S.test('^a'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'test :: RegExp -> String -> Boolean\n' +
-                 '        ^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  "^a" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘RegExp’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'test :: RegExp -> String -> Boolean\n' +
+         '        ^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  "^a" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘RegExp’.\n');
 
   throws(function() { S.test(/^a/, [1, 2, 3]); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'test :: RegExp -> String -> Boolean\n' +
-                 '                  ^^^^^^\n' +
-                 '                    1\n' +
-                 '\n' +
-                 '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'test :: RegExp -> String -> Boolean\n' +
+         '                  ^^^^^^\n' +
+         '                    1\n' +
+         '\n' +
+         '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.test(/^a/, 'abacus'), true);
   eq(S.test(/^a/, 'banana'), false);

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('toLower', function() {
@@ -14,16 +12,16 @@ test('toLower', function() {
   eq(S.toLower.length, 1);
 
   throws(function() { S.toLower(true); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'toLower :: String -> String\n' +
-                 '           ^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  true :: Boolean\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'toLower :: String -> String\n' +
+         '           ^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  true :: Boolean\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.toLower(''), '');
   eq(S.toLower('ABC def 123'), 'abc def 123');

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('toUpper', function() {
@@ -14,16 +12,16 @@ test('toUpper', function() {
   eq(S.toUpper.length, 1);
 
   throws(function() { S.toUpper(true); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'toUpper :: String -> String\n' +
-                 '           ^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  true :: Boolean\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'toUpper :: String -> String\n' +
+         '           ^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  true :: Boolean\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.toUpper(''), '');
   eq(S.toUpper('ABC def 123'), 'ABC DEF 123');

--- a/test/trim.js
+++ b/test/trim.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('trim', function() {
@@ -14,16 +12,16 @@ test('trim', function() {
   eq(S.trim.length, 1);
 
   throws(function() { S.trim(/XXX/); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'trim :: String -> String\n' +
-                 '        ^^^^^^\n' +
-                 '          1\n' +
-                 '\n' +
-                 '1)  /XXX/ :: RegExp\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'trim :: String -> String\n' +
+         '        ^^^^^^\n' +
+         '          1\n' +
+         '\n' +
+         '1)  /XXX/ :: RegExp\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.trim(''), '');
   eq(S.trim(' '), '');

--- a/test/unfoldr.js
+++ b/test/unfoldr.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('unfoldr', function() {
@@ -14,16 +12,16 @@ test('unfoldr', function() {
   eq(S.unfoldr.length, 2);
 
   throws(function() { S.unfoldr(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'unfoldr :: Function -> b -> Array a\n' +
-                 '           ^^^^^^^^\n' +
-                 '              1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Function’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'unfoldr :: Function -> b -> Array a\n' +
+         '           ^^^^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Function’.\n');
 
   var f = function(n) {
     return n >= 5 ? S.Nothing : S.Just([n, n + 1]);

--- a/test/unlines.js
+++ b/test/unlines.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('unlines', function() {
@@ -14,16 +12,16 @@ test('unlines', function() {
   eq(S.unlines.length, 1);
 
   throws(function() { S.unlines(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'unlines :: Array String -> String\n' +
-                 '           ^^^^^^^^^^^^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'unlines :: Array String -> String\n' +
+         '           ^^^^^^^^^^^^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array String’.\n');
 
   eq(S.unlines([]), '');
   eq(S.unlines(['']), '\n');

--- a/test/unwords.js
+++ b/test/unwords.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('unwords', function() {
@@ -14,16 +12,16 @@ test('unwords', function() {
   eq(S.unwords.length, 1);
 
   throws(function() { S.unwords(null); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'unwords :: Array String -> String\n' +
-                 '           ^^^^^^^^^^^^\n' +
-                 '                1\n' +
-                 '\n' +
-                 '1)  null :: Null\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘Array String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'unwords :: Array String -> String\n' +
+         '           ^^^^^^^^^^^^\n' +
+         '                1\n' +
+         '\n' +
+         '1)  null :: Null\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Array String’.\n');
 
   eq(S.unwords([]), '');
   eq(S.unwords(['']), '');

--- a/test/values.js
+++ b/test/values.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('values', function() {
@@ -14,30 +12,30 @@ test('values', function() {
   eq(S.values.length, 1);
 
   throws(function() { S.values('xxx'); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'values :: StrMap a -> Array a\n' +
-                 '          ^^^^^^^^\n' +
-                 '             1\n' +
-                 '\n' +
-                 '1)  "xxx" :: String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘StrMap a’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'values :: StrMap a -> Array a\n' +
+         '          ^^^^^^^^\n' +
+         '             1\n' +
+         '\n' +
+         '1)  "xxx" :: String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘StrMap a’.\n');
 
   throws(function() { S.values({a: '1', b: 2, c: '3'}); },
-         errorEq(TypeError,
-                 'Type-variable constraint violation\n' +
-                 '\n' +
-                 'values :: StrMap a -> Array a\n' +
-                 '                 ^\n' +
-                 '                 1\n' +
-                 '\n' +
-                 '1)  "1" :: String\n' +
-                 '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                 '    "3" :: String\n' +
-                 '\n' +
-                 'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n'));
+         TypeError,
+         'Type-variable constraint violation\n' +
+         '\n' +
+         'values :: StrMap a -> Array a\n' +
+         '                 ^\n' +
+         '                 1\n' +
+         '\n' +
+         '1)  "1" :: String\n' +
+         '    2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+         '    "3" :: String\n' +
+         '\n' +
+         'Since there is no type of which all the above values are members, the type-variable constraint has been violated.\n');
 
   eq(S.values({}), []);
   eq(S.values({a: 1, b: 2, c: 3}).sort(), [1, 2, 3]);

--- a/test/words.js
+++ b/test/words.js
@@ -1,11 +1,9 @@
 'use strict';
 
-var throws = require('assert').throws;
-
 var S = require('..');
 
 var eq = require('./internal/eq');
-var errorEq = require('./internal/errorEq');
+var throws = require('./internal/throws');
 
 
 test('words', function() {
@@ -14,16 +12,16 @@ test('words', function() {
   eq(S.words.length, 1);
 
   throws(function() { S.words(['foo']); },
-         errorEq(TypeError,
-                 'Invalid value\n' +
-                 '\n' +
-                 'words :: String -> Array String\n' +
-                 '         ^^^^^^\n' +
-                 '           1\n' +
-                 '\n' +
-                 '1)  ["foo"] :: Array String\n' +
-                 '\n' +
-                 'The value at position 1 is not a member of ‘String’.\n'));
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'words :: String -> Array String\n' +
+         '         ^^^^^^\n' +
+         '           1\n' +
+         '\n' +
+         '1)  ["foo"] :: Array String\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘String’.\n');
 
   eq(S.words(''), []);
   eq(S.words(' '), []);


### PR DESCRIPTION
Before:

```javascript
var throws = require('assert').throws;

var errorEq = require('./internal/errorEq');
```

```javascript
throws(function() { S.prop('xxx', [1, 2, 3]); },
       errorEq(TypeError,
               '‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not'));
```

After:

```javascript
var throws = require('./internal/throws');
```

```javascript
throws(function() { S.prop('xxx', [1, 2, 3]); },
       TypeError,
       '‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not');
```
