### PR TITLE
A more clever way to ignore only `createSanctuary` body indentation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "root": true,
-  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"]
+  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"],
+  "rules": {
+    "indent": ["error", 2, {"SwitchCase": 1, "FunctionDeclaration": {"parameters": "first"}, "FunctionExpression": {"parameters": "first"}, "CallExpression": {"arguments": "first"}, "ArrayExpression": "first", "ObjectExpression": "first", "ignoredNodes": ["ConditionalExpression", "MemberExpression", "FunctionDeclaration[id.name=createSanctuary] > BlockStatement.body"]}]
+  }
 }

--- a/index.js
+++ b/index.js
@@ -336,8 +336,6 @@
   //  createSanctuary :: Options -> Module
   function createSanctuary(opts) {
 
-  /* eslint-disable indent */
-
   //  checkTypes :: Boolean
   var checkTypes = opts.checkTypes;
 
@@ -4557,8 +4555,6 @@
       splitOnRegex);
 
   return S;
-
-  /* eslint-enable indent */
 
   }
 


### PR DESCRIPTION
Instead of disabling `indent` rule for a range of lines, disable it
for direct children of `createSanctuary` function, thus enabling
`indent` rule checks for it's deeper children.

For example, the following code if put inside `createSanctuary` would
have been considered correct by eslint before this commit:

```js
  def('fromPairs',
    {f: [Z.Foldable]},
    [f($.Pair($.String, a)), $.StrMap(a)],
    fromPairs);
```

After this commit, code like this whould have been reported as
`indent` rule violation.