### PR TITLE
array: generalize S.reverse

### DIFF
--- a/test/internal/List.js
+++ b/test/internal/List.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var FL = require('fantasy-land');
+var $ = require('sanctuary-def');
+var Z = require('sanctuary-type-classes');
+var type = require('sanctuary-type-identifiers');
+
+var curry2 = require('./curry2');
+var eq = require('./eq');
+
+
+var List = {prototype: _List.prototype};
+
+List.prototype.constructor = List;
+
+function _List(tag, head, tail) {
+  this.isCons = tag === 'Cons';
+  this.isNil = tag === 'Nil';
+  if (this.isCons) {
+    this.head = head;
+    this.tail = tail;
+  }
+}
+
+List['@@type'] = 'sanctuary/List';
+
+//  Type :: Type -> Type
+List.Type = $.UnaryType(
+  List['@@type'],
+  '',
+  function(x) { return type(x) === List['@@type']; },
+  function(list) {
+    return Z.reduce(function(xs, x) { xs.push(x); return xs; }, [], list);
+  }
+);
+
+//  Nil :: List a
+var Nil = List.Nil = new _List('Nil');
+
+//  Cons :: (a, List a) -> List a
+var Cons = List.Cons = function Cons(head, tail) {
+  eq(arguments.length, Cons.length);
+  return new _List('Cons', head, tail);
+};
+
+List[FL.empty] = function() { return Nil; };
+
+List[FL.of] = function(x) { return Cons(x, Nil); };
+
+List[FL.zero] = List[FL.empty];
+
+List.prototype[FL.equals] = function(other) {
+  return this.isNil ?
+    other.isNil :
+    other.isCons &&
+      Z.equals(other.head, this.head) &&
+      Z.equals(other.tail, this.tail);
+};
+
+List.prototype[FL.concat] = function(other) {
+  return this.isNil ?
+    other :
+    Cons(this.head, Z.concat(this.tail, other));
+};
+
+List.prototype[FL.map] = function(f) {
+  return this.isNil ?
+    Nil :
+    Cons(f(this.head), Z.map(f, this.tail));
+};
+
+List.prototype[FL.ap] = function(other) {
+  return this.isNil || other.isNil ?
+    Nil :
+    Z.concat(Z.map(other.head, this), Z.ap(other.tail, this));
+};
+
+List.prototype[FL.chain] = function(f) {
+  return this.isNil ?
+    Nil :
+    Z.concat(f(this.head), Z.chain(f, this.tail));
+};
+
+List.prototype[FL.alt] = List.prototype[FL.concat];
+
+List.prototype[FL.reduce] = function(f, x) {
+  return this.isNil ?
+    x :
+    Z.reduce(f, f(x, this.head), this.tail);
+};
+
+List.prototype[FL.traverse] = function(typeRep, f) {
+  return this.isNil ?
+    Z.of(typeRep, Nil) :
+    Z.ap(Z.map(curry2(Cons), f(this.head)), Z.traverse(typeRep, f, this.tail));
+};
+
+List.prototype.inspect =
+List.prototype.toString = function() {
+  return this.isNil ?
+    'Nil' :
+    'Cons(' + Z.toString(this.head) + ', ' + Z.toString(this.tail) + ')';
+};
+
+module.exports = List;

--- a/test/internal/sanctuary.js
+++ b/test/internal/sanctuary.js
@@ -5,6 +5,8 @@ var type = require('sanctuary-type-identifiers');
 
 var S = require('../..');
 
+var List = require('./List');
+
 
 //  UnaryType :: String -> Type
 function UnaryType(typeIdent) {
@@ -27,6 +29,7 @@ var UselessType = $.NullaryType(
 var env = S.env.concat([
   UnaryType('sanctuary/Compose'),
   UnaryType('sanctuary/Identity'),
+  List.Type($.Unknown),
   UselessType
 ]);
 

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -1,21 +1,29 @@
 'use strict';
 
-var S = require('..');
+var S = require('./internal/sanctuary');
 
+var List = require('./internal/List');
 var eq = require('./internal/eq');
+
+
+var Cons = List.Cons;
+var Nil = List.Nil;
 
 
 test('reverse', function() {
 
   eq(typeof S.reverse, 'function');
   eq(S.reverse.length, 1);
-  eq(S.reverse.toString(), 'reverse :: List a -> List a');
+  eq(S.reverse.toString(), 'reverse :: (Applicative f, Foldable f, Monoid f) => f a -> f a');
 
   eq(S.reverse([]), []);
+  eq(S.reverse([1]), [1]);
+  eq(S.reverse([1, 2]), [2, 1]);
   eq(S.reverse([1, 2, 3]), [3, 2, 1]);
-  eq(S.reverse(['1', '2', '3']), ['3', '2', '1']);
 
-  eq(S.reverse(''), '');
-  eq(S.reverse('123'), '321');
+  eq(S.reverse(Nil), Nil);
+  eq(S.reverse(Cons(1, Nil)), Cons(1, Nil));
+  eq(S.reverse(Cons(1, Cons(2, Nil))), Cons(2, Cons(1, Nil)));
+  eq(S.reverse(Cons(1, Cons(2, Cons(3, Nil)))), Cons(3, Cons(2, Cons(1, Nil))));
 
 });


### PR DESCRIPTION
:warning: This is a breaking change, as [`reverse`][1] will no longer operate on strings.

This pull request inches us closer to a goal I stated in #411: removing the [List][2] type.


[1]: https://github.com/sanctuary-js/sanctuary/tree/v0.13.2#reverse
[2]: https://github.com/sanctuary-js/sanctuary/tree/v0.13.2#list
