### PR TITLE
array: add S.sort and S.sortBy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-def": "0.11.0",
+    "sanctuary-def": "0.11.1",
     "sanctuary-type-classes": "5.2.0",
     "sanctuary-type-identifiers": "2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "make lint test"
   },
   "dependencies": {
-    "sanctuary-def": "0.11.0",
+    "sanctuary-def": "0.11.1",
     "sanctuary-type-classes": "5.2.0",
     "sanctuary-type-identifiers": "2.0.1"
   },

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('sort', function() {
+
+  eq(typeof S.sort, 'function');
+  eq(S.sort.length, 1);
+  eq(S.sort.toString(), 'sort :: (Ord a, Applicative m, Foldable m, Monoid m) => m a -> m a');
+
+  eq(S.sort([]), []);
+  eq(S.sort(['foo', 'bar', 'baz']), ['bar', 'baz', 'foo']);
+  eq(S.sort([S.Left(4), S.Right(3), S.Left(2), S.Right(1)]), [S.Left(2), S.Left(4), S.Right(1), S.Right(3)]);
+
+  eq(S.sort(S.range(0, 100)), S.range(0, 100));
+  eq(S.sort(S.reverse(S.range(0, 100))), S.range(0, 100));
+
+});

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('sortBy', function() {
+
+  eq(typeof S.sortBy, 'function');
+  eq(S.sortBy.length, 2);
+  eq(S.sortBy.toString(), 'sortBy :: (Ord b, Applicative m, Foldable m, Monoid m) => (a -> b) -> m a -> m a');
+
+  eq(S.sortBy(S.I, []), []);
+  eq(S.sortBy(S.I, ['five']), ['five']);
+  eq(S.sortBy(S.I, ['five', 'six']), ['five', 'six']);
+  eq(S.sortBy(S.I, ['five', 'six', 'seven']), ['five', 'seven', 'six']);
+  eq(S.sortBy(S.prop('length'), ['five', 'six', 'seven']), ['six', 'five', 'seven']);
+
+  var _7s = {rank: 7, suit: 's'};
+  var _5h = {rank: 5, suit: 'h'};
+  var _2h = {rank: 2, suit: 'h'};
+  var _5s = {rank: 5, suit: 's'};
+  eq(S.sortBy(S.prop('rank'), [_7s, _5h, _2h, _5s]), [_2h, _5h, _5s, _7s]);
+  eq(S.sortBy(S.prop('rank'), [_7s, _5s, _2h, _5h]), [_2h, _5s, _5h, _7s]);
+  eq(S.sortBy(S.prop('suit'), [_7s, _5h, _2h, _5s]), [_5h, _2h, _7s, _5s]);
+  eq(S.sortBy(S.prop('suit'), [_5s, _2h, _5h, _7s]), [_2h, _5h, _5s, _7s]);
+
+});


### PR DESCRIPTION
Closes #353

This takes the `sortBy` implementation from <https://github.com/sanctuary-js/sanctuary/pull/365#issuecomment-298272599>, applies @safareli's improvements from <https://github.com/sanctuary-js/sanctuary/pull/365#issuecomment-300780512>, and further improves the algorithm by using binary search.

`sort` is trivially derived via `sortBy(I)`.
