### PR TITLE
hide doctest-specific imports from build tools

### DIFF
--- a/index.js
+++ b/index.js
@@ -410,11 +410,12 @@
 
   /* istanbul ignore if */
   if (typeof __doctest !== 'undefined') {
+    /* global __doctest:false */
     /* eslint-disable no-unused-vars */
-    var _List = require('./test/internal/List');
+    var _List = __doctest.require('./test/internal/List');
     var Cons = _List.Cons;
     var Nil = _List.Nil;
-    var Sum = require('./test/internal/Sum');
+    var Sum = __doctest.require('./test/internal/Sum');
     /* eslint-enable no-unused-vars */
     env = Z.concat(env, [_List.Type($.Unknown), Sum.Type]);
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "browserify": "13.1.x",
-    "doctest": "0.12.x",
+    "doctest": "0.13.x",
     "eslint": "4.9.x",
     "fantasy-land": "3.4.0",
     "istanbul": "0.4.x",


### PR DESCRIPTION
Fixes #469

@dakom, does updating your `sanctuary` dependency to `sanctuary-js/sanctuary#4f6826d` fix your issue?
