### PR TITLE
Add value constructor for string maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -3741,6 +3741,22 @@
   //. [type identifier][] is `'Object'` and the values of its enumerable own
   //. properties are all members of type `a`.
 
+  //# singleton :: String -> a -> StrMap a
+  //.
+  //. Takes a string and a value of any type, and returns a string map with
+  //. a single entry (mapping the key to the value).
+  //.
+  //. ```javascript
+  //. > S.singleton('foo', 42)
+  //. {foo: 42}
+  //. ```
+  function singleton(key, val) {
+    var strMap = {};
+    strMap[key] = val;
+    return strMap;
+  }
+  S.singleton = def('singleton', {}, [$.String, a, $.StrMap(a)], singleton);
+
   //# keys :: StrMap a -> Array String
   //.
   //. Returns the keys of the given string map, in arbitrary order.

--- a/test/singleton.js
+++ b/test/singleton.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var S = require('..');
+
+var eq = require('./internal/eq');
+
+
+test('singleton', function() {
+
+  eq(S.singleton('foo', 42), {foo: 42});
+
+});


### PR DESCRIPTION
Followup from [here](https://github.com/sanctuary-js/sanctuary/issues/434#issuecomment-346505904). Name is up for debate, I think `embed` might be nicer.

Something is wrong with my setup it looks like, because tests explode when I run `npm test`. Punting to the CI.

```
node_modules/.bin/istanbul cover node_modules/.bin/_mocha
No coverage information was collected, exit without writing coverage information
/mnt/d/depot/git/sanctuary/node_modules/.bin/_mocha:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:599:28)
    at Object.Module._extensions..js (module.js:646:10)
    at Object.Module._extensions.(anonymous function) [as .js] (/mnt/d/depot/git/sanctuary/node_modules/istanbul/lib/hook.js:109:37)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at runFn (/mnt/d/depot/git/sanctuary/node_modules/istanbul/lib/command/common/run-with-cover.js:122:16)
Makefile:58: recipe for target 'test' failed
make: *** [test] Error 1
npm ERR! Test failed.  See above for more details.
```