### PR TITLE
Clarify Ramda <-> Sanctuary relationship

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,18 @@
 //. [![CircleCI](https://img.shields.io/circleci/project/github/sanctuary-js/sanctuary/master.svg)](https://circleci.com/gh/sanctuary-js/sanctuary/tree/master)
 //. [![Gitter](https://img.shields.io/gitter/room/badges/shields.svg)](https://gitter.im/sanctuary-js/sanctuary)
 //.
-//. Sanctuary is a functional programming library inspired by Haskell
-//. and PureScript. It's stricter and more opinionated than [Ramda][],
-//. and provides a similar suite of functions.
+//. Sanctuary is a JavaScript functional programming library inspired by
+//. Haskell and PureScript. It's stricter than [Ramda][], and provides a
+//. similar suite of functions.
+//.
+//. Sanctuary promotes programs composed of simple, pure functions. Such
+//. programs are easier to comprehend, test, and maintain &ndash; they are
+//. also a pleasure to write.
+//.
+//. Sanctuary provides two data types, [Maybe][] and [Either][], both of
+//. which are compatible with [Fantasy Land][]. Thanks to these data types
+//. even Sanctuary functions which may fail, such as [`head`](#head), are
+//. composable.
 //.
 //. Sanctuary makes it possible to write safe code without null checks.
 //. In JavaScript it's trivial to introduce a possible run-time type error:
@@ -3498,9 +3507,12 @@
 //. [Apply]:            v:fantasyland/fantasy-land#apply
 //. [Bifunctor]:        v:fantasyland/fantasy-land#bifunctor
 //. [BinaryType]:       v:sanctuary-js/sanctuary-def#BinaryType
+//. [Either]:           #either-type
 //. [Extend]:           v:fantasyland/fantasy-land#extend
+//. [Fantasy Land]:     v:fantasyland/fantasy-land
 //. [Foldable]:         v:fantasyland/fantasy-land#foldable
 //. [Functor]:          v:fantasyland/fantasy-land#functor
+//. [Maybe]:            #maybe-type
 //. [Monad]:            v:fantasyland/fantasy-land#monad
 //. [Monoid]:           v:fantasyland/fantasy-land#monoid
 //. [Nullable]:         v:sanctuary-js/sanctuary-def#Nullable


### PR DESCRIPTION
The relationship between Sanctuary, Ramda, and even Ramda-fantasy is currently pretty difficult to get a solid grip on for a newcomer like myself. I have found that information is surprisingly difficult to obtain, but in the end I found the relationship clarified very well by @davidchambers in #178. 

Making such a small change to the README would make a huge difference. Maybe a small section along the lines of "Ramda vs. Sancuary" should be added as well, explaining the main differences of using just Ramda, Ramda with monads from Ramda-fantasy, and using Sanctuary. This section could also clarify that one currently has to use Ramda and Sanctuary alongside each other but in the future Sanctuary can be used on its own.

Some examples of the confusion in the community can be seen at [Ramda issue #1610](https://github.com/ramda/ramda/issues/1610), [Ramda issue #1641](https://github.com/ramda/ramda/issues/1641), [Ramda issue #1391](https://github.com/ramda/ramda/pull/1391).

Ramda will try to clarify the relationship from their side in the upcoming [Ramda manual](https://github.com/ramda/ramda/issues/1282).