### PR TITLE
Bugfix: TypeScript definitions cause error TS7006 when building with noImplicitAny.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -532,8 +532,8 @@ export function apSecond<A>(p: Array<A>): <B>(q: Array<B>) => Array<B>;
 export function apSecond<A, B>(p: Apply<A>,   q: Apply<B>):   Apply<B>;
 export function apSecond<A>(p: Apply<A>): <B>(q: Apply<B>) => Apply<B>;
 
-export function of<A>(p: TypeRep,   q: A):   (any) => A;
-export function of<A>(p: TypeRep): (q: A) => (any) => A;
+export function of<A>(p: TypeRep,   q: A):   (a: any) => A;
+export function of<A>(p: TypeRep): (q: A) => (a: any) => A;
 export function of<A>(p: TypeRep,   q: A):   Applicative<A>;
 export function of<A>(p: TypeRep): (q: A) => Applicative<A>;
 
@@ -591,9 +591,9 @@ export function parseInt(radix: Placeholder, s: string): (radix: Integer) => May
 export function parseInt(radix: Integer,   s: string):   Maybe<Integer>;
 export function parseInt(radix: Integer): (s: string) => Maybe<Integer>;
 
-export function parseJson<A>(pred: Placeholder,        s: string): (pred: (any) => boolean) => Maybe<A>;
-export function parseJson<A>(pred: (any) => boolean,   s: string):   Maybe<A>;
-export function parseJson<A>(pred: (any) => boolean): (s: string) => Maybe<A>;
+export function parseJson<A>(pred: Placeholder,        s: string): (pred: (a: any) => boolean) => Maybe<A>;
+export function parseJson<A>(pred: (a: any) => boolean,   s: string):   Maybe<A>;
+export function parseJson<A>(pred: (a: any) => boolean): (s: string) => Maybe<A>;
 
 //  RegExp
 


### PR DESCRIPTION
Definitions like `(any) =>` are untyped params named any (implicit any types) and blow up when building with the noImplicitAny rule turned on. Fixable with placeholder parameter names and explicit types like `(a: any) =>`.

A tsconfig.json that causes the issue:
```json
{
  "compilerOptions": {
    "target": "ES2017",
    "outDir": "dist",
    "rootDir": "src",
    "moduleResolution": "node",
    "module": "commonjs",
    "declaration": true,
    "importHelpers": true,
    "inlineSourceMap": true,
    "listFiles": false,
    "traceResolution": false,
    "pretty": true,
    "types": ["node"],
    "baseUrl": "src",
    "strictNullChecks": true,
    "strict": true,
    "noImplicitAny": true,
    "noImplicitReturns": true,
    "noImplicitThis": true,
    "noUnusedLocals": true
  },
  "include": ["src/**/*.ts"],
  "exclude": ["node_modules/**"],
  "compileOnSave": false
}
```

Errors:
```shell
$ tsc -p ./tsconfig.json

535 export function of<A>(p: TypeRep,   q: A):   (any) => A;
                                                  ~~~

node_modules/sanctuary/index.d.ts(535,47): error TS7006: Parameter 'any' implicitly has an 'any' type.


536 export function of<A>(p: TypeRep): (q: A) => (any) => A;
                                                  ~~~

node_modules/sanctuary/index.d.ts(536,47): error TS7006: Parameter 'any' implicitly has an 'any' type.


594 export function parseJson<A>(pred: Placeholder,        s: string): (pred: (any) => boolean) => Maybe<A>;
                                                                               ~~~

node_modules/sanctuary/index.d.ts(594,76): error TS7006: Parameter 'any' implicitly has an 'any' type.


595 export function parseJson<A>(pred: (any) => boolean,   s: string):   Maybe<A>;
                                        ~~~

node_modules/sanctuary/index.d.ts(595,37): error TS7006: Parameter 'any' implicitly has an 'any' type.


596 export function parseJson<A>(pred: (any) => boolean): (s: string) => Maybe<A>;
                                        ~~~

node_modules/sanctuary/index.d.ts(596,37): error TS7006: Parameter 'any' implicitly has an 'any' type
```

After applying this diff, I was able to compile and run a few simple calls to Sanctuary functions! Looking pretty awesome! 🎉 