### PR TITLE
remove support for node 0.12

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,16 +2,16 @@ dependencies:
   override:
     - printf '%s\n' color=false progress=false >.npmrc
     - rm -rf node_modules
-    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 4 make setup ;; 2) nvm install 6 && nvm exec 6 make setup ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm install 6 && nvm exec 6 make setup ;; 2) nvm install 7 && nvm exec 7 make setup ;; esac:
         parallel: true
 
 machine:
   node:
-    version: 0.12.7
+    version: 4
 
 test:
   override:
     - make lint
-    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 4 make test ;; 2) nvm exec 6 make test ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 6 make test ;; 2) nvm exec 7 make test ;; esac:
         parallel: true
     - node_modules/.bin/karma start


### PR DESCRIPTION
Now that Node 0.12 is officially end of life we should remove it from our test matrix. I have replaced it with Node 7 but can remove it if we want to speed up build times.