### PR TITLE
Lock CircleCI badge to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sanctuary
 
 [![npm](https://img.shields.io/npm/v/sanctuary.svg)](https://www.npmjs.com/package/sanctuary)
-[![CircleCI](https://img.shields.io/circleci/project/github/sanctuary-js/sanctuary.svg)](https://circleci.com/gh/sanctuary-js/sanctuary)
+[![CircleCI](https://img.shields.io/circleci/project/github/sanctuary-js/sanctuary/master.svg)](https://circleci.com/gh/sanctuary-js/sanctuary/tree/master)
 [![Gitter](https://img.shields.io/gitter/room/badges/shields.svg)](https://gitter.im/sanctuary-js/sanctuary)
 
 Sanctuary is a functional programming library inspired by Haskell and

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
 //. # Sanctuary
 //.
 //. [![npm](https://img.shields.io/npm/v/sanctuary.svg)](https://www.npmjs.com/package/sanctuary)
-//. [![CircleCI](https://img.shields.io/circleci/project/github/sanctuary-js/sanctuary.svg)](https://circleci.com/gh/sanctuary-js/sanctuary)
+//. [![CircleCI](https://img.shields.io/circleci/project/github/sanctuary-js/sanctuary/master.svg)](https://circleci.com/gh/sanctuary-js/sanctuary/tree/master)
 //. [![Gitter](https://img.shields.io/gitter/room/badges/shields.svg)](https://gitter.im/sanctuary-js/sanctuary)
 //.
 //. Sanctuary is a functional programming library inspired by Haskell and


### PR DESCRIPTION
I kind of got spooked when I saw the build failing and saw the browsers tests dieing. After a bit I noticed the badge is just linked to all builds which I think is a bit confusing at times at can make it look like sanctuary is broken.

This PR changes the badge to only get the status from the master branch and to link to master branch builds on CircleCI.