### PR TITLE
list: remove unnecessary use of Array#slice

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,7 @@
       return R.contains(R.type(x), ['Array', 'String']);
     },
     function(list) {
-      return R.type(list) === 'String' ? [] : _slice.call(list);
+      return R.type(list) === 'String' ? [] : list;
     }
   );
 


### PR DESCRIPTION
As a result of #264 the value of `list` in the else branch is guaranteed to be a member of `Array Any` (whereas previously it could have been an `arguments` object or some other array-like object).
