### PR TITLE
array: generalize S.find

### DIFF
--- a/index.js
+++ b/index.js
@@ -3434,11 +3434,11 @@
   S.joinWith =
   def('joinWith', {}, [$.String, $.Array($.String), $.String], joinWith);
 
-  //# find :: (a -> Boolean) -> Array a -> Maybe a
+  //# find :: Foldable f => (a -> Boolean) -> f a -> Maybe a
   //.
-  //. Takes a predicate and an array and returns Just the leftmost element of
-  //. the array which satisfies the predicate; Nothing if none of the array's
-  //. elements satisfies the predicate.
+  //. Takes a predicate and a structure and returns Just the leftmost element
+  //. of the structure which satisfies the predicate; Nothing if there is no
+  //. such element.
   //.
   //. ```javascript
   //. > S.find(n => n < 0, [1, -2, 3, -4, 5])
@@ -3448,15 +3448,13 @@
   //. Nothing
   //. ```
   function find(pred, xs) {
-    var result = Nothing;
-    xs.some(function(x) {
-      var ok = pred(x);
-      if (ok) result = Just(x);
-      return ok;
-    });
-    return result;
+    return Z.reduce(
+      function(m, x) { return m.isJust ? m : pred(x) ? Just(x) : Nothing; },
+      Nothing,
+      xs
+    );
   }
-  S.find = def('find', {}, [Pred(a), $.Array(a), $Maybe(a)], find);
+  S.find = def('find', {f: [Z.Foldable]}, [Pred(a), f(a), $Maybe(a)], find);
 
   //# pluck :: (Accessible a, Functor f) => String -> f a -> f b
   //.

--- a/test/find.js
+++ b/test/find.js
@@ -9,10 +9,14 @@ test('find', function() {
 
   eq(typeof S.find, 'function');
   eq(S.find.length, 2);
-  eq(S.find.toString(), 'find :: (a -> Boolean) -> Array a -> Maybe a');
+  eq(S.find.toString(), 'find :: Foldable f => (a -> Boolean) -> f a -> Maybe a');
 
   eq(S.find(S.even, []), S.Nothing);
   eq(S.find(S.even, [1, 3, 5, 7, 9]), S.Nothing);
   eq(S.find(S.even, [1, 2, 3, 4, 5]), S.Just(2));
+  eq(S.find(S.even, {}), S.Nothing);
+  eq(S.find(S.even, {a: 1, b: 3, c: 5, d: 7, e: 9}), S.Nothing);
+  eq(S.find(S.even, {a: 1, b: 2, c: 3, d: 4, e: 5}), S.Just(2));
+  eq(S.find(S.even, {e: 5, d: 4, c: 3, b: 2, a: 1}), S.Just(2));
 
 });


### PR DESCRIPTION
This leads me to believe that sanctuary-type-classes should ensure consistent enumeration order in [`Object$prototype$reduce`][1] (by sorting the keys). Do others agree that this is desirable?

```haskell
> find (const True) (Map.fromList [("x", 0), ("y", 1)])
Just 0

> find (const True) (Map.fromList [("y", 1), ("x", 0)])
Just 0
```


[1]: https://github.com/sanctuary-js/sanctuary-type-classes/blob/v5.0.0/index.js#L862-L867
