### PR TITLE
array: add S.partition

### DIFF
--- a/index.js
+++ b/index.js
@@ -3456,6 +3456,30 @@
   }
   S.find = def('find', {f: [Z.Foldable]}, [Pred(a), f(a), $Maybe(a)], find);
 
+  //# partition :: (Applicative f, Foldable f, Semigroup (f b), Semigroup (f c)) => (a -> Either b c) -> f a -> Pair (f b) (f c)
+  //.
+  //. Partitions a [Foldable][] into a [`Pair`][$.Pair] of Foldables, the first
+  //. comprising all the Left values returned by the given function, the second
+  //. comprising all the Right values returned by the given function.
+  //.
+  //. ```javascript
+  //. > S.partition(S.tagBy(S.even), [1, 2, 3, 4, 5])
+  //. [[1, 3, 5], [2, 4]]
+  //. ```
+  function partition(f, foldable) {
+    var empty = Z.empty(foldable.constructor);
+    return Z.reduce(function(pair, x) {
+      return either(function(x) { return [append(x, pair[0]), pair[1]]; },
+                    function(x) { return [pair[0], append(x, pair[1])]; },
+                    f(x));
+    }, [empty, empty], foldable);
+  }
+  S.partition =
+  def('partition',
+      {f: [Z.Applicative, Z.Foldable, Z.Semigroup]},
+      [Fn(a, $Either(b, c)), f(a), $.Pair(f(b), f(c))],
+      partition);
+
   //# pluck :: (Accessible a, Functor f) => String -> f a -> f b
   //.
   //. Combines [`map`](#map) and [`prop`](#prop). `pluck(k, xs)` is equivalent
@@ -4418,6 +4442,7 @@
 }));
 
 //. [$.Array]:          v:sanctuary-js/sanctuary-def#Array
+//. [$.Pair]:           v:sanctuary-js/sanctuary-def#Pair
 //. [$.String]:         v:sanctuary-js/sanctuary-def#String
 //. [Alt]:              v:fantasyland/fantasy-land#alt
 //. [Alternative]:      v:fantasyland/fantasy-land#alternative

--- a/test/partition.js
+++ b/test/partition.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('partition', function() {
+
+  eq(typeof S.partition, 'function');
+  eq(S.partition.length, 2);
+  eq(S.partition.toString(), 'partition :: (Applicative f, Foldable f, Semigroup f) => (a -> Either b c) -> f a -> Pair (f b) (f c)');
+
+  eq(S.partition(S.tagBy(S.even), []), [[], []]);
+  eq(S.partition(S.tagBy(S.even), [1, 2, 3, 4, 5]), [[1, 3, 5], [2, 4]]);
+
+});


### PR DESCRIPTION
As @safareli demonstrated in https://github.com/sanctuary-js/sanctuary/issues/385#issuecomment-294993056, this is just one of several `partition` functions from which we can choose. Is this the best choice? I don't know. I do appreciate how nicely it works with `tagBy` (#379).
