### PR TITLE
test: share constructors to remove duplication

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "browserify": "13.1.x",
     "doctest": "0.10.x",
     "eslint": "2.9.x",
+    "fantasy-land": "0.3.x",
     "istanbul": "0.4.x",
     "jsverify": "0.7.x",
     "karma": "1.3.x",

--- a/test/Either/Either.js
+++ b/test/Either/Either.js
@@ -1,85 +1,21 @@
 'use strict';
 
 var jsc = require('jsverify');
-var R = require('ramda');
 
 var S = require('../..');
 
+var Compose = require('../internal/Compose');
+var EitherArb = require('../internal/EitherArb');
+var Identity = require('../internal/Identity');
+var IdentityArb = require('../internal/IdentityArb');
 
-//  Identity :: a -> Identity a
-function Identity(x) {
-  return {
-    of: Identity,
-    map: function(fn) {
-      return Identity(fn(x));
-    },
-    ap: function(y) {
-      return Identity(x(y));
-    },
-    equals: function(other) {
-      return R.equals(x, other.value);
-    },
-    value: x
-  };
-}
-
-Identity.of = Identity;
-
-//  IdentityArb :: Arbitrary a -> Arbitrary (Identity a)
-function IdentityArb(arb) {
-  return arb.smap(Identity, function(i) { return i.value; });
-}
-
-//  identityToMaybe :: Identity a -> Maybe a
-function identityToMaybe(i) {
-  return S.Just(i.value);
-}
-
-//  EitherArb :: Arbitrary a -> Arbitrary b -> Arbitrary (Either a b)
-function EitherArb(lArb, rArb) {
-  return jsc.oneof(LeftArb(lArb), RightArb(rArb));
-}
-
-//  LeftArb :: Arbitrary a -> Arbitrary (Either a b)
-function LeftArb(arb) {
-  return arb.smap(S.Left, function(e) { return e.value; }, R.toString);
-}
-
-//  RightArb :: Arbitrary a -> Arbitrary (Either b a)
-function RightArb(arb) {
-  return arb.smap(S.Right, function(e) { return e.value; }, R.toString);
-}
-
-//  Compose :: Apply f, Apply g
-//          => { of: b -> f b } -> { of: c -> g c }
-//          -> f (g a) -> Compose f g a
-function Compose(F, G) {
-  function _Compose(x) {
-    return {
-      constructor: _Compose,
-      map: function(f) {
-        return _Compose(R.map(R.map(f), x));
-      },
-      ap: function(y) {
-        return _Compose(R.ap(R.map(R.ap, x), y.value));
-      },
-      equals: function(other) {
-        return R.equals(x, other.value);
-      },
-      value: x
-    };
-  }
-  _Compose.of = function(x) {
-    return _Compose(F.of(G.of(x)));
-  };
-  return _Compose;
-}
 
 suite('Either', function() {
 
   suite('Traversable laws', function() {
 
     test('satisfies naturality', function() {
+      var identityToMaybe = S.compose(S.Just, S.prop('value'));
       jsc.assert(jsc.forall(EitherArb(jsc.integer, IdentityArb(jsc.string)), function(either) {
         var lhs = identityToMaybe(either.sequence(Identity.of));
         var rhs = either.map(identityToMaybe).sequence(S.Maybe.of);
@@ -97,7 +33,7 @@ suite('Either', function() {
 
     test('satisfies composition', function() {
       jsc.assert(jsc.forall(EitherArb(jsc.string, IdentityArb(EitherArb(jsc.string, jsc.integer))), function(u) {
-        var C = Compose(Identity, S.Either);
+        var C = Compose(Identity)(S.Either);
         var lhs = u.map(C).sequence(C.of);
         var rhs = C(u.sequence(Identity.of).map(function(x) {
           return x.sequence(S.Either.of);

--- a/test/Maybe/Maybe.js
+++ b/test/Maybe/Maybe.js
@@ -1,84 +1,15 @@
 'use strict';
 
 var jsc = require('jsverify');
-var R = require('ramda');
 
 var S = require('../..');
 
+var Compose = require('../internal/Compose');
+var EitherArb = require('../internal/EitherArb');
+var Identity = require('../internal/Identity');
+var IdentityArb = require('../internal/IdentityArb');
+var MaybeArb = require('../internal/MaybeArb');
 
-//  Identity :: a -> Identity a
-function Identity(x) {
-  return {
-    of: Identity,
-    map: function(fn) {
-      return Identity(fn(x));
-    },
-    ap: function(y) {
-      return Identity(x(y));
-    },
-    equals: function(other) {
-      return R.equals(x, other.value);
-    },
-    value: x
-  };
-}
-
-Identity.of = Identity;
-
-//  IdentityArb :: Arbitrary a -> Arbitrary (Identity a)
-function IdentityArb(arb) {
-  return arb.smap(Identity, function(i) { return i.value; });
-}
-
-//  MaybeArb :: Arbitrary a -> Arbitrary (Maybe a)
-function MaybeArb(arb) {
-  return jsc.oneof(JustArb(arb), jsc.constant(S.Nothing));
-}
-
-//  JustArb :: Arbitrary a -> Arbitrary (Maybe a)
-function JustArb(arb) {
-  return arb.smap(S.Just, function(m) { return m.value; }, R.toString);
-}
-
-//  EitherArb :: Arbitrary a -> Arbitrary b -> Arbitrary (Either a b)
-function EitherArb(lArb, rArb) {
-  return jsc.oneof(LeftArb(lArb), RightArb(rArb));
-}
-
-//  LeftArb :: Arbitrary a -> Arbitrary (Either a b)
-function LeftArb(arb) {
-  return arb.smap(S.Left, function(e) { return e.value; }, R.toString);
-}
-
-//  RightArb :: Arbitrary a -> Arbitrary (Either b a)
-function RightArb(arb) {
-  return arb.smap(S.Right, function(e) { return e.value; }, R.toString);
-}
-
-//  Compose :: Apply f, Apply g
-//          => { of: b -> f b } -> { of: c -> g c }
-//          -> f (g a) -> Compose f g a
-function Compose(F, G) {
-  function _Compose(x) {
-    return {
-      constructor: _Compose,
-      map: function(f) {
-        return _Compose(R.map(R.map(f), x));
-      },
-      ap: function(y) {
-        return _Compose(R.ap(R.map(R.ap, x), y.value));
-      },
-      equals: function(other) {
-        return R.equals(x, other.value);
-      },
-      value: x
-    };
-  }
-  _Compose.of = function(x) {
-    return _Compose(F.of(G.of(x)));
-  };
-  return _Compose;
-}
 
 suite('Maybe', function() {
 
@@ -102,7 +33,7 @@ suite('Maybe', function() {
 
     test('satisfies composition', function() {
       jsc.assert(jsc.forall(MaybeArb(IdentityArb(MaybeArb(jsc.integer))), function(u) {
-        var C = Compose(Identity, S.Maybe);
+        var C = Compose(Identity)(S.Maybe);
         var lhs = u.map(C).sequence(C.of);
         var rhs = C(u.sequence(Identity.of).map(function(x) {
           return x.sequence(S.Maybe.of);

--- a/test/internal/Compose.js
+++ b/test/internal/Compose.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var FL = require('fantasy-land');
+var R = require('ramda');
+
+
+//  Compose :: (Apply f, Apply g) => { of :: b -> f b } -> { of :: c -> g c } -> f (g a) -> Compose f g a
+module.exports = function Compose(F) {
+  return function ComposeF(G) {
+    function ComposeFG(value) {
+      if (!(this instanceof ComposeFG)) return new ComposeFG(value);
+      this.value = value;
+    }
+
+    ComposeFG.of = function(x) {
+      return ComposeFG(F.of(G.of(x)));
+    };
+
+    ComposeFG.prototype['@@type'] = 'sanctuary/Compose';
+
+    ComposeFG.prototype[FL.equals] = function(other) {
+      return R.equals(this.value, other.value);
+    };
+
+    ComposeFG.prototype[FL.map] = function(f) {
+      return ComposeFG(R.map(R.map(f), this.value));
+    };
+
+    ComposeFG.prototype[FL.ap] = function(other) {
+      return ComposeFG(R.ap(R.map(R.ap, this.value), other.value));
+    };
+
+    //  name :: TypeRep a -> String
+    function name(typeRep) {
+      return typeRep.prototype != null &&
+             typeof typeRep.prototype['@@type'] === 'string' ?
+               typeRep.prototype['@@type'].replace(/^[^/]*[/]/, '') :
+               typeRep.name;
+    }
+
+    ComposeFG.prototype.inspect =
+    ComposeFG.prototype.toString = function() {
+      return 'Compose(' + name(F) + ')' +
+                    '(' + name(G) + ')' +
+                    '(' + R.toString(this.value) + ')';
+    };
+
+    return ComposeFG;
+  };
+};

--- a/test/internal/EitherArb.js
+++ b/test/internal/EitherArb.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var jsc = require('jsverify');
+var R = require('ramda');
+
+var S = require('../..');
+
+
+//  EitherArb :: Arbitrary a -> Arbitrary b -> Arbitrary (Either a b)
+module.exports = function EitherArb(lArb, rArb) {
+  return jsc.oneof(lArb.smap(S.Left, S.prop('value'), R.toString),
+                   rArb.smap(S.Right, S.prop('value'), R.toString));
+};

--- a/test/internal/Identity.js
+++ b/test/internal/Identity.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var FL = require('fantasy-land');
+
+var R = require('ramda');
+
+
+//  Identity :: a -> Identity a
+function Identity(value) {
+  if (!(this instanceof Identity)) return new Identity(value);
+  this.value = value;
+}
+
+Identity[FL.of] = Identity;
+
+Identity.prototype['@@type'] = 'sanctuary/Identity';
+
+Identity.prototype[FL.equals] = function(other) {
+  return R.equals(this.value, other.value);
+};
+
+Identity.prototype[FL.concat] = function(other) {
+  return Identity(R.concat(this.value, other.value));
+};
+
+Identity.prototype[FL.map] = function(f) {
+  return Identity(f(this.value));
+};
+
+Identity.prototype[FL.ap] = function(other) {
+  return R.map(other.value, this);
+};
+
+Identity.prototype[FL.chain] = function(f) {
+  return f(this.value);
+};
+
+Identity.prototype[FL.reduce] = function(f, x) {
+  return f(x, this.value);
+};
+
+Identity.prototype[FL.traverse] = function(f, of) {
+  return R.map(Identity, f(this.value));
+};
+
+Identity.prototype[FL.extend] = function(f) {
+  return Identity(f(this));
+};
+
+Identity.prototype[FL.extract] = function() {
+  return this.value;
+};
+
+Identity.prototype.inspect =
+Identity.prototype.toString = function() {
+  return 'Identity(' + R.toString(this.value) + ')';
+};
+
+module.exports = Identity;

--- a/test/internal/IdentityArb.js
+++ b/test/internal/IdentityArb.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var R = require('ramda');
+
+var S = require('../..');
+
+var Identity = require('./Identity');
+
+
+//  IdentityArb :: Arbitrary a -> Arbitrary (Identity a)
+module.exports = function IdentityArb(arb) {
+  return arb.smap(Identity, S.prop('value'), R.toString);
+};

--- a/test/internal/MaybeArb.js
+++ b/test/internal/MaybeArb.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var jsc = require('jsverify');
+var R = require('ramda');
+
+var S = require('../..');
+
+
+//  MaybeArb :: Arbitrary a -> Arbitrary (Maybe a)
+module.exports = function MaybeArb(arb) {
+  return jsc.oneof(arb.smap(S.Just, S.prop('value'), R.toString),
+                   jsc.constant(S.Nothing));
+};


### PR DESCRIPTION
I've become aware of something which has been disrupting my flow. When working on a significant change I often find myself restructuring existing code to make it easier to modify or extend, but this has the effect of making my patch bigger (and scarier). My plan is to submit a preliminary pull request for the restructuring in such a case, so that the subsequent pull request for the significant change is easier to review.

This is a preliminary pull request. As it consists entirely of restructuring, it should be relatively easy to review. :)
