### PR TITLE
Add addition comments and stying to documentation 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1496,7 +1496,7 @@
   //.
   //. The T ([thrush][]) combinator. Takes a value and a function, and returns
   //. the result of applying the function to the value. Equivalent to Haskell's
-  //. `(&)` function.
+  //. `(&)` function, which is a reverse application operator.
   //.
   //. ```javascript
   //. > S.T (42) (S.add (1))

--- a/index.js
+++ b/index.js
@@ -1449,7 +1449,7 @@
     impl: curry2 (Z.contramap)
   };
 
-  //. ### Combinator
+  //. ### Combinator: A function or definition with no free variables.
 
   //# I :: a -> a
   //.

--- a/index.js
+++ b/index.js
@@ -1453,7 +1453,7 @@
 
   //# I :: a -> a
   //.
-  //. The I combinator. Returns its argument. Equivalent to Haskell's `id`
+  //. The `I` combinator. Returns its argument. Equivalent to Haskell's `id`
   //. function.
   //.
   //. ```javascript


### PR DESCRIPTION
The 'i' of identity appears in a font which makes it read as an l.