### PR TITLE
Static imports to aid bundle traversing tools

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,18 +207,16 @@
 
   'use strict';
 
-  //  deps :: Array String
-  var deps = [
-    'sanctuary-def',
-    'sanctuary-type-classes',
-    'sanctuary-type-identifiers'
-  ];
-
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f(require(deps[0]), require(deps[1]), require(deps[2]));
+    module.exports = f(require('sanctuary-def'),
+                       require('sanctuary-type-classes'),
+                       require('sanctuary-type-identifiers'));
   } else if (typeof define === 'function' && define.amd != null) {
-    define(deps, f);
+    define(['sanctuary-def',
+            'sanctuary-type-classes',
+            'sanctuary-type-identifiers'],
+           f);
   } else {
     self.sanctuary = f(self.sanctuaryDef,
                        self.sanctuaryTypeClasses,


### PR DESCRIPTION
Browserify require static import's in order to establish a dependency tree.

This PR addresses this issue by replacing e.g. `require(deps[0])` with `require('sanctuary-def')`