### PR TITLE
makefile: support Git versions which do not accept --date=format:...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: LICENSE README.md
 .PHONY: LICENSE
 LICENSE:
 	cp -- '$@' '$@.orig'
-	sed 's/Copyright (c) .* Sanctuary/Copyright (c) $(shell git log --date=format:%Y --pretty=format:%ad | sort -r | head -n 1) Sanctuary/' '$@.orig' >'$@'
+	sed 's/Copyright (c) .* Sanctuary/Copyright (c) $(shell git log --date=short --pretty=format:%ad | sort -r | head -n 1 | cut -d - -f 1) Sanctuary/' '$@.orig' >'$@'
 	rm -- '$@.orig'
 
 README.md: README.md.tmp package.json scripts/version-urls


### PR DESCRIPTION
As @vendethiel discovered, the version of Git provided by OS X Yosemite (`git version 2.5.4 (Apple Git-61)`) does not support `--date:format:...`. Instead, we can use `--date=short` which specifies YYYY-MM-DD format, then use `cut -d - -f 1` to extract the year.

@vendethiel, please confirm that this change addresses your problem. :)
