### PR TITLE
documentation: use placeholder for version-specific type URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@
 //. //
 //. //   The value at position 1 is not a member of ‘FiniteNumber’.
 //. //
-//. //   See https://github.com/sanctuary-js/sanctuary-def/tree/v0.12.0#FiniteNumber for information about the sanctuary-def/FiniteNumber type.
+//. //   See v:sanctuary-js/sanctuary-def#FiniteNumber for information about the sanctuary-def/FiniteNumber type.
 //. ```
 //.
 //. Compare this to the behaviour of Ramda's unchecked equivalent:

--- a/scripts/version-urls
+++ b/scripts/version-urls
@@ -12,7 +12,7 @@ var pkg = require('../package.json');
 var deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
 
 process.stdout.write(fs.readFileSync(process.argv[2], 'utf8').replace(
-  new RegExp(' v:(.+)/(.+)', 'g'),
+  / v:(\S+)[/](\S+)/g,
   function(_, owner, rest) {
     var parts = rest.split(/(?=#)/);
     var name = parts[0];


### PR DESCRIPTION
Remembering to update such things manually is clearly not a good solution.
