### PR TITLE
Implement browser testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ lint:
 	  -- index.js
 	$(ESLINT) \
 	  --env node \
+	  -- karma.conf.js
+	$(ESLINT) \
+	  --env node \
 	  --global suite \
 	  --global test \
 	  --rule 'dot-notation: [error, {allowKeywords: true}]' \
@@ -62,7 +65,7 @@ setup:
 
 .PHONY: test
 test:
-	$(ISTANBUL) cover node_modules/.bin/_mocha -- --recursive --timeout 20000 --ui tdd
+	$(ISTANBUL) cover node_modules/.bin/_mocha
 	$(ISTANBUL) check-coverage --branches 100
 ifeq ($(shell node --version | cut -d . -f 1),v6)
 	$(DOCTEST) -- index.js

--- a/circle.yml
+++ b/circle.yml
@@ -2,15 +2,16 @@ dependencies:
   override:
     - printf '%s\n' color=false progress=false >.npmrc
     - rm -rf node_modules
-    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 0.12.7 make setup ;; 2) nvm exec 4 make setup ;; 3) nvm install 6 && nvm exec 6 make setup ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 4 make setup ;; 2) nvm install 6 && nvm exec 6 make setup ;; esac:
         parallel: true
 
 machine:
   node:
-    version: 0.10.34
+    version: 0.12.7
 
 test:
   override:
     - make lint
-    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 0.12.7 make test ;; 2) nvm exec 4 make test ;; 3) nvm exec 6 make test ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 4 make test ;; 2) nvm exec 6 make test ;; esac:
         parallel: true
+    - node_modules/.bin/karma start

--- a/index.js
+++ b/index.js
@@ -496,11 +496,12 @@
   //. false
   //. ```
   function is(typeRep, x) {
-    return type(x) ===
-           (typeRep.prototype != null &&
-            _toString.call(typeRep.prototype['@@type']) === '[object String]' ?
-              typeRep.prototype['@@type'] :
-              typeRep.name);
+    if (_toString.call(typeRep.prototype['@@type']) === '[object String]') {
+      return x != null && x['@@type'] === typeRep.prototype['@@type'];
+    } else {
+      var match = /function (\w*)/.exec(typeRep);
+      return match != null && match[1] === type(x);
+    }
   }
   S.is = def('is', {}, [TypeRep, $.Any, $.Boolean], is);
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,115 @@
+'use strict';
+
+//  depMain :: String -> String
+var depMain = function(name) {
+  var pkg = require(name + '/package.json');
+  var main = 'main' in pkg ? pkg.main : 'index.js';
+  return './node_modules/' + name + '/' + main;
+};
+
+//  dependencies :: Array String
+var dependencies = Object.keys(require('./package.json').dependencies);
+
+//  https://saucelabs.com/platforms
+var customLaunchers = {
+  sl_chrome: {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    version: '51'
+  },
+  sl_firefox: {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: '47'
+  },
+  sl_safari_8: {
+    base: 'SauceLabs',
+    browserName: 'safari',
+    platform: 'OS X 10.10',
+    version: '8'
+  },
+  sl_safari_10: {
+    base: 'SauceLabs',
+    browserName: 'safari',
+    platform: 'OS X 10.11',
+    version: '10'
+  },
+  sl_ios_safari_8: {
+    base: 'SauceLabs',
+    browserName: 'iphone',
+    version: '8.1'
+  },
+  sl_ie_9: {
+    base: 'SauceLabs',
+    browserName: 'internet explorer',
+    platform: 'Windows 2008',
+    version: '9'
+  },
+  sl_ie_11: {
+    base: 'SauceLabs',
+    browserName: 'internet explorer',
+    platform: 'Windows 8.1',
+    version: '11'
+  }
+};
+
+var options = {
+
+  browserDisconnectTimeout: 10000,
+  browserDisconnectTolerance: 2,
+  browserNoActivityTimeout: 90000,
+  captureTimeout: 120000,
+
+  client: {
+    mocha: {opts: 'test/mocha.opts'}
+  },
+
+  plugins: [
+    require('karma-browserify'),
+    require('karma-mocha'),
+    require('karma-sauce-launcher')
+  ],
+
+  frameworks: [
+    'browserify',
+    'mocha'
+  ],
+
+  files: dependencies.map(depMain).concat(['index.js', 'test/**/*.js']),
+
+  preprocessors: {
+    'test/**/*.js': ['browserify']
+  },
+
+  reporters: [
+    'dots',
+    'saucelabs'
+  ],
+
+  singleRun: true,
+
+  browserify: {
+    configure: function(bundle) {
+      bundle.on('prebundle', function() {
+        dependencies.forEach(function(name) {
+          bundle.require(depMain(name), {expose: name});
+        });
+      });
+    }
+  },
+
+  sauceLabs: {
+    testName: 'Sanctuary',
+    project: 'Sanctuary',
+    name: 'Sanctuary Test Suite',
+    startTunnel: true,
+    timeout: 600
+  },
+
+  customLaunchers: customLaunchers,
+
+  browsers: Object.keys(customLaunchers)
+
+};
+
+module.exports = function(config) { config.set(options); };

--- a/package.json
+++ b/package.json
@@ -15,10 +15,15 @@
     "sanctuary-def": "0.6.x"
   },
   "devDependencies": {
+    "browserify": "13.1.x",
     "doctest": "0.10.x",
     "eslint": "2.9.x",
     "istanbul": "0.4.x",
     "jsverify": "0.7.x",
+    "karma": "1.3.x",
+    "karma-browserify": "5.1.x",
+    "karma-mocha": "1.3.x",
+    "karma-sauce-launcher": "1.1.x",
     "mocha": "3.x.x",
     "remember-bower": "0.1.x",
     "sanctuary-style": "0.3.x",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--recursive
+--timeout 20000
+--ui tdd


### PR DESCRIPTION
This PR when it's finished will add support for running the unit tests through Karma and hookup CircleCI to execute them on multiple browsers via SauceLabs, so that we can properly prove browser support and potentially resolve #292.

At the moment I have karma successfully being able to execute the test suite using browserify to handle the test suite translation to the browser (module loading mostly). Browserify adds a little bit of weight to DevDeps but does do a good job of bundling the tests correctly.

One thing I will probably want your input on @davidchambers is how to go about integrating the `karma start` command into the Makefile. Since we can run the tests in many different ways via karma:

- Simple quick test run using a headless browser (PhantomJS)
- Test manually by bringing your own browser
- Send tests to Saucelabs for cross browser testing

I'm thinking maybe put something like the first in the current test command and creating a new command to send off the tests.