### PR TITLE
documentation: fill gap in heading hierarchy

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,6 +358,8 @@
 
   var _ = {};
 
+  //. ### Configure
+
   //# create :: { checkTypes :: Boolean, env :: Array Type } -> Module
   //.
   //. Takes an options record and returns a Sanctuary module. `checkTypes`


### PR DESCRIPTION
Commit message:

>     Before:                         After:
>
>     h1. Sanctuary                   h1. Sanctuary
>       h2. Types                       h2. Types
>       h2. Type checking               h2. Type checking
>       h2. API                         h2. API
>                                         h3. Configure
>           h4. create                      h4. create
>           h4. env                         h4. env
>           h4. unchecked                   h4. unchecked
>         h3. Classify                    h3. Classify
>           h4. type                        h4. type
>           h4. is                          h4. is
>         h3. Showable                    h3. Showable
>           h4. show                        h4. show
>         ...                             ...

This will obviate the need for the special case included in sanctuary-js/sanctuary-site#49.
