### PR TITLE
test: avoid implementation-dependent parsing of date string

### DIFF
--- a/test/toString.js
+++ b/test/toString.js
@@ -40,7 +40,7 @@ test('toString', function() {
   eq(S.toString(new Date(0)), 'new Date("1970-01-01T00:00:00.000Z")');
   eq(S.toString(new Date(42)), 'new Date("1970-01-01T00:00:00.042Z")');
   eq(S.toString(new Date(NaN)), 'new Date(NaN)');
-  eq(S.toString(new Date('2001-02-03T04:05:06')), 'new Date("2001-02-03T04:05:06.000Z")');
+  eq(S.toString(new Date('2001-02-03')), 'new Date("2001-02-03T00:00:00.000Z")');
   eq(S.toString([]), '[]');
   eq(S.toString(['foo']), '["foo"]');
   eq(S.toString(['foo', 'bar', 'baz']), '["foo", "bar", "baz"]');


### PR DESCRIPTION
Fixes #455

[MDN][1]:

> __Note:__ parsing of date strings with the `Date` constructor (and `Date.parse`, they are equivalent) is strongly discouraged due to browser differences and inconsistencies. Support for RFC 2822 format strings is by convention only. Support for ISO 8601 formats differs in that date-only strings (e.g. "1970-01-01") are treated as UTC, not local.

@futpib, please confirm that this addresses the issue for you.


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
