### PR TITLE
sanctuary-def@0.12.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-def": "0.12.0",
+    "sanctuary-def": "0.12.1",
     "sanctuary-type-classes": "6.0.0",
     "sanctuary-type-identifiers": "2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "make lint test"
   },
   "dependencies": {
-    "sanctuary-def": "0.12.0",
+    "sanctuary-def": "0.12.1",
     "sanctuary-type-classes": "6.0.0",
     "sanctuary-type-identifiers": "2.0.1"
   },


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-def/releases/v0.12.1>

I don't think this change affects Sanctuary, but keeping dependencies up to date is good practice.
