### PR TITLE
move @@type properties to type representatives

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,9 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-def": "0.8.0",
-    "sanctuary-type-classes": "1.3.1"
+    "sanctuary-def": "0.9.0",
+    "sanctuary-type-classes": "2.0.1",
+    "sanctuary-type-identifiers": "1.0.0"
   },
   "ignore": [
     "/.git/",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,11 @@ function depMain(name) {
 }
 
 //  dependencies :: Array String
-var dependencies = ['sanctuary-type-classes', 'sanctuary-def'];
+var dependencies = [
+  'sanctuary-type-identifiers',
+  'sanctuary-type-classes',
+  'sanctuary-def'
+];
 
 eq(dependencies.slice().sort(),
    Object.keys(require('./package.json').dependencies).sort());

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test": "make lint test"
   },
   "dependencies": {
-    "sanctuary-def": "0.8.0",
-    "sanctuary-type-classes": "1.3.1"
+    "sanctuary-def": "0.9.0",
+    "sanctuary-type-classes": "2.0.1",
+    "sanctuary-type-identifiers": "1.0.0"
   },
   "devDependencies": {
     "browserify": "13.1.x",

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -13,7 +13,6 @@ suite('Left', function() {
   test('data constructor', function() {
     eq(typeof S.Left, 'function');
     eq(S.Left.length, 1);
-    eq(S.Left(42)['@@type'], 'sanctuary/Either');
     eq(S.Left(42).constructor, S.Either);
     eq(S.Left(42).isLeft, true);
     eq(S.Left(42).isRight, false);

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -13,7 +13,6 @@ suite('Right', function() {
   test('data constructor', function() {
     eq(typeof S.Right, 'function');
     eq(S.Right.length, 1);
-    eq(S.Right(42)['@@type'], 'sanctuary/Either');
     eq(S.Right(42).constructor, S.Either);
     eq(S.Right(42).isLeft, false);
     eq(S.Right(42).isRight, true);

--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -12,10 +12,7 @@ suite('Just', function() {
   test('data constructor', function() {
     eq(typeof S.Just, 'function');
     eq(S.Just.length, 1);
-    eq(S.Just(42)['@@type'], 'sanctuary/Maybe');
-//  Revert when updating to sanctuary-type-classes@2.0.0.
-//  eq(S.Just(42).constructor, S.Maybe);
-    eq(S.Just(42).constructor === S.Maybe, true);
+    eq(S.Just(42).constructor, S.Maybe);
     eq(S.Just(42).isNothing, false);
     eq(S.Just(42).isJust, true);
   });

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -10,10 +10,7 @@ var eq = require('../internal/eq');
 suite('Nothing', function() {
 
   test('member of the "Maybe a" type', function() {
-    eq(S.Nothing['@@type'], 'sanctuary/Maybe');
-//  Revert when updating to sanctuary-type-classes@2.0.0.
-//  eq(S.Nothing.constructor, S.Maybe);
-    eq(S.Nothing.constructor === S.Maybe, true);
+    eq(S.Nothing.constructor, S.Maybe);
     eq(S.Nothing.isNothing, true);
     eq(S.Nothing.isJust, false);
   });

--- a/test/create.js
+++ b/test/create.js
@@ -8,8 +8,11 @@ var eq = require('./internal/eq');
 var throws = require('./internal/throws');
 
 
+//  FooTrue42 :: Type
+var FooTrue42 = $.EnumType('my-package/FooTrue42', '', ['foo', true, 42]);
+
 //  customEnv :: Array Type
-var customEnv = S.env.concat([$.EnumType(['foo', true, 42])]);
+var customEnv = S.env.concat([FooTrue42]);
 
 var checkedDefaultEnv   = S.create({checkTypes: true, env: S.env});
 var checkedCustomEnv    = S.create({checkTypes: true, env: customEnv});

--- a/test/internal/Compose.js
+++ b/test/internal/Compose.js
@@ -12,11 +12,11 @@ module.exports = function Compose(F) {
       this.value = value;
     }
 
+    ComposeFG['@@type'] = 'sanctuary/Compose';
+
     ComposeFG[FL.of] = function(x) {
       return ComposeFG(Z.of(F, Z.of(G, x)));
     };
-
-    ComposeFG.prototype['@@type'] = 'sanctuary/Compose';
 
     ComposeFG.prototype[FL.equals] = function(other) {
       return Z.equals(this.value, other.value);
@@ -32,9 +32,8 @@ module.exports = function Compose(F) {
 
     //  name :: TypeRep a -> String
     function name(typeRep) {
-      return typeRep.prototype != null &&
-             typeof typeRep.prototype['@@type'] === 'string' ?
-               typeRep.prototype['@@type'].replace(/^[^/]*[/]/, '') :
+      return typeof typeRep['@@type'] === 'string' ?
+               typeRep['@@type'].replace(/^[^/]*[/]/, '') :
                typeRep.name;
     }
 

--- a/test/internal/Identity.js
+++ b/test/internal/Identity.js
@@ -11,9 +11,9 @@ function Identity(value) {
   this.value = value;
 }
 
-Identity[FL.of] = Identity;
+Identity['@@type'] = 'sanctuary/Identity';
 
-Identity.prototype['@@type'] = 'sanctuary/Identity';
+Identity[FL.of] = Identity;
 
 Identity.prototype[FL.equals] = function(other) {
   return Z.equals(this.value, other.value);

--- a/test/is.js
+++ b/test/is.js
@@ -39,7 +39,7 @@ test('is', function() {
   eq(S.is(S.Either, S.Right(9)),          true);
 
   function FooBar() {}
-  FooBar.prototype['@@type'] = 'foobar/FooBar';
+  FooBar['@@type'] = 'foobar/FooBar';
   function Foo() {}
   Foo.prototype = new FooBar();
   function Bar() {}

--- a/test/regex.js
+++ b/test/regex.js
@@ -9,7 +9,7 @@ test('regex', function() {
 
   eq(typeof S.regex, 'function');
   eq(S.regex.length, 2);
-  eq(S.regex.toString(), 'regex :: ("" | "g" | "i" | "m" | "gi" | "gm" | "im" | "gim") -> String -> RegExp');
+  eq(S.regex.toString(), 'regex :: RegexFlags -> String -> RegExp');
 
   eq(S.regex('', '\\d'), /\d/);
   eq(S.regex('g', '\\d'), /\d/g);

--- a/test/type.js
+++ b/test/type.js
@@ -35,10 +35,11 @@ test('type', function() {
   eq(S.type(S.Just(42)),  'sanctuary/Maybe');
 
   function Gizmo() {}
-  Gizmo.prototype['@@type'] = 'gadgets/Gizmo';
+  Gizmo['@@type'] = 'gadgets/Gizmo';
 
   eq(S.type(new Gizmo()), 'gadgets/Gizmo');
-  eq(S.type({'@@type': 'foobar/FooBar'}), 'foobar/FooBar');
+  eq(S.type(Gizmo), 'Function');
+  eq(S.type(Gizmo.prototype), 'Object');
 
   eq(S.type(vm.runInNewContext('[1, 2, 3]')), 'Array');
 


### PR DESCRIPTION
This pull request depends on sanctuary-js/sanctuary-type-identifiers#1. Furthermore, this pull request must not be merged until sanctuary-js/sanctuary-def#112 has been merged, `sanctuary-def@0.9.0` has been published, and Sanctuary has been updated to use that version. Here's the current problem:

```javascript
var $ = require('sanctuary-def');

function Identity(x) {
  if (!(this instanceof Identity)) return new Identity(x);
  this.value = x;
}

Identity['@@type'] = 'my-package/Identity';

$.Function._test(Math.abs);  // => true
$.Function._test(Identity);  // => false
```
