### PR TITLE
documentation: use version-specific project URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3532,9 +3532,9 @@
 //. [Z.map]:            v:sanctuary-js/sanctuary-type-classes#map
 //. [`of`]:             v:fantasyland/fantasy-land#of-method
 //. [parseInt]:         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
-//. [sanctuary-def]:    https://github.com/sanctuary-js/sanctuary-def
+//. [sanctuary-def]:    v:sanctuary-js/sanctuary-def
 //. [thrush]:           https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown
-//. [type identifier]:  https://github.com/sanctuary-js/sanctuary-type-identifiers
+//. [type identifier]:  v:sanctuary-js/sanctuary-type-identifiers
 //.
 //. [`Either#fantasy-land/bimap`]:      #Either.prototype.fantasy-land/bimap
 //. [`Either#fantasy-land/map`]:        #Either.prototype.fantasy-land/map

--- a/scripts/version-urls
+++ b/scripts/version-urls
@@ -10,11 +10,13 @@ var pkg = require('../package.json');
 var deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
 
 process.stdout.write(fs.readFileSync(process.argv[2], 'utf8').replace(
-  new RegExp(' v:(.+)/(.+)#(.+)', 'g'),
-  function(_, owner, name, id) {
+  new RegExp(' v:(.+)/(.+)', 'g'),
+  function(_, owner, rest) {
+    var parts = rest.split(/(?=#)/);
+    var name = parts[0];
     if (name in deps && /^\d+[.]\d+[.]\d+$/.test(deps[name])) {
       return ' https://github.com/' + owner + '/' + name +
-             '/tree/v' + deps[name] + '#' + id;
+             '/tree/v' + deps[name] + parts.slice(1).join('');
     }
     process.stderr.write('Exact version not specified for ' + name + '\n');
     process.exit(1);


### PR DESCRIPTION
This will be particularly useful when we address #252 as we'll be able to link to the precise version of the Fantasy Land specification we target.
