### PR TITLE
documentation: remove outdated section on type representatives

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,20 +129,6 @@
 //. type signature, separated from the rest of the signature by a fat arrow
 //. (`=>`).
 //.
-//. ### Type representatives
-//.
-//. What is the type of `Number`? One answer is `a -> Number`, since it's a
-//. function which takes an argument of any type and returns a Number value.
-//. When provided as the first argument to [`is`](#is), though, `Number` is
-//. really the value-level representative of the Number type.
-//.
-//. Sanctuary uses the TypeRep pseudotype to describe type representatives.
-//. For example:
-//.
-//.     Number :: TypeRep Number
-//.
-//. `Number` is the sole inhabitant of the TypeRep Number type.
-//.
 //. ## Type checking
 //.
 //. Sanctuary functions are defined via [sanctuary-def][] to provide run-time
@@ -357,7 +343,7 @@
   //  TypeRep :: Type -> Type
   var TypeRep = $.UnaryType
     ('sanctuary/TypeRep')
-    (readmeUrl ('type-representatives'))
+    ('https://github.com/fantasyland/fantasy-land#type-representatives')
     (function(x) {
        return $.AnyFunction._test (x) ||
               x != null && $.String._test (x['@@type']);
@@ -1752,7 +1738,7 @@
 
   //# Maybe :: TypeRep Maybe
   //.
-  //. The [type representative](#type-representatives) for the Maybe type.
+  //. The [type representative][] for the Maybe type.
   var Maybe = {prototype: _Maybe.prototype};
 
   Maybe.prototype.constructor = Maybe;
@@ -2481,7 +2467,7 @@
 
   //# Either :: TypeRep Either
   //.
-  //. The [type representative](#type-representatives) for the Either type.
+  //. The [type representative][] for the Either type.
   var Either = {prototype: _Either.prototype};
 
   Either.prototype.constructor = Either;
@@ -5215,76 +5201,77 @@
 
 }));
 
-//. [Alt]:              v:fantasyland/fantasy-land#alt
-//. [Alternative]:      v:fantasyland/fantasy-land#alternative
-//. [Applicative]:      v:fantasyland/fantasy-land#applicative
-//. [Apply]:            v:fantasyland/fantasy-land#apply
-//. [Bifunctor]:        v:fantasyland/fantasy-land#bifunctor
-//. [BinaryType]:       v:sanctuary-js/sanctuary-def#BinaryType
-//. [Chain]:            v:fantasyland/fantasy-land#chain
-//. [Either]:           #either-type
-//. [Extend]:           v:fantasyland/fantasy-land#extend
-//. [Fantasy Land]:     v:fantasyland/fantasy-land
-//. [Foldable]:         v:fantasyland/fantasy-land#foldable
-//. [Haskell]:          https://www.haskell.org/
-//. [Kleisli]:          https://en.wikipedia.org/wiki/Kleisli_category
-//. [Maybe]:            #maybe-type
-//. [Monad]:            v:fantasyland/fantasy-land#monad
-//. [Monoid]:           v:fantasyland/fantasy-land#monoid
-//. [Nullable]:         v:sanctuary-js/sanctuary-def#Nullable
-//. [Ord]:              v:fantasyland/fantasy-land#ord
-//. [PureScript]:       http://www.purescript.org/
-//. [Ramda]:            http://ramdajs.com/
-//. [RegexFlags]:       v:sanctuary-js/sanctuary-def#RegexFlags
-//. [Semigroup]:        v:fantasyland/fantasy-land#semigroup
-//. [Semigroupoid]:     v:fantasyland/fantasy-land#semigroupoid
-//. [Traversable]:      v:fantasyland/fantasy-land#traversable
-//. [UnaryType]:        v:sanctuary-js/sanctuary-def#UnaryType
-//. [`$.test`]:         v:sanctuary-js/sanctuary-def#test
-//. [`Z.alt`]:          v:sanctuary-js/sanctuary-type-classes#alt
-//. [`Z.ap`]:           v:sanctuary-js/sanctuary-type-classes#ap
-//. [`Z.apFirst`]:      v:sanctuary-js/sanctuary-type-classes#apFirst
-//. [`Z.apSecond`]:     v:sanctuary-js/sanctuary-type-classes#apSecond
-//. [`Z.bimap`]:        v:sanctuary-js/sanctuary-type-classes#bimap
-//. [`Z.chain`]:        v:sanctuary-js/sanctuary-type-classes#chain
-//. [`Z.chainRec`]:     v:sanctuary-js/sanctuary-type-classes#chainRec
-//. [`Z.compose`]:      v:sanctuary-js/sanctuary-type-classes#compose
-//. [`Z.concat`]:       v:sanctuary-js/sanctuary-type-classes#concat
-//. [`Z.contramap`]:    v:sanctuary-js/sanctuary-type-classes#contramap
-//. [`Z.dropWhile`]:    v:sanctuary-js/sanctuary-type-classes#dropWhile
-//. [`Z.duplicate`]:    v:sanctuary-js/sanctuary-type-classes#duplicate
-//. [`Z.empty`]:        v:sanctuary-js/sanctuary-type-classes#empty
-//. [`Z.equals`]:       v:sanctuary-js/sanctuary-type-classes#equals
-//. [`Z.extend`]:       v:sanctuary-js/sanctuary-type-classes#extend
-//. [`Z.extract`]:      v:sanctuary-js/sanctuary-type-classes#extract
-//. [`Z.filter`]:       v:sanctuary-js/sanctuary-type-classes#filter
-//. [`Z.flip`]:         v:sanctuary-js/sanctuary-type-classes#flip
-//. [`Z.foldMap`]:      v:sanctuary-js/sanctuary-type-classes#foldMap
-//. [`Z.gt`]:           v:sanctuary-js/sanctuary-type-classes#gt
-//. [`Z.gte`]:          v:sanctuary-js/sanctuary-type-classes#gte
-//. [`Z.id`]:           v:sanctuary-js/sanctuary-type-classes#id
-//. [`Z.invert`]:       v:sanctuary-js/sanctuary-type-classes#invert
-//. [`Z.join`]:         v:sanctuary-js/sanctuary-type-classes#join
-//. [`Z.lt`]:           v:sanctuary-js/sanctuary-type-classes#lt
-//. [`Z.lte`]:          v:sanctuary-js/sanctuary-type-classes#lte
-//. [`Z.map`]:          v:sanctuary-js/sanctuary-type-classes#map
-//. [`Z.mapLeft`]:      v:sanctuary-js/sanctuary-type-classes#mapLeft
-//. [`Z.of`]:           v:sanctuary-js/sanctuary-type-classes#of
-//. [`Z.promap`]:       v:sanctuary-js/sanctuary-type-classes#promap
-//. [`Z.reject`]:       v:sanctuary-js/sanctuary-type-classes#reject
-//. [`Z.sequence`]:     v:sanctuary-js/sanctuary-type-classes#sequence
-//. [`Z.takeWhile`]:    v:sanctuary-js/sanctuary-type-classes#takeWhile
-//. [`Z.toString`]:     v:sanctuary-js/sanctuary-type-classes#toString
-//. [`Z.traverse`]:     v:sanctuary-js/sanctuary-type-classes#traverse
-//. [`Z.zero`]:         v:sanctuary-js/sanctuary-type-classes#zero
-//. [`of`]:             v:fantasyland/fantasy-land#of-method
-//. [equivalence]:      https://en.wikipedia.org/wiki/Equivalence_relation
-//. [iff]:              https://en.wikipedia.org/wiki/If_and_only_if
-//. [parseInt]:         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
-//. [sanctuary-def]:    v:sanctuary-js/sanctuary-def
-//. [stable sort]:      https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
-//. [thrush]:           https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown
-//. [type identifier]:  v:sanctuary-js/sanctuary-type-identifiers
+//. [Alt]:                  v:fantasyland/fantasy-land#alt
+//. [Alternative]:          v:fantasyland/fantasy-land#alternative
+//. [Applicative]:          v:fantasyland/fantasy-land#applicative
+//. [Apply]:                v:fantasyland/fantasy-land#apply
+//. [Bifunctor]:            v:fantasyland/fantasy-land#bifunctor
+//. [BinaryType]:           v:sanctuary-js/sanctuary-def#BinaryType
+//. [Chain]:                v:fantasyland/fantasy-land#chain
+//. [Either]:               #either-type
+//. [Extend]:               v:fantasyland/fantasy-land#extend
+//. [Fantasy Land]:         v:fantasyland/fantasy-land
+//. [Foldable]:             v:fantasyland/fantasy-land#foldable
+//. [Haskell]:              https://www.haskell.org/
+//. [Kleisli]:              https://en.wikipedia.org/wiki/Kleisli_category
+//. [Maybe]:                #maybe-type
+//. [Monad]:                v:fantasyland/fantasy-land#monad
+//. [Monoid]:               v:fantasyland/fantasy-land#monoid
+//. [Nullable]:             v:sanctuary-js/sanctuary-def#Nullable
+//. [Ord]:                  v:fantasyland/fantasy-land#ord
+//. [PureScript]:           http://www.purescript.org/
+//. [Ramda]:                http://ramdajs.com/
+//. [RegexFlags]:           v:sanctuary-js/sanctuary-def#RegexFlags
+//. [Semigroup]:            v:fantasyland/fantasy-land#semigroup
+//. [Semigroupoid]:         v:fantasyland/fantasy-land#semigroupoid
+//. [Traversable]:          v:fantasyland/fantasy-land#traversable
+//. [UnaryType]:            v:sanctuary-js/sanctuary-def#UnaryType
+//. [`$.test`]:             v:sanctuary-js/sanctuary-def#test
+//. [`Z.alt`]:              v:sanctuary-js/sanctuary-type-classes#alt
+//. [`Z.ap`]:               v:sanctuary-js/sanctuary-type-classes#ap
+//. [`Z.apFirst`]:          v:sanctuary-js/sanctuary-type-classes#apFirst
+//. [`Z.apSecond`]:         v:sanctuary-js/sanctuary-type-classes#apSecond
+//. [`Z.bimap`]:            v:sanctuary-js/sanctuary-type-classes#bimap
+//. [`Z.chain`]:            v:sanctuary-js/sanctuary-type-classes#chain
+//. [`Z.chainRec`]:         v:sanctuary-js/sanctuary-type-classes#chainRec
+//. [`Z.compose`]:          v:sanctuary-js/sanctuary-type-classes#compose
+//. [`Z.concat`]:           v:sanctuary-js/sanctuary-type-classes#concat
+//. [`Z.contramap`]:        v:sanctuary-js/sanctuary-type-classes#contramap
+//. [`Z.dropWhile`]:        v:sanctuary-js/sanctuary-type-classes#dropWhile
+//. [`Z.duplicate`]:        v:sanctuary-js/sanctuary-type-classes#duplicate
+//. [`Z.empty`]:            v:sanctuary-js/sanctuary-type-classes#empty
+//. [`Z.equals`]:           v:sanctuary-js/sanctuary-type-classes#equals
+//. [`Z.extend`]:           v:sanctuary-js/sanctuary-type-classes#extend
+//. [`Z.extract`]:          v:sanctuary-js/sanctuary-type-classes#extract
+//. [`Z.filter`]:           v:sanctuary-js/sanctuary-type-classes#filter
+//. [`Z.flip`]:             v:sanctuary-js/sanctuary-type-classes#flip
+//. [`Z.foldMap`]:          v:sanctuary-js/sanctuary-type-classes#foldMap
+//. [`Z.gt`]:               v:sanctuary-js/sanctuary-type-classes#gt
+//. [`Z.gte`]:              v:sanctuary-js/sanctuary-type-classes#gte
+//. [`Z.id`]:               v:sanctuary-js/sanctuary-type-classes#id
+//. [`Z.invert`]:           v:sanctuary-js/sanctuary-type-classes#invert
+//. [`Z.join`]:             v:sanctuary-js/sanctuary-type-classes#join
+//. [`Z.lt`]:               v:sanctuary-js/sanctuary-type-classes#lt
+//. [`Z.lte`]:              v:sanctuary-js/sanctuary-type-classes#lte
+//. [`Z.map`]:              v:sanctuary-js/sanctuary-type-classes#map
+//. [`Z.mapLeft`]:          v:sanctuary-js/sanctuary-type-classes#mapLeft
+//. [`Z.of`]:               v:sanctuary-js/sanctuary-type-classes#of
+//. [`Z.promap`]:           v:sanctuary-js/sanctuary-type-classes#promap
+//. [`Z.reject`]:           v:sanctuary-js/sanctuary-type-classes#reject
+//. [`Z.sequence`]:         v:sanctuary-js/sanctuary-type-classes#sequence
+//. [`Z.takeWhile`]:        v:sanctuary-js/sanctuary-type-classes#takeWhile
+//. [`Z.toString`]:         v:sanctuary-js/sanctuary-type-classes#toString
+//. [`Z.traverse`]:         v:sanctuary-js/sanctuary-type-classes#traverse
+//. [`Z.zero`]:             v:sanctuary-js/sanctuary-type-classes#zero
+//. [`of`]:                 v:fantasyland/fantasy-land#of-method
+//. [equivalence]:          https://en.wikipedia.org/wiki/Equivalence_relation
+//. [iff]:                  https://en.wikipedia.org/wiki/If_and_only_if
+//. [parseInt]:             https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
+//. [sanctuary-def]:        v:sanctuary-js/sanctuary-def
+//. [stable sort]:          https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
+//. [thrush]:               https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown
+//. [type identifier]:      v:sanctuary-js/sanctuary-type-identifiers
+//. [type representative]:  v:fantasyland/fantasy-land#type-representatives
 //.
 //. [`Either#fantasy-land/bimap`]:      #Either.prototype.fantasy-land/bimap
 //. [`Either#fantasy-land/map`]:        #Either.prototype.fantasy-land/map


### PR DESCRIPTION
This section has been out of date since #513 was merged. I'm pleased that this section is no longer necessary, as it was always quite confusing.
