### PR TITLE
sanctuary-type-classes@7.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "sanctuary-def": "0.13.1",
-    "sanctuary-type-classes": "7.1.0",
+    "sanctuary-type-classes": "7.1.1",
     "sanctuary-type-identifiers": "2.0.1"
   },
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "sanctuary-def": "0.13.1",
-    "sanctuary-type-classes": "7.1.0",
+    "sanctuary-type-classes": "7.1.1",
     "sanctuary-type-identifiers": "2.0.1"
   },
   "devDependencies": {

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -28,4 +28,6 @@ test('sequence', function() {
   eq(S.sequence(S.Either, Identity(S.Left('A'))), S.Left('A'));
   eq(S.sequence(S.Either, Identity(S.Right(-1))), S.Right(Identity(-1)));
 
+  eq(S.sequence(Array, {a: [1, 2], b: [3, 4]}), [{a: 1, b: 3}, {a: 1, b: 4}, {a: 2, b: 3}, {a: 2, b: 4}]);
+
 });

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -32,4 +32,6 @@ test('traverse', function() {
   eq(S.traverse(Identity, S.I, [Identity(1), Identity(2)]), Identity([1, 2]));
   eq(S.traverse(Identity, S.I, [Identity(1), Identity(2), Identity(3)]), Identity([1, 2, 3]));
 
+  eq(S.traverse(Array, S.I, {a: [1, 2], b: [3, 4]}), [{a: 1, b: 3}, {a: 1, b: 4}, {a: 2, b: 3}, {a: 2, b: 4}]);
+
 });


### PR DESCRIPTION
This brings the fix from sanctuary-js/sanctuary-type-classes#75 to this library, so `S.sequence` and `S.traverse` now behave correctly when applied to string maps.

/cc @masaeedu
