### PR TITLE
array: remove unprincipled List type constructor

### DIFF
--- a/test/Maybe/Maybe.js
+++ b/test/Maybe/Maybe.js
@@ -128,7 +128,7 @@ suite('Maybe', function() {
 
     monadLaws.leftIdentity(
       jsc.constant(S.head),
-      jsc.string
+      jsc.array(jsc.number)
     );
 
     monadLaws.rightIdentity(

--- a/test/at.js
+++ b/test/at.js
@@ -9,7 +9,7 @@ test('at', function() {
 
   eq(typeof S.at, 'function');
   eq(S.at.length, 2);
-  eq(S.at.toString(), 'at :: Integer -> List a -> Maybe a');
+  eq(S.at.toString(), 'at :: Integer -> Array a -> Maybe a');
 
   eq(S.at(-4, ['foo', 'bar', 'baz']), S.Nothing);
   eq(S.at(-3, ['foo', 'bar', 'baz']), S.Just('foo'));

--- a/test/drop.js
+++ b/test/drop.js
@@ -9,7 +9,7 @@ test('drop', function() {
 
   eq(typeof S.drop, 'function');
   eq(S.drop.length, 2);
-  eq(S.drop.toString(), 'drop :: Integer -> List a -> Maybe (List a)');
+  eq(S.drop.toString(), 'drop :: Integer -> Array a -> Maybe (Array a)');
 
   eq(S.drop(0, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
   eq(S.drop(1, [1, 2, 3, 4, 5]), S.Just([2, 3, 4, 5]));
@@ -18,14 +18,6 @@ test('drop', function() {
   eq(S.drop(4, [1, 2, 3, 4, 5]), S.Just([5]));
   eq(S.drop(5, [1, 2, 3, 4, 5]), S.Just([]));
   eq(S.drop(6, [1, 2, 3, 4, 5]), S.Nothing);
-
-  eq(S.drop(0, '12345'), S.Just('12345'));
-  eq(S.drop(1, '12345'), S.Just('2345'));
-  eq(S.drop(2, '12345'), S.Just('345'));
-  eq(S.drop(3, '12345'), S.Just('45'));
-  eq(S.drop(4, '12345'), S.Just('5'));
-  eq(S.drop(5, '12345'), S.Just(''));
-  eq(S.drop(6, '12345'), S.Nothing);
 
   eq(S.drop(-1, [1, 2, 3, 4, 5]), S.Nothing);
 

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -9,7 +9,7 @@ test('dropLast', function() {
 
   eq(typeof S.dropLast, 'function');
   eq(S.dropLast.length, 2);
-  eq(S.dropLast.toString(), 'dropLast :: Integer -> List a -> Maybe (List a)');
+  eq(S.dropLast.toString(), 'dropLast :: Integer -> Array a -> Maybe (Array a)');
 
   eq(S.dropLast(0, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
   eq(S.dropLast(1, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4]));
@@ -18,14 +18,6 @@ test('dropLast', function() {
   eq(S.dropLast(4, [1, 2, 3, 4, 5]), S.Just([1]));
   eq(S.dropLast(5, [1, 2, 3, 4, 5]), S.Just([]));
   eq(S.dropLast(6, [1, 2, 3, 4, 5]), S.Nothing);
-
-  eq(S.dropLast(0, '12345'), S.Just('12345'));
-  eq(S.dropLast(1, '12345'), S.Just('1234'));
-  eq(S.dropLast(2, '12345'), S.Just('123'));
-  eq(S.dropLast(3, '12345'), S.Just('12'));
-  eq(S.dropLast(4, '12345'), S.Just('1'));
-  eq(S.dropLast(5, '12345'), S.Just(''));
-  eq(S.dropLast(6, '12345'), S.Nothing);
 
   eq(S.dropLast(-1, [1, 2, 3, 4, 5]), S.Nothing);
 

--- a/test/head.js
+++ b/test/head.js
@@ -9,7 +9,7 @@ test('head', function() {
 
   eq(typeof S.head, 'function');
   eq(S.head.length, 1);
-  eq(S.head.toString(), 'head :: List a -> Maybe a');
+  eq(S.head.toString(), 'head :: Array a -> Maybe a');
 
   eq(S.head([]), S.Nothing);
   eq(S.head(['foo']), S.Just('foo'));

--- a/test/init.js
+++ b/test/init.js
@@ -9,7 +9,7 @@ test('init', function() {
 
   eq(typeof S.init, 'function');
   eq(S.init.length, 1);
-  eq(S.init.toString(), 'init :: List a -> Maybe (List a)');
+  eq(S.init.toString(), 'init :: Array a -> Maybe (Array a)');
 
   eq(S.init([]), S.Nothing);
   eq(S.init(['foo']), S.Just([]));

--- a/test/last.js
+++ b/test/last.js
@@ -9,7 +9,7 @@ test('last', function() {
 
   eq(typeof S.last, 'function');
   eq(S.last.length, 1);
-  eq(S.last.toString(), 'last :: List a -> Maybe a');
+  eq(S.last.toString(), 'last :: Array a -> Maybe a');
 
   eq(S.last([]), S.Nothing);
   eq(S.last(['foo']), S.Just('foo'));

--- a/test/slice.js
+++ b/test/slice.js
@@ -9,7 +9,7 @@ test('slice', function() {
 
   eq(typeof S.slice, 'function');
   eq(S.slice.length, 3);
-  eq(S.slice.toString(), 'slice :: Integer -> Integer -> List a -> Maybe (List a)');
+  eq(S.slice.toString(), 'slice :: Integer -> Integer -> Array a -> Maybe (Array a)');
 
   eq(S.slice(6, 1, [1, 2, 3, 4, 5]), S.Nothing);
   eq(S.slice(1, 6, [1, 2, 3, 4, 5]), S.Nothing);
@@ -27,9 +27,5 @@ test('slice', function() {
   eq(S.slice(1, -2, [1, 2, 3, 4, 5]), S.Just([2, 3]));
 
   eq(S.slice(0, 5, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
-
-  eq(S.slice(1, -3, 'abcde'), S.Just('b'));
-  eq(S.slice(2, -3, 'abcde'), S.Just(''));
-  eq(S.slice(3, -3, 'abcde'), S.Nothing);
 
 });

--- a/test/tail.js
+++ b/test/tail.js
@@ -9,7 +9,7 @@ test('tail', function() {
 
   eq(typeof S.tail, 'function');
   eq(S.tail.length, 1);
-  eq(S.tail.toString(), 'tail :: List a -> Maybe (List a)');
+  eq(S.tail.toString(), 'tail :: Array a -> Maybe (Array a)');
 
   eq(S.tail([]), S.Nothing);
   eq(S.tail(['foo']), S.Just([]));

--- a/test/take.js
+++ b/test/take.js
@@ -9,7 +9,7 @@ test('take', function() {
 
   eq(typeof S.take, 'function');
   eq(S.take.length, 2);
-  eq(S.take.toString(), 'take :: Integer -> List a -> Maybe (List a)');
+  eq(S.take.toString(), 'take :: Integer -> Array a -> Maybe (Array a)');
 
   eq(S.take(0, [1, 2, 3, 4, 5]), S.Just([]));
   eq(S.take(1, [1, 2, 3, 4, 5]), S.Just([1]));
@@ -18,14 +18,6 @@ test('take', function() {
   eq(S.take(4, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4]));
   eq(S.take(5, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
   eq(S.take(6, [1, 2, 3, 4, 5]), S.Nothing);
-
-  eq(S.take(0, '12345'), S.Just(''));
-  eq(S.take(1, '12345'), S.Just('1'));
-  eq(S.take(2, '12345'), S.Just('12'));
-  eq(S.take(3, '12345'), S.Just('123'));
-  eq(S.take(4, '12345'), S.Just('1234'));
-  eq(S.take(5, '12345'), S.Just('12345'));
-  eq(S.take(6, '12345'), S.Nothing);
 
   eq(S.take(-1, [1, 2, 3, 4, 5]), S.Nothing);
 

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -9,7 +9,7 @@ test('takeLast', function() {
 
   eq(typeof S.takeLast, 'function');
   eq(S.takeLast.length, 2);
-  eq(S.takeLast.toString(), 'takeLast :: Integer -> List a -> Maybe (List a)');
+  eq(S.takeLast.toString(), 'takeLast :: Integer -> Array a -> Maybe (Array a)');
 
   eq(S.takeLast(0, [1, 2, 3, 4, 5]), S.Just([]));
   eq(S.takeLast(1, [1, 2, 3, 4, 5]), S.Just([5]));
@@ -18,14 +18,6 @@ test('takeLast', function() {
   eq(S.takeLast(4, [1, 2, 3, 4, 5]), S.Just([2, 3, 4, 5]));
   eq(S.takeLast(5, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
   eq(S.takeLast(6, [1, 2, 3, 4, 5]), S.Nothing);
-
-  eq(S.takeLast(0, '12345'), S.Just(''));
-  eq(S.takeLast(1, '12345'), S.Just('5'));
-  eq(S.takeLast(2, '12345'), S.Just('45'));
-  eq(S.takeLast(3, '12345'), S.Just('345'));
-  eq(S.takeLast(4, '12345'), S.Just('2345'));
-  eq(S.takeLast(5, '12345'), S.Just('12345'));
-  eq(S.takeLast(6, '12345'), S.Nothing);
 
   eq(S.takeLast(-1, [1, 2, 3, 4, 5]), S.Nothing);
 


### PR DESCRIPTION
The time has come. :)

The following functions will no longer operate on strings:

  - `S.at`
  - `S.drop`
  - `S.dropLast`
  - `S.head`
  - `S.init`
  - `S.last`
  - `S.slice`
  - `S.tail`
  - `S.take`
  - `S.takeLast`
