### PR TITLE
string: add S.stripPrefix and S.stripSuffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -3995,6 +3995,50 @@
   }
   S.trim = def('trim', {}, [$.String, $.String], trim);
 
+  //# stripPrefix :: String -> String -> Maybe String
+  //.
+  //. Returns Just the portion of the given string (the second argument) left
+  //. after removing the given prefix (the first argument) if the string starts
+  //. with the prefix; Nothing otherwise.
+  //.
+  //. See also [`stripSuffix`](#stripSuffix).
+  //.
+  //. ```javascript
+  //. > S.stripPrefix('https://', 'https://sanctuary.js.org')
+  //. Just('sanctuary.js.org')
+  //.
+  //. > S.stripPrefix('https://', 'http://sanctuary.js.org')
+  //. Nothing
+  //. ```
+  function stripPrefix(prefix, s) {
+    var idx = prefix.length;
+    return s.slice(0, idx) === prefix ? Just(s.slice(idx)) : Nothing;
+  }
+  S.stripPrefix =
+  def('stripPrefix', {}, [$.String, $.String, $Maybe($.String)], stripPrefix);
+
+  //# stripSuffix :: String -> String -> Maybe String
+  //.
+  //. Returns Just the portion of the given string (the second argument) left
+  //. after removing the given suffix (the first argument) if the string ends
+  //. with the suffix; Nothing otherwise.
+  //.
+  //. See also [`stripPrefix`](#stripPrefix).
+  //.
+  //. ```javascript
+  //. > S.stripSuffix('.md', 'README.md')
+  //. Just('README')
+  //.
+  //. > S.stripSuffix('.md', 'README')
+  //. Nothing
+  //. ```
+  function stripSuffix(suffix, s) {
+    var idx = s.length - suffix.length;  // value may be negative
+    return s.slice(idx) === suffix ? Just(s.slice(0, idx)) : Nothing;
+  }
+  S.stripSuffix =
+  def('stripSuffix', {}, [$.String, $.String, $Maybe($.String)], stripSuffix);
+
   //# words :: String -> Array String
   //.
   //. Takes a string and returns the array of words the string contains

--- a/test/stripPrefix.js
+++ b/test/stripPrefix.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('stripPrefix', function() {
+
+  eq(typeof S.stripPrefix, 'function');
+  eq(S.stripPrefix.length, 2);
+  eq(S.stripPrefix.toString(), 'stripPrefix :: String -> String -> Maybe String');
+
+  eq(S.stripPrefix('', ''), S.Just(''));
+  eq(S.stripPrefix('', 'abc'), S.Just('abc'));
+  eq(S.stripPrefix('a', ''), S.Nothing);
+  eq(S.stripPrefix('a', 'abc'), S.Just('bc'));
+  eq(S.stripPrefix('a', '[abc]'), S.Nothing);
+  eq(S.stripPrefix('aaa', 'a'), S.Nothing);
+  eq(S.stripPrefix('https://', 'https://sanctuary.js.org'), S.Just('sanctuary.js.org'));
+  eq(S.stripPrefix('https://', 'http://sanctuary.js.org'), S.Nothing);
+
+});

--- a/test/stripSuffix.js
+++ b/test/stripSuffix.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('stripSuffix', function() {
+
+  eq(typeof S.stripSuffix, 'function');
+  eq(S.stripSuffix.length, 2);
+  eq(S.stripSuffix.toString(), 'stripSuffix :: String -> String -> Maybe String');
+
+  eq(S.stripSuffix('', ''), S.Just(''));
+  eq(S.stripSuffix('', 'xyz'), S.Just('xyz'));
+  eq(S.stripSuffix('z', ''), S.Nothing);
+  eq(S.stripSuffix('z', 'xyz'), S.Just('xy'));
+  eq(S.stripSuffix('z', '[xyz]'), S.Nothing);
+  eq(S.stripSuffix('zzz', 'z'), S.Nothing);
+  eq(S.stripSuffix('.md', 'README.md'), S.Just('README'));
+  eq(S.stripSuffix('.md', 'README'), S.Nothing);
+
+});


### PR DESCRIPTION
Closes #329

When reviewing, please pay particularly close attention to the `stripSuffix` implementation. Negative indexes impinge on my reasoning ability, but in striking a balance between readability and efficiency I decided not to use `Math.max(0, s.length - suffix.length)` to avoid them.
