### PR TITLE
array: add S.size

### DIFF
--- a/index.js
+++ b/index.js
@@ -3320,6 +3320,36 @@
 
   //. ### Array
 
+  //# size :: Foldable f => f a -> Integer
+  //.
+  //. Returns the number of elements of the given structure.
+  //.
+  //. ```javascript
+  //. > S.size([])
+  //. 0
+  //.
+  //. > S.size(['foo', 'bar', 'baz'])
+  //. 3
+  //.
+  //. > S.size(Nil)
+  //. 0
+  //.
+  //. > S.size(Cons('foo', Cons('bar', Cons('baz', Nil))))
+  //. 3
+  //.
+  //. > S.size(S.Nothing)
+  //. 0
+  //.
+  //. > S.size(S.Just('quux'))
+  //. 1
+  //. ```
+  function size(foldable) {
+    //  Fast path for arrays.
+    if (Array.isArray(foldable)) return foldable.length;
+    return Z.reduce(function(n, _) { return n + 1; }, 0, foldable);
+  }
+  S.size = def('size', {f: [Z.Foldable]}, [f(a), $.Integer], size);
+
   //# append :: (Applicative f, Semigroup (f a)) => a -> f a -> f a
   //.
   //. Returns the result of appending the first argument to the second.

--- a/test/size.js
+++ b/test/size.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var S = require('./internal/sanctuary');
+
+var List = require('./internal/List');
+var eq = require('./internal/eq');
+
+
+var Cons = List.Cons;
+var Nil = List.Nil;
+
+
+test('size', function() {
+
+  eq(typeof S.size, 'function');
+  eq(S.size.length, 1);
+  eq(S.size.toString(), 'size :: Foldable f => f a -> Integer');
+
+  eq(S.size([]), 0);
+  eq(S.size(['foo']), 1);
+  eq(S.size(['foo', 'bar']), 2);
+  eq(S.size(['foo', 'bar', 'baz']), 3);
+
+  eq(S.size(Nil), 0);
+  eq(S.size(Cons('foo', Nil)), 1);
+  eq(S.size(Cons('foo', Cons('bar', Nil))), 2);
+  eq(S.size(Cons('foo', Cons('bar', Cons('baz', Nil)))), 3);
+
+  eq(S.size(S.Nothing), 0);
+  eq(S.size(S.Just(0)), 1);
+
+});


### PR DESCRIPTION
This is equivalent to Haskell's [`length`][1] function.

I quite often find myself using `S.prop('length')` as `Array a -> Integer`; it will be convenient to be able to use <del>`S.length`</del> <ins>`S.size`</ins> in these situations instead. :)


[1]: http://hackage.haskell.org/package/base-4.9.1.0/docs/Data-Foldable.html#v:length
