### PR TITLE
classify: change S.is to take a sanctuary-def Type value

### DIFF
--- a/index.js
+++ b/index.js
@@ -451,32 +451,22 @@
         return r;
       });
 
-  //# is :: TypeRep a -> Any -> Boolean
+  //# is :: Type -> Any -> Boolean
   //.
-  //. Takes a [type representative](#type-representatives) and a value of any
-  //. type and returns `true` [iff][] the given value is of the specified type.
-  //. Subtyping is not respected.
+  //. Returns `true` [iff][] the given value is a member of the specified type.
+  //. See [`$.test`][] for details.
   //.
   //. ```javascript
-  //. > S.is(Number, 42)
+  //. > S.is($.Array($.Integer), [1, 2, 3])
   //. true
   //.
-  //. > S.is(Object, 42)
-  //. false
-  //.
-  //. > S.is(String, 42)
+  //. > S.is($.Array($.Integer), [1, 2, 3.14])
   //. false
   //. ```
-  function is(typeRep, x) {
-    var xType = type(x);
-    if ($.String._test(typeRep['@@type'])) {
-      return xType === typeRep['@@type'];
-    } else {
-      var match = /function (\w*)/.exec(typeRep);
-      return match != null && match[1] === xType;
-    }
+  function is(type, x) {
+    return $.test(env, type, x);
   }
-  S.is = def('is', {}, [TypeRep(a), $.Any, $.Boolean], is);
+  S.is = def('is', {}, [$.Type, $.Any, $.Boolean], is);
 
   //. ### Showable
 
@@ -3699,19 +3689,19 @@
   //. See also [`gets`](#gets) and [`prop`](#prop).
   //.
   //. ```javascript
-  //. > S.get(S.is(Number), 'x', {x: 1, y: 2})
+  //. > S.get(S.is($.Number), 'x', {x: 1, y: 2})
   //. Just(1)
   //.
-  //. > S.get(S.is(Number), 'x', {x: '1', y: '2'})
+  //. > S.get(S.is($.Number), 'x', {x: '1', y: '2'})
   //. Nothing
   //.
-  //. > S.get(S.is(Number), 'x', {})
+  //. > S.get(S.is($.Number), 'x', {})
   //. Nothing
   //.
-  //. > S.get($.test([], $.Array($.Number)), 'x', {x: [1, 2, 3]})
+  //. > S.get(S.is($.Array($.Number)), 'x', {x: [1, 2, 3]})
   //. Just([1, 2, 3])
   //.
-  //. > S.get($.test([], $.Array($.Number)), 'x', {x: [1, 2, 3, null]})
+  //. > S.get(S.is($.Array($.Number)), 'x', {x: [1, 2, 3, null]})
   //. Nothing
   //. ```
   function get(pred, key, x) {
@@ -3733,13 +3723,13 @@
   //. See also [`get`](#get).
   //.
   //. ```javascript
-  //. > S.gets(S.is(Number), ['a', 'b', 'c'], {a: {b: {c: 42}}})
+  //. > S.gets(S.is($.Number), ['a', 'b', 'c'], {a: {b: {c: 42}}})
   //. Just(42)
   //.
-  //. > S.gets(S.is(Number), ['a', 'b', 'c'], {a: {b: {c: '42'}}})
+  //. > S.gets(S.is($.Number), ['a', 'b', 'c'], {a: {b: {c: '42'}}})
   //. Nothing
   //.
-  //. > S.gets(S.is(Number), ['a', 'b', 'c'], {})
+  //. > S.gets(S.is($.Number), ['a', 'b', 'c'], {})
   //. Nothing
   //. ```
   function gets(pred, keys, x) {
@@ -4231,16 +4221,16 @@
   //. result satisfies the predicate; Nothing otherwise.
   //.
   //. ```javascript
-  //. > S.parseJson($.test([], $.Array($.Integer)), '[')
+  //. > S.parseJson(S.is($.Array($.Integer)), '[')
   //. Nothing
   //.
-  //. > S.parseJson($.test([], $.Array($.Integer)), '["1","2","3"]')
+  //. > S.parseJson(S.is($.Array($.Integer)), '["1","2","3"]')
   //. Nothing
   //.
-  //. > S.parseJson($.test([], $.Array($.Integer)), '[0,1.5,3,4.5]')
+  //. > S.parseJson(S.is($.Array($.Integer)), '[0,1.5,3,4.5]')
   //. Nothing
   //.
-  //. > S.parseJson($.test([], $.Array($.Integer)), '[1,2,3]')
+  //. > S.parseJson(S.is($.Array($.Integer)), '[1,2,3]')
   //. Just([1, 2, 3])
   //. ```
   function parseJson(pred, s) {
@@ -4631,6 +4621,7 @@
 //. [Semigroupoid]:     v:fantasyland/fantasy-land#semigroupoid
 //. [Traversable]:      v:fantasyland/fantasy-land#traversable
 //. [UnaryType]:        v:sanctuary-js/sanctuary-def#UnaryType
+//. [`$.test`]:         v:sanctuary-js/sanctuary-def#test
 //. [`Z.alt`]:          v:sanctuary-js/sanctuary-type-classes#alt
 //. [`Z.ap`]:           v:sanctuary-js/sanctuary-type-classes#ap
 //. [`Z.apFirst`]:      v:sanctuary-js/sanctuary-type-classes#apFirst

--- a/test/get.js
+++ b/test/get.js
@@ -15,19 +15,17 @@ test('get', function() {
   eq(S.get.length, 3);
   eq(S.get.toString(), 'get :: (Any -> Boolean) -> String -> a -> Maybe b');
 
-  eq(S.get(S.is(Number), 'x', {x: 0, y: 42}), S.Just(0));
-  eq(S.get(S.is(Number), 'y', {x: 0, y: 42}), S.Just(42));
-  eq(S.get(S.is(Number), 'z', {x: 0, y: 42}), S.Nothing);
-  eq(S.get(S.is(String), 'z', {x: 0, y: 42}), S.Nothing);
-  eq(S.get(S.is(String), 'x', {x: 0, y: 42}), S.Nothing);
-
-  eq(S.get(S.is(RegExp), 'x', {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
-  eq(S.get(S.is(vm.runInNewContext('RegExp')), 'x', {x: /.*/}), S.Just(/.*/));
+  eq(S.get(S.is($.Number), 'x', {x: 0, y: 42}), S.Just(0));
+  eq(S.get(S.is($.Number), 'y', {x: 0, y: 42}), S.Just(42));
+  eq(S.get(S.is($.Number), 'z', {x: 0, y: 42}), S.Nothing);
+  eq(S.get(S.is($.String), 'z', {x: 0, y: 42}), S.Nothing);
+  eq(S.get(S.is($.String), 'x', {x: 0, y: 42}), S.Nothing);
+  eq(S.get(S.is($.RegExp), 'x', {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
 
   eq(S.get(S.K(true), 'valueOf', null), S.Nothing);
   eq(S.get(S.K(true), 'valueOf', undefined), S.Nothing);
 
-  eq(S.get($.test([], $.Array($.Number)), 'x', {x: [1, 2]}), S.Just([1, 2]));
-  eq(S.get($.test([], $.Array($.Number)), 'x', {x: [1, 2, null]}), S.Nothing);
+  eq(S.get(S.is($.Array($.Number)), 'x', {x: [1, 2]}), S.Just([1, 2]));
+  eq(S.get(S.is($.Array($.Number)), 'x', {x: [1, 2, null]}), S.Nothing);
 
 });

--- a/test/gets.js
+++ b/test/gets.js
@@ -15,21 +15,19 @@ test('gets', function() {
   eq(S.gets.length, 3);
   eq(S.gets.toString(), 'gets :: (Any -> Boolean) -> Array String -> a -> Maybe b');
 
-  eq(S.gets(S.is(Number), ['x'], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(S.is(Number), ['y'], {x: {z: 0}, y: 42}), S.Just(42));
-  eq(S.gets(S.is(Number), ['z'], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(S.is(Number), ['x', 'z'], {x: {z: 0}, y: 42}), S.Just(0));
-  eq(S.gets(S.is(Number), ['a', 'b', 'c'], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(S.is(Number), [], {x: {z: 0}, y: 42}), S.Nothing);
-  eq(S.gets(S.is(Object), [], {x: {z: 0}, y: 42}), S.Just({x: {z: 0}, y: 42}));
-
-  eq(S.gets(S.is(RegExp), ['x'], {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
-  eq(S.gets(S.is(vm.runInNewContext('RegExp')), ['x'], {x: /.*/}), S.Just(/.*/));
+  eq(S.gets(S.is($.Number), ['x'], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is($.Number), ['y'], {x: {z: 0}, y: 42}), S.Just(42));
+  eq(S.gets(S.is($.Number), ['z'], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is($.Number), ['x', 'z'], {x: {z: 0}, y: 42}), S.Just(0));
+  eq(S.gets(S.is($.Number), ['a', 'b', 'c'], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is($.Number), [], {x: {z: 0}, y: 42}), S.Nothing);
+  eq(S.gets(S.is($.Object), [], {x: {z: 0}, y: 42}), S.Just({x: {z: 0}, y: 42}));
+  eq(S.gets(S.is($.RegExp), ['x'], {x: vm.runInNewContext('/.*/')}), S.Just(/.*/));
 
   eq(S.gets(S.K(true), ['valueOf'], null), S.Nothing);
   eq(S.gets(S.K(true), ['valueOf'], undefined), S.Nothing);
 
-  eq(S.gets($.test([], $.Array($.Number)), ['x'], {x: [1, 2]}), S.Just([1, 2]));
-  eq(S.gets($.test([], $.Array($.Number)), ['x'], {x: [1, 2, null]}), S.Nothing);
+  eq(S.gets(S.is($.Array($.Number)), ['x'], {x: [1, 2]}), S.Just([1, 2]));
+  eq(S.gets(S.is($.Array($.Number)), ['x'], {x: [1, 2, null]}), S.Nothing);
 
 });

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -13,11 +13,10 @@ test('parseJson', function() {
   eq(S.parseJson.length, 2);
   eq(S.parseJson.toString(), 'parseJson :: (Any -> Boolean) -> String -> Maybe a');
 
-  eq(S.parseJson(S.is(Object), '[Invalid JSON]'), S.Nothing);
-  eq(S.parseJson(S.is(Array), '{"foo":"bar"}'), S.Nothing);
-  eq(S.parseJson(S.is(Array), '["foo","bar"]'), S.Just(['foo', 'bar']));
-
-  eq(S.parseJson($.test([], $.Array($.Number)), '[1,2]'), S.Just([1, 2]));
-  eq(S.parseJson($.test([], $.Array($.Number)), '[1,2,null]'), S.Nothing);
+  eq(S.parseJson(S.is($.Any), '[Invalid JSON]'), S.Nothing);
+  eq(S.parseJson(S.is($.Array($.Any)), '{"foo":"bar"}'), S.Nothing);
+  eq(S.parseJson(S.is($.Array($.Any)), '["foo","bar"]'), S.Just(['foo', 'bar']));
+  eq(S.parseJson(S.is($.Array($.Number)), '[1,2]'), S.Just([1, 2]));
+  eq(S.parseJson(S.is($.Array($.Number)), '[1,2,null]'), S.Nothing);
 
 });


### PR DESCRIPTION
Closes #502

This pull request greatly increases the expressive power of `S.is` by allowing us to specify types such as `Array (Maybe Integer)` rather than `Array ???`.

If this pull request is accepted, #481 will no longer be warranted.

/cc @futpib, @gautaz, @miwillhite, @najlachamseddine, @tomkel
