### PR TITLE
update S.env to reference the module's environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,13 +221,15 @@
     var Cons = (__doctest.require ('./test/internal/List')).Cons;
     var Sum = __doctest.require ('./test/internal/Sum');
     var S = (function(S) {
-      return S.create ({
+      var S_ = S.create ({
         checkTypes: true,
         env: S.env.concat ([
           (__doctest.require ('./test/internal/List')).Type ($.Unknown),
           Sum.Type
         ])
       });
+      S_.env = S.env;  // see S.env doctest
+      return S_;
     } (require ('.')));
     /* eslint-enable no-unused-vars */
   }
@@ -336,25 +338,6 @@
      })
     (K ([]));
 
-  //  defaultEnv :: Array Type
-  var defaultEnv = Z.concat ($.env, [
-    $.FiniteNumber,
-    $.NonZeroFiniteNumber,
-    $Either ($.Unknown) ($.Unknown),
-    Fn ($.Unknown) ($.Unknown),
-    $.GlobalRegExp,
-    $.NonGlobalRegExp,
-    $.Integer,
-    $.NonNegativeInteger,
-    $Maybe ($.Unknown),
-    $.Array2 ($.Unknown) ($.Unknown),
-    $.RegexFlags,
-    $.Type,
-    $.TypeClass,
-    $.ValidDate,
-    $.ValidNumber
-  ]);
-
   //  Options :: Type
   var Options = $.RecordType ({checkTypes: $.Boolean, env: $.Array ($.Any)});
 
@@ -413,7 +396,7 @@
   function create(opts) {
     var def = $.create (opts);
     var S = {
-      env: defaultEnv,
+      env: opts.env,
       is: def ('is') ({}) ([$.Type, $.Any, $.Boolean]) ($.test (opts.env)),
       MaybeType: $Maybe,
       Maybe: Maybe,
@@ -434,8 +417,8 @@
 
   //# env :: Array Type
   //.
-  //. The default environment, which may be used as is or as the basis of a
-  //. custom environment in conjunction with [`create`](#create).
+  //. The Sanctuary module's environment (`(S.create ({checkTypes, env})).env`
+  //. is a reference to `env`). Useful in conjunction with [`create`](#create).
   //.
   //. ```javascript
   //. > S.env
@@ -5152,7 +5135,26 @@
     impl: splitOnRegex
   };
 
-  return create ({checkTypes: true, env: defaultEnv});
+  return create ({
+    checkTypes: true,
+    env: Z.concat ($.env, [
+      $.FiniteNumber,
+      $.NonZeroFiniteNumber,
+      $Either ($.Unknown) ($.Unknown),
+      Fn ($.Unknown) ($.Unknown),
+      $.GlobalRegExp,
+      $.NonGlobalRegExp,
+      $.Integer,
+      $.NonNegativeInteger,
+      $Maybe ($.Unknown),
+      $.Array2 ($.Unknown) ($.Unknown),
+      $.RegexFlags,
+      $.Type,
+      $.TypeClass,
+      $.ValidDate,
+      $.ValidNumber
+    ])
+  });
 
 }));
 

--- a/test/create.js
+++ b/test/create.js
@@ -32,6 +32,11 @@ test ('create', function() {
   eq (S.sort (Object.keys (uncheckedDefaultEnv))) (expected);
   eq (S.sort (Object.keys (uncheckedCustomEnv))) (expected);
 
+  eq (checkedDefaultEnv.env) (S.env);
+  eq (checkedCustomEnv.env) (customEnv);
+  eq (uncheckedDefaultEnv.env) (S.env);
+  eq (uncheckedCustomEnv.env) (customEnv);
+
   eq (uncheckedDefaultEnv.add (1) (42)) (S.add (1) (42));
   eq (uncheckedDefaultEnv.add (1) ('XXX')) ('1XXX');
 


### PR DESCRIPTION
`S.env` is currently a reference to the default environment for *every* Sanctuary module `S`. It would be more useful for `S.env` to reference the particular environment provided when creating `S`, enabling:

```javascript
const S0 = require ('sanctuary');
const S1 = S0.create ({checkTypes: ..., env: S0.env.concat ([...])});
const S2 = S1.create ({checkTypes: ..., env: S1.env.concat ([...])});
```

One would currently need to keep track of the various environments in some other way:

```javascript
const S0 = require ('sanctuary');
const env1 = S0.env.concat ([...]);
const S1 = S0.create ({checkTypes: ..., env: env1});
const env2 = env1.concat ([...]);
const S2 = S1.create ({checkTypes: ..., env: env2});
```
