### PR TITLE
Replace Type constructors in env with actual Types

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,13 +349,13 @@
   var defaultEnv = Z.concat($.env, [
     $.FiniteNumber,
     $.NonZeroFiniteNumber,
-    $Either,
+    $Either($.Unknown, $.Unknown),
     Fn($.Unknown, $.Unknown),
     $.GlobalRegExp,
     $.NonGlobalRegExp,
     $.Integer,
-    $Maybe,
-    $.Pair,
+    $Maybe($.Unknown),
+    $.Pair($.Unknown, $.Unknown),
     $.RegexFlags,
     $.ValidDate,
     $.ValidNumber

--- a/test/env.js
+++ b/test/env.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var $ = require('sanctuary-def');
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+//  Type :: Type
+var Type = $.NullaryType(
+  'sanctuary/Type',
+  '',
+  function(x) { return S.type(x) === 'sanctuary-def/Type'; }
+);
+
+test('env', function() {
+
+  eq(typeof S.env, 'object');
+  eq($.test([], $.Array(Type), S.env), true);
+
+});


### PR DESCRIPTION
Based on sanctuary-js/sanctuary-def#123

This fixes the inconsistent type of `env`, allowing it to be passed into `$.test`. We should release this as a patch.