### PR TITLE
documentation: use version-specific function URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ LICENSE:
 	sed 's/Copyright (c) .* Sanctuary/Copyright (c) $(shell git log --date=format:%Y --pretty=format:%ad | sort -r | head -n 1) Sanctuary/' '$@.orig' >'$@'
 	rm -- '$@.orig'
 
-README.md: index.js
+README.md: README.md.tmp package.json scripts/version-urls
+	scripts/version-urls '$<' >'$@'
+
+.INTERMEDIATE: README.md.tmp
+README.md.tmp: index.js
 	$(TRANSCRIBE) \
 	  --heading-level 4 \
 	  --url 'https://github.com/sanctuary-js/sanctuary/blob/v$(VERSION)/{filename}#L{line}' \
@@ -34,7 +38,7 @@ lint:
 	  -- index.js
 	$(ESLINT) \
 	  --env node \
-	  -- karma.conf.js
+	  -- karma.conf.js scripts/version-urls
 	$(ESLINT) \
 	  --env node \
 	  --global suite \

--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ See also [`maybeToNullable`](#maybeToNullable).
 <h4 name="maybeToNullable"><code><a href="https://github.com/sanctuary-js/sanctuary/blob/v0.11.1/index.js#L1257">maybeToNullable :: Maybe a -> Nullable a</a></code></h4>
 
 Returns the given Maybe's value if the Maybe is a Just; `null` otherwise.
-[Nullable][] is defined in sanctuary-def.
+[Nullable][] is defined in [sanctuary-def][].
 
 See also [`fromMaybe`](#fromMaybe).
 
@@ -2248,23 +2248,23 @@ See also [`lines`](#lines).
 'foo\nbar\nbaz\n'
 ```
 
-[Apply]:          https://github.com/fantasyland/fantasy-land#apply
-[BinaryType]:     https://github.com/sanctuary-js/sanctuary-def#binarytype
-[Extend]:         https://github.com/fantasyland/fantasy-land#extend
-[Foldable]:       https://github.com/fantasyland/fantasy-land#foldable
-[Functor]:        https://github.com/fantasyland/fantasy-land#functor
-[Monad]:          https://github.com/fantasyland/fantasy-land#monad
-[Monoid]:         https://github.com/fantasyland/fantasy-land#monoid
-[Nullable]:       https://github.com/sanctuary-js/sanctuary-def#nullable
-[R.equals]:       http://ramdajs.com/docs/#equals
-[R.map]:          http://ramdajs.com/docs/#map
-[R.type]:         http://ramdajs.com/docs/#type
+[Apply]:          https://github.com/fantasyland/fantasy-land/tree/v0.2.1#apply
+[BinaryType]:     https://github.com/sanctuary-js/sanctuary-def/tree/v0.6.0#binarytype
+[Extend]:         https://github.com/fantasyland/fantasy-land/tree/v0.2.1#extend
+[Foldable]:       https://github.com/fantasyland/fantasy-land/tree/v0.2.1#foldable
+[Functor]:        https://github.com/fantasyland/fantasy-land/tree/v0.2.1#functor
+[Monad]:          https://github.com/fantasyland/fantasy-land/tree/v0.2.1#monad
+[Monoid]:         https://github.com/fantasyland/fantasy-land/tree/v0.2.1#monoid
+[Nullable]:       https://github.com/sanctuary-js/sanctuary-def/tree/v0.6.0#nullable
+[R.equals]:       http://ramdajs.com/0.21.0/docs/#equals
+[R.map]:          http://ramdajs.com/0.21.0/docs/#map
+[R.type]:         http://ramdajs.com/0.21.0/docs/#type
 [Ramda]:          http://ramdajs.com/
 [RegExp]:         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
-[RegexFlags]:     https://github.com/sanctuary-js/sanctuary-def#regexflags
-[Semigroup]:      https://github.com/fantasyland/fantasy-land#semigroup
-[Traversable]:    https://github.com/fantasyland/fantasy-land#traversable
-[UnaryType]:      https://github.com/sanctuary-js/sanctuary-def#unarytype
+[RegexFlags]:     https://github.com/sanctuary-js/sanctuary-def/tree/v0.6.0#regexflags
+[Semigroup]:      https://github.com/fantasyland/fantasy-land/tree/v0.2.1#semigroup
+[Traversable]:    https://github.com/fantasyland/fantasy-land/tree/v0.2.1#traversable
+[UnaryType]:      https://github.com/sanctuary-js/sanctuary-def/tree/v0.6.0#unarytype
 [parseInt]:       https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
 [sanctuary-def]:  https://github.com/sanctuary-js/sanctuary-def
 [thrush]:         https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown

--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,8 @@
     "types"
   ],
   "dependencies": {
-    "ramda": "0.22.x",
-    "sanctuary-def": "0.6.x"
+    "ramda": "0.22.1",
+    "sanctuary-def": "0.6.0"
   },
   "ignore": [
     "/.git/",

--- a/index.js
+++ b/index.js
@@ -1313,7 +1313,7 @@
   //# maybeToNullable :: Maybe a -> Nullable a
   //.
   //. Returns the given Maybe's value if the Maybe is a Just; `null` otherwise.
-  //. [Nullable][] is defined in sanctuary-def.
+  //. [Nullable][] is defined in [sanctuary-def][].
   //.
   //. See also [`fromMaybe`](#fromMaybe).
   //.
@@ -3496,24 +3496,24 @@
 
 }));
 
-//. [$.Array]:          https://github.com/sanctuary-js/sanctuary-def/#array
-//. [$.String]:         https://github.com/sanctuary-js/sanctuary-def/#string
-//. [Apply]:            https://github.com/fantasyland/fantasy-land#apply
-//. [BinaryType]:       https://github.com/sanctuary-js/sanctuary-def#binarytype
-//. [Extend]:           https://github.com/fantasyland/fantasy-land#extend
-//. [Foldable]:         https://github.com/fantasyland/fantasy-land#foldable
-//. [Functor]:          https://github.com/fantasyland/fantasy-land#functor
-//. [Monad]:            https://github.com/fantasyland/fantasy-land#monad
-//. [Monoid]:           https://github.com/fantasyland/fantasy-land#monoid
-//. [Nullable]:         https://github.com/sanctuary-js/sanctuary-def#nullable
+//. [$.Array]:          v:sanctuary-js/sanctuary-def#array
+//. [$.String]:         v:sanctuary-js/sanctuary-def#string
+//. [Apply]:            v:fantasyland/fantasy-land#apply
+//. [BinaryType]:       v:sanctuary-js/sanctuary-def#binarytype
+//. [Extend]:           v:fantasyland/fantasy-land#extend
+//. [Foldable]:         v:fantasyland/fantasy-land#foldable
+//. [Functor]:          v:fantasyland/fantasy-land#functor
+//. [Monad]:            v:fantasyland/fantasy-land#monad
+//. [Monoid]:           v:fantasyland/fantasy-land#monoid
+//. [Nullable]:         v:sanctuary-js/sanctuary-def#nullable
 //. [Object#toString]:  https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
-//. [R.equals]:         http://ramdajs.com/docs/#equals
-//. [R.map]:            http://ramdajs.com/docs/#map
+//. [R.equals]:         v:ramda/ramda#equals
+//. [R.map]:            v:ramda/ramda#map
 //. [Ramda]:            http://ramdajs.com/
-//. [RegexFlags]:       https://github.com/sanctuary-js/sanctuary-def#regexflags
-//. [Semigroup]:        https://github.com/fantasyland/fantasy-land#semigroup
-//. [Traversable]:      https://github.com/fantasyland/fantasy-land#traversable
-//. [UnaryType]:        https://github.com/sanctuary-js/sanctuary-def#unarytype
+//. [RegexFlags]:       v:sanctuary-js/sanctuary-def#regexflags
+//. [Semigroup]:        v:fantasyland/fantasy-land#semigroup
+//. [Traversable]:      v:fantasyland/fantasy-land#traversable
+//. [UnaryType]:        v:sanctuary-js/sanctuary-def#unarytype
 //. [parseInt]:         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
 //. [sanctuary-def]:    https://github.com/sanctuary-js/sanctuary-def
 //. [thrush]:           https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "test": "make lint test"
   },
   "dependencies": {
-    "ramda": "0.22.x",
-    "sanctuary-def": "0.6.x"
+    "ramda": "0.22.1",
+    "sanctuary-def": "0.6.0"
   },
   "devDependencies": {
     "browserify": "13.1.x",
     "doctest": "0.10.x",
     "eslint": "2.9.x",
-    "fantasy-land": "0.3.x",
+    "fantasy-land": "0.3.0",
     "istanbul": "0.4.x",
     "jsverify": "0.7.x",
     "karma": "1.3.x",

--- a/scripts/version-urls
+++ b/scripts/version-urls
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var fs = require('fs');
+
+var pkg = require('../package.json');
+
+//  deps :: StrMap String
+var deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+
+process.stdout.write(fs.readFileSync(process.argv[2], 'utf8').replace(
+  new RegExp(' v:(.+)/(.+)#(.+)', 'g'),
+  function(_, owner, name, id) {
+    if (name in deps && /^\d+[.]\d+[.]\d+$/.test(deps[name])) {
+      if (owner === 'ramda' && name === 'ramda') {
+        return ' http://ramdajs.com/' + deps[name] + '/docs/#' + id;
+      } else {
+        return ' https://github.com/' + owner + '/' + name +
+               '/tree/v' + deps[name] + '#' + id;
+      }
+    }
+    process.stderr.write('Exact version not specified for ' + name + '\n');
+    process.exit(1);
+  }
+));


### PR DESCRIPTION
Linking to things which can change is not a good idea. As a case in point, we currently have broken links as a result of sanctuary-js/sanctuary-def#97 (we link to `#nullable` rather than `#Nullable`, for example).

This pull request:

  - introduces `version-urls`, a script which replaces specially formatted placeholders with version-specific function URLs; and
  - updates __README.md__ to fix the broken links immediately (and remove the possibility of further breakages).

The second of these changes is a bit confusing, since it relates to `v0.11.1` (the most recent release) rather than to `master`. Some detective work is required to determine the appropriate dependency versions. :mag:

```console
$ npm view sanctuary@0.11.1 dependencies.ramda
0.21.x

$ node --print "$(npm view ramda versions).filter(v => /^0[.]21[.]/.test(v))"
[ '0.21.0' ]
```

```console
$ npm view sanctuary@0.11.1 dependencies.sanctuary-def
0.6.x

$ node --print "$(npm view sanctuary-def versions).filter(v => /^0[.]6[.]/.test(v))"
[ '0.6.0' ]
```

The Fantasy Land dependency was not made explicit in __package.json__ at the time Sanctuary v0.11.1 was released, so we must assume the most recent Fantasy Land version available at that time.

```console
$ cd ~/github.com/fantasyland/fantasy-land

$ git log --tags --simplify-by-decoration --pretty='format:%ci %d' | grep 'tag: v[0-9]\{1,\}[.][0-9]\{1,\}[.][0-9]\{1,\}'
2016-12-25 11:26:51 +1300  (HEAD -> master, tag: v2.2.0, upstream/master, origin/master, origin/HEAD)
2016-11-05 18:13:32 +0100  (tag: v2.1.0)
2016-10-23 18:10:14 +0200  (tag: v2.0.0)
2016-09-16 16:25:16 +0100  (tag: v1.0.1, tag: 1.0.1)
2016-09-14 09:30:30 +0100  (tag: v1.0.0, tag: 1.0.0)
2016-08-04 18:17:48 +0100  (tag: v0.3.0)
2016-01-31 22:19:11 +0000  (tag: v0.2.1)
2016-01-29 20:54:04 +0000  (tag: v0.2.0)
2014-06-16 16:46:53 -0700  (tag: v0.1.0)

$ cd ~/github.com/sanctuary-js/sanctuary

$ git show --no-patch --format='%ci %d' v0.11.1
tag v0.11.1
Tagger: David Chambers <dc@davidchambers.me>

Version 0.11.1
2016-05-30 23:58:21 -0700  (tag: v0.11.1)
```

Sanctuary v0.11.1 was released on 30 May 2016, at which point v0.2.1 was the most recent Fantasy Land release.
