### PR TITLE
test: use equals(lhs)(rhs) form in jsc.assert blocks

### DIFF
--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -32,7 +32,9 @@ test('groupBy', function() {
   eq(S.groupBy(zeroSum, [2, -3, 3, 3, 3, 4, -4, 4]), [[2], [-3, 3, 3, 3], [4, -4], [4]]);
 
   jsc.assert(jsc.forall('nat -> nat -> bool', 'array nat', function(f, xs) {
-    return equals(S.join(S.groupBy(f, xs)))(xs);
+    var lhs = S.join(S.groupBy(f, xs));
+    var rhs = xs;
+    return equals(lhs)(rhs);
   }), {tests: 1000});
 
 });

--- a/test/insert.js
+++ b/test/insert.js
@@ -5,6 +5,7 @@ var jsc = require('jsverify');
 var S = require('..');
 
 var eq = require('./internal/eq');
+var equals = require('./internal/equals');
 
 
 test('insert', function() {
@@ -19,7 +20,9 @@ test('insert', function() {
 
   jsc.assert(jsc.forall(jsc.string, jsc.number, jsc.dict(jsc.number), function(key, val, map) {
     var insert = S.insert(key, val);
-    return S.equals(insert(insert(map)), insert(map));
+    var lhs = insert(insert(map));
+    var rhs = insert(map);
+    return equals(lhs)(rhs);
   }), {tests: 1000});
 
 });

--- a/test/remove.js
+++ b/test/remove.js
@@ -5,6 +5,7 @@ var jsc = require('jsverify');
 var S = require('..');
 
 var eq = require('./internal/eq');
+var equals = require('./internal/equals');
 
 
 test('remove', function() {
@@ -19,7 +20,9 @@ test('remove', function() {
 
   jsc.assert(jsc.forall(jsc.string, jsc.dict(jsc.number), function(key, map) {
     var remove = S.remove(key);
-    return S.equals(remove(remove(map)), remove(map));
+    var lhs = remove(remove(map));
+    var rhs = remove(map);
+    return equals(lhs)(rhs);
   }), {tests: 1000});
 
 });

--- a/test/splitOn.js
+++ b/test/splitOn.js
@@ -5,6 +5,7 @@ var jsc = require('jsverify');
 var S = require('..');
 
 var eq = require('./internal/eq');
+var equals = require('./internal/equals');
 
 
 test('splitOn', function() {
@@ -26,7 +27,9 @@ test('splitOn', function() {
     var i = jsc.random(min, max);
     var j = jsc.random(min, max);
     var s = t.slice(Math.min(i, j), Math.max(i, j));
-    return S.joinWith(s, S.splitOn(s, t)) === t;
+    var lhs = S.joinWith(s, S.splitOn(s, t));
+    var rhs = t;
+    return equals(lhs)(rhs);
   }), {tests: 1000});
 
 });

--- a/test/splitOnRegex.js
+++ b/test/splitOnRegex.js
@@ -5,6 +5,7 @@ var jsc = require('jsverify');
 var S = require('..');
 
 var eq = require('./internal/eq');
+var equals = require('./internal/equals');
 
 
 test('splitOnRegex', function() {
@@ -53,7 +54,9 @@ test('splitOnRegex', function() {
     var i = jsc.random(min, max);
     var j = jsc.random(min, max);
     var s = t.slice(Math.min(i, j), Math.max(i, j));
-    return S.joinWith(s, S.splitOnRegex(S.regex('g', S.regexEscape(s)), t)) === t;
+    var lhs = S.joinWith(s, S.splitOnRegex(S.regex('g', S.regexEscape(s)), t));
+    var rhs = t;
+    return equals(lhs)(rhs);
   }), {tests: 1000});
 
 });


### PR DESCRIPTION
Currently we use a mixture of `equals(lhs)(rhs)`, `S.equals(lhs, rhs)`, and `lhs === rhs`. There's no reason for this inconsistency.
