### PR TITLE
sanctuary-type-classes@5.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "sanctuary-def": "0.11.0",
-    "sanctuary-type-classes": "4.0.0",
+    "sanctuary-type-classes": "5.0.0",
     "sanctuary-type-identifiers": "1.0.0"
   },
   "ignore": [

--- a/index.js
+++ b/index.js
@@ -247,6 +247,11 @@
     };
   }
 
+  //  negativeZero :: Number -> Boolean
+  function negativeZero(n) {
+    return n === 0 && 1 / n === -Infinity;
+  }
+
   //  typeEq :: String -> a -> Boolean
   function typeEq(typeIdent) {
     return function(x) {
@@ -276,17 +281,6 @@
     'sanctuary/Accessible',
     [],
     function(x) { return x != null; }
-  );
-
-  //  Ord :: TypeClass
-  var Ord = Z.TypeClass(
-    'sanctuary/Ord',
-    [],
-    function(x) {
-      return $.String._test(x) ||
-             $.ValidDate._test(x) ||
-             $.ValidNumber._test(x);
-    }
   );
 
   //  readmeUrl :: String -> String
@@ -565,15 +559,180 @@
   //.
   //. ```javascript
   //. > S.equals(0, -0)
-  //. false
+  //. true
   //.
   //. > S.equals(NaN, NaN)
   //. true
   //.
   //. > S.equals(S.Just([1, 2, 3]), S.Just([1, 2, 3]))
   //. true
+  //.
+  //. > S.equals(S.Just([1, 2, 3]), S.Just([1, 2, 4]))
+  //. false
   //. ```
   S.equals = def('equals', {a: [Z.Setoid]}, [a, a, $.Boolean], Z.equals);
+
+  //# lt :: Ord a => a -> (a -> Boolean)
+  //.
+  //. Flipped version of [`Z.lt`][] intended for partial application.
+  //.
+  //. See also [`lt_`](#lt_).
+  //.
+  //. ```javascript
+  //. > S.filter(S.lt(3), [1, 2, 3, 4, 5])
+  //. [1, 2]
+  //. ```
+  S.lt = def('lt', {a: [Z.Ord]}, [a, Pred(a)], flip$(Z.lt));
+
+  //# lt_ :: Ord a => a -> a -> Boolean
+  //.
+  //. Curried version of [`Z.lt`][].
+  //.
+  //. See also [`lt`](#lt).
+  //.
+  //. ```javascript
+  //. > S.lt_([1, 2, 3], [1, 2, 3])
+  //. false
+  //.
+  //. > S.lt_([1, 2, 3], [1, 2, 4])
+  //. true
+  //.
+  //. > S.lt_([1, 2, 3], [1, 2])
+  //. false
+  //. ```
+  S.lt_ = def('lt_', {a: [Z.Ord]}, [a, a, $.Boolean], Z.lt);
+
+  //# lte :: Ord a => a -> (a -> Boolean)
+  //.
+  //. Flipped version of [`Z.lte`][] intended for partial application.
+  //.
+  //. See also [`lte_`](#lte_).
+  //.
+  //. ```javascript
+  //. > S.filter(S.lte(3), [1, 2, 3, 4, 5])
+  //. [1, 2, 3]
+  //. ```
+  S.lte = def('lte', {a: [Z.Ord]}, [a, Pred(a)], flip$(Z.lte));
+
+  //# lte_ :: Ord a => a -> a -> Boolean
+  //.
+  //. Curried version of [`Z.lte`][].
+  //.
+  //. See also [`lte`](#lte).
+  //.
+  //. ```javascript
+  //. > S.lte_([1, 2, 3], [1, 2, 3])
+  //. true
+  //.
+  //. > S.lte_([1, 2, 3], [1, 2, 4])
+  //. true
+  //.
+  //. > S.lte_([1, 2, 3], [1, 2])
+  //. false
+  //. ```
+  S.lte_ = def('lte_', {a: [Z.Ord]}, [a, a, $.Boolean], Z.lte);
+
+  //# gt :: Ord a => a -> (a -> Boolean)
+  //.
+  //. Flipped version of [`Z.gt`][] intended for partial application.
+  //.
+  //. See also [`gt_`](#gt_).
+  //.
+  //. ```javascript
+  //. > S.filter(S.gt(3), [1, 2, 3, 4, 5])
+  //. [4, 5]
+  //. ```
+  S.gt = def('gt', {a: [Z.Ord]}, [a, Pred(a)], flip$(Z.gt));
+
+  //# gt_ :: Ord a => a -> a -> Boolean
+  //.
+  //. Curried version of [`Z.gt`][].
+  //.
+  //. See also [`gt`](#gt).
+  //.
+  //. ```javascript
+  //. > S.gt_([1, 2, 3], [1, 2, 3])
+  //. false
+  //.
+  //. > S.gt_([1, 2, 3], [1, 2, 4])
+  //. false
+  //.
+  //. > S.gt_([1, 2, 3], [1, 2])
+  //. true
+  //. ```
+  S.gt_ = def('gt_', {a: [Z.Ord]}, [a, a, $.Boolean], Z.gt);
+
+  //# gte :: Ord a => a -> (a -> Boolean)
+  //.
+  //. Flipped version of [`Z.gte`][] intended for partial application.
+  //.
+  //. See also [`gte_`](#gte_).
+  //.
+  //. ```javascript
+  //. > S.filter(S.gte(3), [1, 2, 3, 4, 5])
+  //. [3, 4, 5]
+  //. ```
+  S.gte = def('gte', {a: [Z.Ord]}, [a, Pred(a)], flip$(Z.gte));
+
+  //# gte_ :: Ord a => a -> a -> Boolean
+  //.
+  //. Curried version of [`Z.gte`][].
+  //.
+  //. See also [`gte`](#gte).
+  //.
+  //. ```javascript
+  //. > S.gte_([1, 2, 3], [1, 2, 3])
+  //. true
+  //.
+  //. > S.gte_([1, 2, 3], [1, 2, 4])
+  //. false
+  //.
+  //. > S.gte_([1, 2, 3], [1, 2])
+  //. true
+  //. ```
+  S.gte_ = def('gte_', {a: [Z.Ord]}, [a, a, $.Boolean], Z.gte);
+
+  //# min :: Ord a => a -> a -> a
+  //.
+  //. Returns the smaller of its two arguments (according to [`Z.lte`][]).
+  //.
+  //. See also [`max`](#max).
+  //.
+  //. ```javascript
+  //. > S.min(10, 2)
+  //. 2
+  //.
+  //. > S.min(new Date('1999-12-31'), new Date('2000-01-01'))
+  //. new Date('1999-12-31')
+  //.
+  //. > S.min('10', '2')
+  //. '10'
+  //. ```
+  function min(x, y) {
+    return Z.lte(x, y) ? x : y;
+  }
+  S.min = def('min', {a: [Z.Ord]}, [a, a, a], min);
+
+  //# max :: Ord a => a -> a -> a
+  //.
+  //. Returns the larger of its two arguments (according to [`Z.lte`][]).
+  //.
+  //. See also [`min`](#min).
+  //.
+  //. ```javascript
+  //. > S.max(10, 2)
+  //. 10
+  //.
+  //. > S.max(new Date('1999-12-31'), new Date('2000-01-01'))
+  //. new Date('2000-01-01')
+  //.
+  //. > S.max('10', '2')
+  //. '2'
+  //. ```
+  function max(x, y) {
+    return Z.lte(x, y) ? y : x;
+  }
+  S.max = def('max', {a: [Z.Ord]}, [a, a, a], max);
 
   //# concat :: Semigroup a => a -> a -> a
   //.
@@ -1036,7 +1195,7 @@
   S.filter =
   def('filter',
       {f: [Z.Applicative, Z.Foldable, Z.Monoid]},
-      [Fn(a, $.Boolean), f(a), f(a)],
+      [Pred(a), f(a), f(a)],
       Z.filter);
 
   //# filterM :: (Alternative m, Monad m) => (a -> Boolean) -> m a -> m a
@@ -1058,7 +1217,7 @@
   S.filterM =
   def('filterM',
       {m: [Z.Alternative, Z.Monad]},
-      [Fn(a, $.Boolean), m(a), m(a)],
+      [Pred(a), m(a), m(a)],
       Z.filterM);
 
   //# takeWhile :: (Foldable f, Alternative f) => (a -> Boolean) -> f a -> f a
@@ -1413,6 +1572,14 @@
     if (this.isNothing || Z.Semigroup.test(this.value)) {
       this['fantasy-land/concat'] = Maybe$prototype$concat;
     }
+
+    if (this.isNothing || Z.Setoid.test(this.value)) {
+      this['fantasy-land/equals'] = Maybe$prototype$equals;
+    }
+
+    if (this.isNothing || Z.Ord.test(this.value)) {
+      this['fantasy-land/lte'] = Maybe$prototype$lte;
+    }
   }
 
   //# Nothing :: Maybe a
@@ -1528,14 +1695,14 @@
   //. ```
   Maybe.prototype.inspect = function() { return this.toString(); };
 
-  //# Maybe#fantasy-land/equals :: Maybe a ~> Maybe a -> Boolean
+  //# Maybe#fantasy-land/equals :: Setoid a => Maybe a ~> Maybe a -> Boolean
   //.
-  //. Takes a value of the same type and returns `true` if:
+  //. Takes a value `m` of the same type and returns `true` if:
   //.
-  //.   - it is Nothing and `this` is Nothing; or
+  //.   - `this` and `m` are both Nothing; or
   //.
-  //.   - it is a Just and `this` is a Just, and their values are equal
-  //.     according to [`equals`](#equals).
+  //.   - `this` and `m` are both Justs, and their values are equal according
+  //.     to [`Z.equals`][].
   //.
   //. ```javascript
   //. > S.equals(S.Nothing, S.Nothing)
@@ -1550,10 +1717,39 @@
   //. > S.equals(S.Just([1, 2, 3]), S.Nothing)
   //. false
   //. ```
-  Maybe.prototype['fantasy-land/equals'] = function(other) {
+  function Maybe$prototype$equals(other) {
     return this.isNothing ? other.isNothing
-                          : other.isJust && Z.equals(other.value, this.value);
-  };
+                          : other.isJust && Z.equals(this.value, other.value);
+  }
+
+  //# Maybe#fantasy-land/lte :: Ord a => Maybe a ~> Maybe a -> Boolean
+  //.
+  //. Takes a value `m` of the same type and returns `true` if:
+  //.
+  //.   - `this` is Nothing; or
+  //.
+  //.   - `this` and `m` are both Justs and the value of `this` is less than
+  //.     or equal to the value of `m` according to [`Z.lte`][].
+  //.
+  //. ```javascript
+  //. > S.lte_(S.Nothing, S.Nothing)
+  //. true
+  //.
+  //. > S.lte_(S.Nothing, S.Just(0))
+  //. true
+  //.
+  //. > S.lte_(S.Just(0), S.Nothing)
+  //. false
+  //.
+  //. > S.lte_(S.Just(0), S.Just(1))
+  //. true
+  //.
+  //. > S.lte_(S.Just(1), S.Just(0))
+  //. false
+  //. ```
+  function Maybe$prototype$lte(other) {
+    return this.isNothing || other.isJust && Z.lte(this.value, other.value);
+  }
 
   //# Maybe#fantasy-land/concat :: Semigroup a => Maybe a ~> Maybe a -> Maybe a
   //.
@@ -2043,6 +2239,14 @@
     if (Z.Semigroup.test(this.value)) {
       this['fantasy-land/concat'] = Either$prototype$concat;
     }
+
+    if (Z.Setoid.test(this.value)) {
+      this['fantasy-land/equals'] = Either$prototype$equals;
+    }
+
+    if (Z.Ord.test(this.value)) {
+      this['fantasy-land/lte'] = Either$prototype$lte;
+    }
   }
 
   //# Left :: a -> Either a b
@@ -2142,15 +2346,12 @@
   //. ```
   Either.prototype.inspect = function() { return this.toString(); };
 
-  //# Either#fantasy-land/equals :: Either a b ~> Either a b -> Boolean
+  //# Either#fantasy-land/equals :: (Setoid a, Setoid b) => Either a b ~> Either a b -> Boolean
   //.
-  //. Takes a value of the same type and returns `true` if:
+  //. Takes a value `e` of the same type and returns `true` if:
   //.
-  //.   - it is a Left and `this` is a Left, and their values are equal
-  //.     according to [`equals`](#equals); or
-  //.
-  //.   - it is a Right and `this` is a Right, and their values are equal
-  //.     according to [`equals`](#equals).
+  //.   - `this` and `e` are both Lefts or both Rights, and their values are
+  //.     equal according to [`Z.equals`][].
   //.
   //. ```javascript
   //. > S.equals(S.Right([1, 2, 3]), S.Right([1, 2, 3]))
@@ -2159,9 +2360,37 @@
   //. > S.equals(S.Right([1, 2, 3]), S.Left([1, 2, 3]))
   //. false
   //. ```
-  Either.prototype['fantasy-land/equals'] = function(other) {
-    return other.isLeft === this.isLeft && Z.equals(other.value, this.value);
-  };
+  function Either$prototype$equals(other) {
+    return this.isLeft === other.isLeft && Z.equals(this.value, other.value);
+  }
+
+  //# Either#fantasy-land/lte :: (Ord a, Ord b) => Either a b ~> Either a b -> Boolean
+  //.
+  //. Takes a value `e` of the same type and returns `true` if:
+  //.
+  //.   - `this` is a Left and `e` is a Right; or
+  //.
+  //.   - `this` and `e` are both Lefts or both Rights, and the value of `this`
+  //.     is less than or equal to the value of `e` according to [`Z.lte`][].
+  //.
+  //. ```javascript
+  //. > S.lte_(S.Left(10), S.Right(0))
+  //. true
+  //.
+  //. > S.lte_(S.Right(0), S.Left(10))
+  //. false
+  //.
+  //. > S.lte_(S.Right(0), S.Right(1))
+  //. true
+  //.
+  //. > S.lte_(S.Right(1), S.Right(0))
+  //. false
+  //. ```
+  function Either$prototype$lte(other) {
+    return this.isLeft === other.isLeft ?
+      Z.lte(this.value, other.value) :
+      this.isLeft;
+  }
 
   //# Either#fantasy-land/concat :: (Semigroup a, Semigroup b) => Either a b ~> Either a b -> Either a b
   //.
@@ -2513,7 +2742,7 @@
   function tagBy(pred, a) {
     return pred(a) ? Right(a) : Left(a);
   }
-  S.tagBy = def('tagBy', {}, [Fn(a, $.Boolean), a, $Either(a, a)], tagBy);
+  S.tagBy = def('tagBy', {}, [Pred(a), a, $Either(a, a)], tagBy);
 
   //# encaseEither :: (Error -> l) -> (a -> r) -> a -> Either l r
   //.
@@ -2866,8 +3095,8 @@
   //. ```
   function slice(start, end, xs) {
     var len = xs.length;
-    var fromIdx = Z.equals(start, -0) ? len : start < 0 ? start + len : start;
-    var toIdx = Z.equals(end, -0) ? len : end < 0 ? end + len : end;
+    var fromIdx = negativeZero(start) ? len : start < 0 ? start + len : start;
+    var toIdx = negativeZero(end) ? len : end < 0 ? end + len : end;
 
     return Math.abs(start) <= len && Math.abs(end) <= len && fromIdx <= toIdx ?
       Just(xs.slice(fromIdx, toIdx)) :
@@ -3318,7 +3547,7 @@
   S.groupBy =
   def('groupBy',
       {},
-      [Fn(a, Fn(a, $.Boolean)), $.Array(a), $.Array($.Array(a))],
+      [Fn(a, Pred(a)), $.Array(a), $.Array($.Array(a))],
       groupBy);
 
   //# groupBy_ :: ((a, a) -> Boolean) -> Array a -> Array (Array a)
@@ -3656,56 +3885,6 @@
       {f: [Z.Foldable]},
       [f($.FiniteNumber), $Maybe($.FiniteNumber)],
       mean);
-
-  //# min :: Ord a => a -> a -> a
-  //.
-  //. Returns the smaller of its two arguments.
-  //.
-  //. Strings are compared lexicographically. Specifically, the Unicode
-  //. code point value of each character in the first string is compared
-  //. to the value of the corresponding character in the second string.
-  //.
-  //. See also [`max`](#max).
-  //.
-  //. ```javascript
-  //. > S.min(10, 2)
-  //. 2
-  //.
-  //. > S.min(new Date('1999-12-31'), new Date('2000-01-01'))
-  //. new Date('1999-12-31')
-  //.
-  //. > S.min('10', '2')
-  //. '10'
-  //. ```
-  function min(x, y) {
-    return x < y ? x : y;
-  }
-  S.min = def('min', {a: [Ord]}, [a, a, a], min);
-
-  //# max :: Ord a => a -> a -> a
-  //.
-  //. Returns the larger of its two arguments.
-  //.
-  //. Strings are compared lexicographically. Specifically, the Unicode
-  //. code point value of each character in the first string is compared
-  //. to the value of the corresponding character in the second string.
-  //.
-  //. See also [`min`](#min).
-  //.
-  //. ```javascript
-  //. > S.max(10, 2)
-  //. 10
-  //.
-  //. > S.max(new Date('1999-12-31'), new Date('2000-01-01'))
-  //. new Date('2000-01-01')
-  //.
-  //. > S.max('10', '2')
-  //. '2'
-  //. ```
-  function max(x, y) {
-    return x > y ? x : y;
-  }
-  S.max = def('max', {a: [Ord]}, [a, a, a], max);
 
   //. ### Integer
 
@@ -4265,7 +4444,11 @@
 //. [`Z.extract`]:      v:sanctuary-js/sanctuary-type-classes#extract
 //. [`Z.filter`]:       v:sanctuary-js/sanctuary-type-classes#filter
 //. [`Z.filterM`]:      v:sanctuary-js/sanctuary-type-classes#filterM
+//. [`Z.gt`]:           v:sanctuary-js/sanctuary-type-classes#gt
+//. [`Z.gte`]:          v:sanctuary-js/sanctuary-type-classes#gte
 //. [`Z.join`]:         v:sanctuary-js/sanctuary-type-classes#join
+//. [`Z.lt`]:           v:sanctuary-js/sanctuary-type-classes#lt
+//. [`Z.lte`]:          v:sanctuary-js/sanctuary-type-classes#lte
 //. [`Z.map`]:          v:sanctuary-js/sanctuary-type-classes#map
 //. [`Z.of`]:           v:sanctuary-js/sanctuary-type-classes#of
 //. [`Z.promap`]:       v:sanctuary-js/sanctuary-type-classes#promap

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "dependencies": {
     "sanctuary-def": "0.11.0",
-    "sanctuary-type-classes": "4.0.0",
+    "sanctuary-type-classes": "5.0.0",
     "sanctuary-type-identifiers": "1.0.0"
   },
   "devDependencies": {
     "browserify": "13.1.x",
     "doctest": "0.12.x",
     "eslint": "3.19.x",
-    "fantasy-land": "3.0.0",
+    "fantasy-land": "3.2.0",
     "istanbul": "0.4.x",
     "jsverify": "0.7.x",
     "karma": "1.3.x",

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -3,8 +3,9 @@
 var FL = require('fantasy-land');
 var Z = require('sanctuary-type-classes');
 
-var S = require('../..');
+var S = require('../internal/sanctuary');
 
+var Useless = require('../internal/Useless');
 var eq = require('../internal/eq');
 var squareRoot = require('../internal/squareRoot');
 
@@ -57,15 +58,31 @@ suite('Left', function() {
     eq(S.Left(42)[FL.equals](S.Right(42)), false);
 
     // Value-based equality:
-    eq(S.Left(0)[FL.equals](S.Left(-0)), false);
-    eq(S.Left(-0)[FL.equals](S.Left(0)), false);
+    eq(S.Left(0)[FL.equals](S.Left(-0)), true);
+    eq(S.Left(-0)[FL.equals](S.Left(0)), true);
     eq(S.Left(NaN)[FL.equals](S.Left(NaN)), true);
     eq(S.Left([1, 2, 3])[FL.equals](S.Left([1, 2, 3])), true);
+
+    eq(Z.Setoid.test(S.Left(1)), true);
+    eq(Z.Setoid.test(S.Left(Useless)), false);
   });
 
   test('"fantasy-land/extend" method', function() {
     eq(S.Left('abc')[FL.extend].length, 1);
     eq(S.Left('abc')[FL.extend](function(x) { return x / 2; }), S.Left('abc'));
+  });
+
+  test('"fantasy-land/lte" method', function() {
+    eq(S.Left(1)[FL.lte].length, 1);
+    eq(S.Left(1)[FL.lte](S.Right(0)), true);
+    eq(S.Left(1)[FL.lte](S.Right(1)), true);
+    eq(S.Left(1)[FL.lte](S.Right(2)), true);
+    eq(S.Left(1)[FL.lte](S.Left(0)), false);
+    eq(S.Left(1)[FL.lte](S.Left(1)), true);
+    eq(S.Left(1)[FL.lte](S.Left(2)), true);
+
+    eq(Z.Ord.test(S.Left(1)), true);
+    eq(Z.Ord.test(S.Left(Math.sqrt)), false);
   });
 
   test('"fantasy-land/map" method', function() {

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -3,8 +3,9 @@
 var FL = require('fantasy-land');
 var Z = require('sanctuary-type-classes');
 
-var S = require('../..');
+var S = require('../internal/sanctuary');
 
+var Useless = require('../internal/Useless');
 var eq = require('../internal/eq');
 var squareRoot = require('../internal/squareRoot');
 
@@ -57,15 +58,31 @@ suite('Right', function() {
     eq(S.Right(42)[FL.equals](S.Left(42)), false);
 
     // Value-based equality:
-    eq(S.Right(0)[FL.equals](S.Right(-0)), false);
-    eq(S.Right(-0)[FL.equals](S.Right(0)), false);
+    eq(S.Right(0)[FL.equals](S.Right(-0)), true);
+    eq(S.Right(-0)[FL.equals](S.Right(0)), true);
     eq(S.Right(NaN)[FL.equals](S.Right(NaN)), true);
     eq(S.Right([1, 2, 3])[FL.equals](S.Right([1, 2, 3])), true);
+
+    eq(Z.Setoid.test(S.Right(1)), true);
+    eq(Z.Setoid.test(S.Right(Useless)), false);
   });
 
   test('"fantasy-land/extend" method', function() {
     eq(S.Right(42)[FL.extend].length, 1);
     eq(S.Right(42)[FL.extend](function(x) { return x.value / 2; }), S.Right(21));
+  });
+
+  test('"fantasy-land/lte" method', function() {
+    eq(S.Right(1)[FL.lte].length, 1);
+    eq(S.Right(1)[FL.lte](S.Left(0)), false);
+    eq(S.Right(1)[FL.lte](S.Left(1)), false);
+    eq(S.Right(1)[FL.lte](S.Left(2)), false);
+    eq(S.Right(1)[FL.lte](S.Right(0)), false);
+    eq(S.Right(1)[FL.lte](S.Right(1)), true);
+    eq(S.Right(1)[FL.lte](S.Right(2)), true);
+
+    eq(Z.Ord.test(S.Right(1)), true);
+    eq(Z.Ord.test(S.Right(Math.sqrt)), false);
   });
 
   test('"fantasy-land/map" method', function() {

--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -3,8 +3,9 @@
 var FL = require('fantasy-land');
 var Z = require('sanctuary-type-classes');
 
-var S = require('../..');
+var S = require('../internal/sanctuary');
 
+var Useless = require('../internal/Useless');
 var eq = require('../internal/eq');
 
 
@@ -51,15 +52,29 @@ suite('Just', function() {
     eq(S.Just(42)[FL.equals](S.Nothing), false);
 
     // Value-based equality:
-    eq(S.Just(0)[FL.equals](S.Just(-0)), false);
-    eq(S.Just(-0)[FL.equals](S.Just(0)), false);
+    eq(S.Just(0)[FL.equals](S.Just(-0)), true);
+    eq(S.Just(-0)[FL.equals](S.Just(0)), true);
     eq(S.Just(NaN)[FL.equals](S.Just(NaN)), true);
     eq(S.Just([1, 2, 3])[FL.equals](S.Just([1, 2, 3])), true);
+
+    eq(Z.Setoid.test(S.Just(1)), true);
+    eq(Z.Setoid.test(S.Just(Useless)), false);
   });
 
   test('"fantasy-land/extend" method', function() {
     eq(S.Just(42)[FL.extend].length, 1);
     eq(S.Just(42)[FL.extend](function(x) { return x.value / 2; }), S.Just(21));
+  });
+
+  test('"fantasy-land/lte" method', function() {
+    eq(S.Just(1)[FL.lte].length, 1);
+    eq(S.Just(1)[FL.lte](S.Nothing), false);
+    eq(S.Just(1)[FL.lte](S.Just(0)), false);
+    eq(S.Just(1)[FL.lte](S.Just(1)), true);
+    eq(S.Just(1)[FL.lte](S.Just(2)), true);
+
+    eq(Z.Ord.test(S.Just(1)), true);
+    eq(Z.Ord.test(S.Just(Math.sqrt)), false);
   });
 
   test('"fantasy-land/map" method', function() {

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -3,7 +3,7 @@
 var FL = require('fantasy-land');
 var Z = require('sanctuary-type-classes');
 
-var S = require('../..');
+var S = require('../internal/sanctuary');
 
 var eq = require('../internal/eq');
 
@@ -45,11 +45,21 @@ suite('Nothing', function() {
     eq(S.Nothing[FL.equals].length, 1);
     eq(S.Nothing[FL.equals](S.Nothing), true);
     eq(S.Nothing[FL.equals](S.Just(42)), false);
+
+    eq(Z.Setoid.test(S.Nothing), true);
   });
 
   test('"fantasy-land/extend" method', function() {
     eq(S.Nothing[FL.extend].length, 1);
     eq(S.Nothing[FL.extend](function(x) { return x.value / 2; }), S.Nothing);
+  });
+
+  test('"fantasy-land/lte" method', function() {
+    eq(S.Nothing[FL.lte].length, 1);
+    eq(S.Nothing[FL.lte](S.Nothing), true);
+    eq(S.Nothing[FL.lte](S.Just(0)), true);
+
+    eq(Z.Ord.test(S.Nothing), true);
   });
 
   test('"fantasy-land/map" method', function() {

--- a/test/equals.js
+++ b/test/equals.js
@@ -13,10 +13,16 @@ test('equals', function() {
 
   eq(S.equals(S.Nothing, S.Nothing), true);
   eq(S.equals(S.Just(NaN), S.Just(NaN)), true);
-  eq(S.equals(S.Just(0), S.Just(-0)), false);
+  eq(S.equals(S.Just(0), S.Just(-0)), true);
+  eq(S.equals(S.Nothing, S.Just(0)), false);
+  eq(S.equals(S.Just(0), S.Just(1)), false);
+
   eq(S.equals(S.Left(NaN), S.Left(NaN)), true);
-  eq(S.equals(S.Left(0), S.Left(-0)), false);
+  eq(S.equals(S.Left(0), S.Left(-0)), true);
   eq(S.equals(S.Right(NaN), S.Right(NaN)), true);
-  eq(S.equals(S.Right(0), S.Right(-0)), false);
+  eq(S.equals(S.Right(0), S.Right(-0)), true);
+  eq(S.equals(S.Left(10), S.Left(20)), false);
+  eq(S.equals(S.Left(10), S.Right(0)), false);
+  eq(S.equals(S.Right(0), S.Right(1)), false);
 
 });

--- a/test/gt.js
+++ b/test/gt.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('gt', function() {
+
+  eq(typeof S.gt, 'function');
+  eq(S.gt.length, 1);
+  eq(S.gt.toString(), 'gt :: Ord a => a -> (a -> Boolean)');
+
+  eq(S.filter(S.gt(3), [1, 2, 3, 4, 5]), [4, 5]);
+
+});

--- a/test/gt_.js
+++ b/test/gt_.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('gt_', function() {
+
+  eq(typeof S.gt_, 'function');
+  eq(S.gt_.length, 2);
+  eq(S.gt_.toString(), 'gt_ :: Ord a => a -> a -> Boolean');
+
+  eq(S.gt_(0, 1), false);
+  eq(S.gt_(1, 1), false);
+  eq(S.gt_(2, 1), true);
+
+  eq(S.gt_(S.Just(0), S.Just(1)), false);
+  eq(S.gt_(S.Just(1), S.Just(1)), false);
+  eq(S.gt_(S.Just(2), S.Just(1)), true);
+
+});

--- a/test/gte.js
+++ b/test/gte.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('gte', function() {
+
+  eq(typeof S.gte, 'function');
+  eq(S.gte.length, 1);
+  eq(S.gte.toString(), 'gte :: Ord a => a -> (a -> Boolean)');
+
+  eq(S.filter(S.gte(3), [1, 2, 3, 4, 5]), [3, 4, 5]);
+
+});

--- a/test/gte_.js
+++ b/test/gte_.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('gte_', function() {
+
+  eq(typeof S.gte_, 'function');
+  eq(S.gte_.length, 2);
+  eq(S.gte_.toString(), 'gte_ :: Ord a => a -> a -> Boolean');
+
+  eq(S.gte_(0, 1), false);
+  eq(S.gte_(1, 1), true);
+  eq(S.gte_(2, 1), true);
+
+  eq(S.gte_(S.Just(0), S.Just(1)), false);
+  eq(S.gte_(S.Just(1), S.Just(1)), true);
+  eq(S.gte_(S.Just(2), S.Just(1)), true);
+
+});

--- a/test/internal/Useless.js
+++ b/test/internal/Useless.js
@@ -1,0 +1,8 @@
+'use strict';
+
+//  Useless :: Useless
+module.exports = {
+  constructor: {'@@type': 'sanctuary/Useless'},
+  inspect: function() { return 'Useless'; },
+  toString: function() { return 'Useless'; }
+};

--- a/test/internal/sanctuary.js
+++ b/test/internal/sanctuary.js
@@ -15,10 +15,18 @@ function UnaryType(typeIdent) {
   )($.Unknown);
 }
 
+//  UselessType :: Type
+var UselessType = $.NullaryType(
+  'sanctuary/Useless',
+  '',
+  function(x) { return S.type(x) === 'sanctuary/Useless'; }
+);
+
 //  env :: Array Type
 var env = S.env.concat([
   UnaryType('sanctuary/Compose'),
-  UnaryType('sanctuary/Identity')
+  UnaryType('sanctuary/Identity'),
+  UselessType
 ]);
 
 module.exports = S.create({checkTypes: true, env: env});

--- a/test/lt.js
+++ b/test/lt.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('lt', function() {
+
+  eq(typeof S.lt, 'function');
+  eq(S.lt.length, 1);
+  eq(S.lt.toString(), 'lt :: Ord a => a -> (a -> Boolean)');
+
+  eq(S.filter(S.lt(3), [1, 2, 3, 4, 5]), [1, 2]);
+
+});

--- a/test/lt_.js
+++ b/test/lt_.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('lt_', function() {
+
+  eq(typeof S.lt_, 'function');
+  eq(S.lt_.length, 2);
+  eq(S.lt_.toString(), 'lt_ :: Ord a => a -> a -> Boolean');
+
+  eq(S.lt_(0, 1), true);
+  eq(S.lt_(1, 1), false);
+  eq(S.lt_(2, 1), false);
+
+  eq(S.lt_(S.Just(0), S.Just(1)), true);
+  eq(S.lt_(S.Just(1), S.Just(1)), false);
+  eq(S.lt_(S.Just(2), S.Just(1)), false);
+
+});

--- a/test/lte.js
+++ b/test/lte.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('lte', function() {
+
+  eq(typeof S.lte, 'function');
+  eq(S.lte.length, 1);
+  eq(S.lte.toString(), 'lte :: Ord a => a -> (a -> Boolean)');
+
+  eq(S.filter(S.lte(3), [1, 2, 3, 4, 5]), [1, 2, 3]);
+
+});

--- a/test/lte_.js
+++ b/test/lte_.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('lte_', function() {
+
+  eq(typeof S.lte_, 'function');
+  eq(S.lte_.length, 2);
+  eq(S.lte_.toString(), 'lte_ :: Ord a => a -> a -> Boolean');
+
+  eq(S.lte_(0, 1), true);
+  eq(S.lte_(1, 1), true);
+  eq(S.lte_(2, 1), false);
+
+  eq(S.lte_(S.Just(0), S.Just(1)), true);
+  eq(S.lte_(S.Just(1), S.Just(1)), true);
+  eq(S.lte_(S.Just(2), S.Just(1)), false);
+
+});


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-type-classes/releases/tag/v5.0.0>

This pull request adds four new functions: `lt`, `lte`, `gt`, and `gte`. It also replaces the internal Ord type class with the one defined in sanctuary-type-classes, making `min` and `max` even more general.

This pull request defines `fantasy-land/lte` for Maybe and Either. These additions will need to be applied to sanctuary-js/sanctuary-maybe#3 and sanctuary-js/sanctuary-either#3 respectively.

Note that `S.equals(0, -0)` will evaluate `true` as a result of this change. Since `-0` is neither less than nor greater than `0`, it must be equal to `0` in order to satisfy the [Ord][1] totality law.

@sadasant, you should be able to resume work on #365 once this pull request has been merged. :)


[1]: https://github.com/fantasyland/fantasy-land#ord
