### PR TITLE
sanctuary-def@0.13.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-def": "0.12.1",
+    "sanctuary-def": "0.13.0",
     "sanctuary-type-classes": "6.0.0",
     "sanctuary-type-identifiers": "2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "make lint test"
   },
   "dependencies": {
-    "sanctuary-def": "0.12.1",
+    "sanctuary-def": "0.13.0",
     "sanctuary-type-classes": "6.0.0",
     "sanctuary-type-identifiers": "2.0.1"
   },

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -10,7 +10,7 @@ test('parseInt', function() {
 
   eq(typeof S.parseInt, 'function');
   eq(S.parseInt.length, 2);
-  eq(S.parseInt.toString(), 'parseInt :: Integer -> String -> Maybe Integer');
+  eq(S.parseInt.toString(), 'parseInt :: Radix -> String -> Maybe Integer');
 
   eq(S.parseInt(10, '42'), S.Just(42));
   eq(S.parseInt(16, '2A'), S.Just(42));
@@ -90,8 +90,29 @@ test('parseInt', function() {
   eq(S.parseInt(36, '['), S.Nothing);
 
   // Throws if radix is not in [2 .. 36]
-  throws(function() { S.parseInt(1, ''); }, RangeError, 'Radix not in [2 .. 36]');
-  throws(function() { S.parseInt(37, ''); }, RangeError, 'Radix not in [2 .. 36]');
+  throws(function() { S.parseInt(1, ''); },
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseInt :: Radix -> String -> Maybe Integer\n' +
+         '            ^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, NonNegativeInteger, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Radix’.\n');
+
+  throws(function() { S.parseInt(37, ''); },
+         TypeError,
+         'Invalid value\n' +
+         '\n' +
+         'parseInt :: Radix -> String -> Maybe Integer\n' +
+         '            ^^^^^\n' +
+         '              1\n' +
+         '\n' +
+         '1)  37 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, NonNegativeInteger, ValidNumber\n' +
+         '\n' +
+         'The value at position 1 is not a member of ‘Radix’.\n');
 
   // Is not case-sensitive
   eq(S.parseInt(16, 'FF'), S.Just(255));

--- a/test/type.js
+++ b/test/type.js
@@ -11,7 +11,7 @@ test('type', function() {
 
   eq(typeof S.type, 'function');
   eq(S.type.length, 1);
-  eq(S.type.toString(), 'type :: Any -> { name :: String, namespace :: Maybe String, version :: Integer }');
+  eq(S.type.toString(), 'type :: Any -> { name :: String, namespace :: Maybe String, version :: NonNegativeInteger }');
 
   var args = (function() { return arguments; }());
   eq(S.type(args),                {namespace: S.Nothing, name: 'Arguments', version: 0});


### PR DESCRIPTION
<del>I plan to release `sanctuary-def@0.13.0` in the near future based on what is currently on `master`. I'm opening this pull request before doing so in order to verify the changes.</del>

We can now use `$.Thunk` and `$.Predicate`—added in sanctuary-js/sanctuary-def#161—so we no longer need to define these ourselves.

We can now use `$.NonNegativeInteger`—added by @kurtmilam in sanctuary-js/sanctuary-def#165—to more precisely define the return type of `S.type`.
