### PR TITLE
sanctuary-type-identifiers@2.0.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "sanctuary-def": "0.11.0",
     "sanctuary-type-classes": "5.2.0",
-    "sanctuary-type-identifiers": "1.0.0"
+    "sanctuary-type-identifiers": "2.0.1"
   },
   "ignore": [
     "/.git/",

--- a/index.js
+++ b/index.js
@@ -484,18 +484,29 @@
 
   //. ### Classify
 
-  //# type :: Any -> String
+  //# type :: Any -> { namespace :: Maybe String, name :: String, version :: Integer }
   //.
-  //. Returns the [type identifier][] of the given value.
+  //. Returns the result of parsing the [type identifier][] of the given value.
   //.
   //. ```javascript
   //. > S.type(S.Just(42))
-  //. 'sanctuary/Maybe'
+  //. {namespace: Just('sanctuary'), name: 'Maybe', version: 0}
   //.
   //. > S.type([1, 2, 3])
-  //. 'Array'
+  //. {namespace: Nothing, name: 'Array', version: 0}
   //. ```
-  S.type = def('type', {}, [$.Any, $.String], type);
+  S.type =
+  def('type',
+      {},
+      [$.Any,
+       $.RecordType({namespace: $Maybe($.String),
+                     name: $.String,
+                     version: $.Integer})],
+      function(x) {
+        var r = type.parse(type(x));
+        r.namespace = toMaybe(r.namespace);
+        return r;
+      });
 
   //# is :: TypeRep a -> Any -> Boolean
   //.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "sanctuary-def": "0.11.0",
     "sanctuary-type-classes": "5.2.0",
-    "sanctuary-type-identifiers": "1.0.0"
+    "sanctuary-type-identifiers": "2.0.1"
   },
   "devDependencies": {
     "browserify": "13.1.x",

--- a/test/internal/sanctuary.js
+++ b/test/internal/sanctuary.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var $ = require('sanctuary-def');
+var type = require('sanctuary-type-identifiers');
 
 var S = require('../..');
 
@@ -10,7 +11,7 @@ function UnaryType(typeIdent) {
   return $.UnaryType(
     typeIdent,
     '',
-    function(x) { return S.type(x) === typeIdent; },
+    function(x) { return type(x) === typeIdent; },
     function(v) { return [v.value]; }
   )($.Unknown);
 }
@@ -19,7 +20,7 @@ function UnaryType(typeIdent) {
 var UselessType = $.NullaryType(
   'sanctuary/Useless',
   '',
-  function(x) { return S.type(x) === 'sanctuary/Useless'; }
+  function(x) { return type(x) === 'sanctuary/Useless'; }
 );
 
 //  env :: Array Type

--- a/test/type.js
+++ b/test/type.js
@@ -11,36 +11,36 @@ test('type', function() {
 
   eq(typeof S.type, 'function');
   eq(S.type.length, 1);
-  eq(S.type.toString(), 'type :: Any -> String');
+  eq(S.type.toString(), 'type :: Any -> { name :: String, namespace :: Maybe String, version :: Integer }');
 
   var args = (function() { return arguments; }());
-  eq(S.type(args),                'Arguments');
-  eq(S.type([]),                  'Array');
-  eq(S.type(false),               'Boolean');
-  eq(S.type(new Date(0)),         'Date');
-  eq(S.type(new TypeError()),     'Error');
-  eq(S.type(function() {}),       'Function');
-  eq(S.type(null),                'Null');
-  eq(S.type(0),                   'Number');
-  eq(S.type(/(?:)/),              'RegExp');
-  eq(S.type(''),                  'String');
-  eq(S.type(undefined),           'Undefined');
-  eq(S.type(new Boolean(false)),  'Boolean');
-  eq(S.type(new Number(0)),       'Number');
-  eq(S.type(new String('')),      'String');
+  eq(S.type(args),                {namespace: S.Nothing, name: 'Arguments', version: 0});
+  eq(S.type([]),                  {namespace: S.Nothing, name: 'Array', version: 0});
+  eq(S.type(false),               {namespace: S.Nothing, name: 'Boolean', version: 0});
+  eq(S.type(new Date(0)),         {namespace: S.Nothing, name: 'Date', version: 0});
+  eq(S.type(new TypeError()),     {namespace: S.Nothing, name: 'Error', version: 0});
+  eq(S.type(function() {}),       {namespace: S.Nothing, name: 'Function', version: 0});
+  eq(S.type(null),                {namespace: S.Nothing, name: 'Null', version: 0});
+  eq(S.type(0),                   {namespace: S.Nothing, name: 'Number', version: 0});
+  eq(S.type(/(?:)/),              {namespace: S.Nothing, name: 'RegExp', version: 0});
+  eq(S.type(''),                  {namespace: S.Nothing, name: 'String', version: 0});
+  eq(S.type(undefined),           {namespace: S.Nothing, name: 'Undefined', version: 0});
+  eq(S.type(new Boolean(false)),  {namespace: S.Nothing, name: 'Boolean', version: 0});
+  eq(S.type(new Number(0)),       {namespace: S.Nothing, name: 'Number', version: 0});
+  eq(S.type(new String('')),      {namespace: S.Nothing, name: 'String', version: 0});
 
-  eq(S.type(S.Left(42)),  'sanctuary/Either');
-  eq(S.type(S.Right(42)), 'sanctuary/Either');
-  eq(S.type(S.Nothing),   'sanctuary/Maybe');
-  eq(S.type(S.Just(42)),  'sanctuary/Maybe');
+  eq(S.type(S.Left(42)),          {namespace: S.Just('sanctuary'), name: 'Either', version: 0});
+  eq(S.type(S.Right(42)),         {namespace: S.Just('sanctuary'), name: 'Either', version: 0});
+  eq(S.type(S.Nothing),           {namespace: S.Just('sanctuary'), name: 'Maybe', version: 0});
+  eq(S.type(S.Just(42)),          {namespace: S.Just('sanctuary'), name: 'Maybe', version: 0});
 
   function Gizmo() {}
-  Gizmo['@@type'] = 'gadgets/Gizmo';
+  Gizmo['@@type'] = 'gadgets/Gizmo@42';
 
-  eq(S.type(new Gizmo()), 'gadgets/Gizmo');
-  eq(S.type(Gizmo), 'Function');
-  eq(S.type(Gizmo.prototype), 'Object');
+  eq(S.type(new Gizmo()),         {namespace: S.Just('gadgets'), name: 'Gizmo', version: 42});
+  eq(S.type(Gizmo),               {namespace: S.Nothing, name: 'Function', version: 0});
+  eq(S.type(Gizmo.prototype),     {namespace: S.Nothing, name: 'Object', version: 0});
 
-  eq(S.type(vm.runInNewContext('[1, 2, 3]')), 'Array');
+  eq(S.type(vm.runInNewContext('[1, 2, 3]')), {namespace: S.Nothing, name: 'Array', version: 0});
 
 });


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-type-identifiers/releases/tag/v2.0.0>

Commit message:

> This commit updates the return type of `S.type`. Those wishing to access unparsed type identifiers can use sanctuary-type-identifiers directly.
