### PR TITLE
env: remove refinement types from default environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,19 +315,9 @@
 
   //  defaultEnv :: Array Type
   var defaultEnv = Z.concat($.env, [
-    $.FiniteNumber,
-    $.NonZeroFiniteNumber,
     $Either($.Unknown, $.Unknown),
-    Fn($.Unknown, $.Unknown),
-    $.GlobalRegExp,
-    $.NonGlobalRegExp,
-    $.Integer,
-    $.NonNegativeInteger,
     $Maybe($.Unknown),
-    $.Pair($.Unknown, $.Unknown),
-    $.RegexFlags,
-    $.ValidDate,
-    $.ValidNumber
+    $.Pair($.Unknown, $.Unknown)
   ]);
 
   //  Options :: Type

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -98,7 +98,7 @@ test('parseInt', function() {
          '            ^^^^^\n' +
          '              1\n' +
          '\n' +
-         '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, NonNegativeInteger, ValidNumber\n' +
+         '1)  1 :: Number\n' +
          '\n' +
          'The value at position 1 is not a member of ‘Radix’.\n');
 
@@ -110,7 +110,7 @@ test('parseInt', function() {
          '            ^^^^^\n' +
          '              1\n' +
          '\n' +
-         '1)  37 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, NonNegativeInteger, ValidNumber\n' +
+         '1)  37 :: Number\n' +
          '\n' +
          'The value at position 1 is not a member of ‘Radix’.\n');
 


### PR DESCRIPTION
Commit message:

> This dramatically lowers the performance cost of type checking collections in some cases.

The difference is *staggering* in some cases.

```console
~/github.com/sanctuary-js/sanctuary (master)
$ time node -e 'const S = require("./"), xs = []; for (let id = 1; id <= 8; id += 1) xs.push({id}); S.I(xs)'

real	1m9.221s
user	1m8.379s
sys	0m0.790s
```

```console
~/github.com/sanctuary-js/sanctuary (davidchambers/env)
$ time node -e 'const S = require("./"), xs = []; for (let id = 1; id <= 1000; id += 1) xs.push({id}); S.I(xs)'

real	0m0.450s
user	0m0.456s
sys	0m0.021s
```

Increasing the length of `xs` from 8 to 9 on `master` results in the heap consuming all available memory on my computer. On `davidchambers/env` increasing the length of `xs` from 8 to 1000 only adds about 200 milliseconds to the run time.

Removing refinement types from the default environment will result in less informative error messages in some cases (but much clearer error messages in certain other cases). @Avaq has proposed that sanctuary-def should *explicitly* support refinement types (sanctuary-js/sanctuary-def#162). Were it to do so, refinement types could be ignored when resolving type variables, but could be considered when enumerating a value's types in an error message. The best of both worlds!

Many thanks to @mfidemraizer for providing a minimal test case which made it easy to diagnose this long-standing issue. :clap:
