### PR TITLE
Generalize append  and prepend

### DIFF
--- a/index.js
+++ b/index.js
@@ -2984,21 +2984,30 @@
 
   //. ### Array
 
-  //# append :: a -> Array a -> Array a
+  //# append :: (Applicative f, Semigroup (f a)) => a -> f a -> f a
   //.
-  //. Takes a value of any type and an array of values of that type, and
-  //. returns the result of appending the value to the array.
+  //. Returns the result of appending the first argument to the second.
   //.
   //. See also [`prepend`](#prepend).
   //.
   //. ```javascript
   //. > S.append(3, [1, 2])
   //. [1, 2, 3]
+  //.
+  //. > S.append([1], S.Nothing)
+  //. Just([1])
+  //.
+  //. > S.append([3], S.Just([1, 2]))
+  //. Just([1, 2, 3])
   //. ```
   function append(x, xs) {
-    return Z.concat(xs, [x]);
+    return Z.concat(xs, Z.of(xs.constructor, x));
   }
-  S.append = def('append', {}, [a, $.Array(a), $.Array(a)], append);
+  S.append =
+    def('append',
+        {f: [Z.Applicative, Z.Semigroup]},
+        [a, f(a), f(a)],
+        append);
 
   //# prepend :: a -> Array a -> Array a
   //.

--- a/index.js
+++ b/index.js
@@ -3009,21 +3009,30 @@
         [a, f(a), f(a)],
         append);
 
-  //# prepend :: a -> Array a -> Array a
+  //# prepend :: (Applicative f, Semigroup (f a)) => a -> f a -> f a
   //.
-  //. Takes a value of any type and an array of values of that type, and
-  //. returns the result of prepending the value to the array.
+  //. Returns the result of prepending the first argument to the second.
   //.
   //. See also [`append`](#append).
   //.
   //. ```javascript
   //. > S.prepend(1, [2, 3])
   //. [1, 2, 3]
+  //.
+  //. > S.prepend([1], S.Nothing)
+  //. Just([1])
+  //.
+  //. > S.prepend([1], S.Just([2, 3]))
+  //. Just([1, 2, 3])
   //. ```
   function prepend(x, xs) {
-    return Z.concat([x], xs);
+    return Z.concat(Z.of(xs.constructor, x), xs);
   }
-  S.prepend = def('prepend', {}, [a, $.Array(a), $.Array(a)], prepend);
+  S.prepend =
+  def('prepend',
+      {f: [Z.Applicative, Z.Semigroup]},
+      [a, f(a), f(a)],
+      prepend);
 
   //# joinWith :: String -> Array String -> String
   //.

--- a/test/append.js
+++ b/test/append.js
@@ -9,10 +9,16 @@ test('append', function() {
 
   eq(typeof S.append, 'function');
   eq(S.append.length, 2);
-  eq(S.append.toString(), 'append :: a -> Array a -> Array a');
+  eq(S.append.toString(), 'append :: (Applicative f, Semigroup f) => a -> f a -> f a');
 
   eq(S.append(3, []), [3]);
   eq(S.append(3, [1, 2]), [1, 2, 3]);
   eq(S.append([5, 6], [[1, 2], [3, 4]]), [[1, 2], [3, 4], [5, 6]]);
+
+  eq(S.append([2], S.Nothing), S.Just([2]));
+  eq(S.append([2], S.Just([1])), S.Just([1, 2]));
+
+  eq(S.append([2], S.Left('error')), S.Right([2]));
+  eq(S.append([2], S.Right([1])), S.Right([1, 2]));
 
 });

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -9,10 +9,16 @@ test('prepend', function() {
 
   eq(typeof S.prepend, 'function');
   eq(S.prepend.length, 2);
-  eq(S.prepend.toString(), 'prepend :: a -> Array a -> Array a');
+  eq(S.prepend.toString(), 'prepend :: (Applicative f, Semigroup f) => a -> f a -> f a');
 
   eq(S.prepend(1, []), [1]);
   eq(S.prepend(1, [2, 3]), [1, 2, 3]);
   eq(S.prepend([1, 2], [[3, 4], [5, 6]]), [[1, 2], [3, 4], [5, 6]]);
+
+  eq(S.prepend([1], S.Nothing), S.Just([1]));
+  eq(S.prepend([1], S.Just([2])), S.Just([1, 2]));
+
+  eq(S.prepend([1], S.Left('error')), S.Right([1]));
+  eq(S.prepend([1], S.Right([2])), S.Right([1, 2]));
 
 });


### PR DESCRIPTION
See #343.

While implementing I assumed `Nothing` and `Left` would annihilate:

```js
S.append(1, S.Nothing) // Nothing
```

The only other thing I could think to do would be to wrap the value in `Just` or `Right`. But that would break the short-circuiting behavior.