### PR TITLE
maybe, either: define "fantasy-land/concat" conditionally

### DIFF
--- a/index.js
+++ b/index.js
@@ -1021,12 +1021,6 @@
   //. ```javascript
   //. > S.filter(S.odd, [1, 2, 3, 4, 5])
   //. [1, 3, 5]
-  //.
-  //. > S.filter(S.odd, S.Just(9))
-  //. Just(9)
-  //.
-  //. > S.filter(S.odd, S.Just(4))
-  //. Nothing
   //. ```
   S.filter =
   def('filter',
@@ -1400,6 +1394,12 @@
     this.isNothing = tag === 'Nothing';
     this.isJust = tag === 'Just';
     if (this.isJust) this.value = value;
+
+    //  Add "fantasy-land/concat" method conditionally so that Just('abc')
+    //  satisfies the requirements of Semigroup but Just(123) does not.
+    if (this.isNothing || Z.Semigroup.test(this.value)) {
+      this['fantasy-land/concat'] = Maybe$prototype$concat;
+    }
   }
 
   //# Nothing :: Maybe a
@@ -1569,11 +1569,11 @@
   //. > S.concat(S.Just([1, 2, 3]), S.Nothing)
   //. Just([1, 2, 3])
   //. ```
-  Maybe.prototype['fantasy-land/concat'] = function(other) {
+  function Maybe$prototype$concat(other) {
     return this.isNothing ?
       other :
       other.isNothing ? this : Just(Z.concat(this.value, other.value));
-  };
+  }
 
   //# Maybe#fantasy-land/map :: Maybe a ~> (a -> b) -> Maybe b
   //.
@@ -2023,6 +2023,13 @@
     this.isLeft = tag === 'Left';
     this.isRight = tag === 'Right';
     this.value = value;
+
+    //  Add "fantasy-land/concat" method conditionally so that Left('abc')
+    //  and Right('abc') satisfy the requirements of Semigroup but Left(123)
+    //  and Right(123) do not.
+    if (Z.Semigroup.test(this.value)) {
+      this['fantasy-land/concat'] = Either$prototype$concat;
+    }
   }
 
   //# Left :: a -> Either a b
@@ -2171,11 +2178,11 @@
   //. > S.concat(S.Right([1, 2, 3]), S.Left('abc'))
   //. Right([1, 2, 3])
   //. ```
-  Either.prototype['fantasy-land/concat'] = function(other) {
+  function Either$prototype$concat(other) {
     return this.isLeft ?
       other.isLeft ? Left(Z.concat(this.value, other.value)) : other :
       other.isLeft ? this : Right(Z.concat(this.value, other.value));
-  };
+  }
 
   //# Either#fantasy-land/map :: Either a b ~> (b -> c) -> Either a c
   //.

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var FL = require('fantasy-land');
+var Z = require('sanctuary-type-classes');
 
 var S = require('../..');
 
@@ -44,6 +45,9 @@ suite('Left', function() {
     eq(S.Left('abc')[FL.concat].length, 1);
     eq(S.Left('abc')[FL.concat](S.Left('def')), S.Left('abcdef'));
     eq(S.Left('abc')[FL.concat](S.Right('xyz')), S.Right('xyz'));
+
+    eq(Z.Semigroup.test(S.Left('abc')), true);
+    eq(Z.Semigroup.test(S.Left(123)), false);
   });
 
   test('"fantasy-land/equals" method', function() {

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var FL = require('fantasy-land');
+var Z = require('sanctuary-type-classes');
 
 var S = require('../..');
 
@@ -44,6 +45,9 @@ suite('Right', function() {
     eq(S.Right('abc')[FL.concat].length, 1);
     eq(S.Right('abc')[FL.concat](S.Left('xyz')), S.Right('abc'));
     eq(S.Right('abc')[FL.concat](S.Right('def')), S.Right('abcdef'));
+
+    eq(Z.Semigroup.test(S.Right('abc')), true);
+    eq(Z.Semigroup.test(S.Right(123)), false);
   });
 
   test('"fantasy-land/equals" method', function() {

--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var FL = require('fantasy-land');
+var Z = require('sanctuary-type-classes');
 
 var S = require('../..');
 
@@ -38,6 +39,9 @@ suite('Just', function() {
     eq(S.Just('foo')[FL.concat].length, 1);
     eq(S.Just('foo')[FL.concat](S.Nothing), S.Just('foo'));
     eq(S.Just('foo')[FL.concat](S.Just('bar')), S.Just('foobar'));
+
+    eq(Z.Semigroup.test(S.Just('abc')), true);
+    eq(Z.Semigroup.test(S.Just(123)), false);
   });
 
   test('"fantasy-land/equals" method', function() {

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var FL = require('fantasy-land');
+var Z = require('sanctuary-type-classes');
 
 var S = require('../..');
 
@@ -36,6 +37,8 @@ suite('Nothing', function() {
     eq(S.Nothing[FL.concat].length, 1);
     eq(S.Nothing[FL.concat](S.Nothing), S.Nothing);
     eq(S.Nothing[FL.concat](S.Just('foo')), S.Just('foo'));
+
+    eq(Z.Semigroup.test(S.Nothing), true);
   });
 
   test('"fantasy-land/equals" method', function() {

--- a/test/filter.js
+++ b/test/filter.js
@@ -15,8 +15,5 @@ test('filter', function() {
   eq(S.filter(S.odd, [0, 2, 4, 6, 8]), []);
   eq(S.filter(S.odd, [1, 3, 5, 7, 9]), [1, 3, 5, 7, 9]);
   eq(S.filter(S.odd, [1, 2, 3, 4, 5]), [1, 3, 5]);
-  eq(S.filter(S.odd, S.Nothing), S.Nothing);
-  eq(S.filter(S.odd, S.Just(4)), S.Nothing);
-  eq(S.filter(S.odd, S.Just(9)), S.Just(9));
 
 });


### PR DESCRIPTION
Closes #346

Before:

```javascript
S.concat(S.Just(1), S.Just(1));
// ! TypeError: Semigroup.methods.concat(...) is not a function
```

After:

```javascript
S.concat(S.Just(1), S.Just(1));
// ! TypeError: Type-class constraint violation
//
//   concat :: Semigroup a => a -> a -> a
//             ^^^^^^^^^^^    ^
//                            1
//
//   1)  Just(1) :: Maybe Number, Maybe FiniteNumber, Maybe NonZeroFiniteNumber, Maybe Integer, Maybe ValidNumber
//
//   ‘concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.
```

Losing the ability to `filter(odd, Just(4))` is a real shame. This happens because `Just(4)` does not satisfy the requirements of Monoid as it does not satisfy the requirements of Semigroup.

It seems we need [`mfilter`][1]. Fantasy Land does not yet specify MonadPlus. We could define `mfilter` and hard-code support for the Maybe type, while also pushing to have MonadPlus added to Fantasy Land. With luck we would later be able to move the implementation from `mfilter` to `Maybe#fantasy-land/mplus`. Is this reasonable?


[1]: http://hackage.haskell.org/package/base-4.9.1.0/docs/Control-Monad.html#v:mfilter
