### PR TITLE
maybe, either: integrate sanctuary-maybe and sanctuary-either

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,8 @@
   ],
   "dependencies": {
     "sanctuary-def": "0.17.0",
+    "sanctuary-either": "1.0.0",
+    "sanctuary-maybe": "1.0.0",
     "sanctuary-show": "1.0.0",
     "sanctuary-type-classes": "9.0.0",
     "sanctuary-type-identifiers": "2.0.1"

--- a/index.js
+++ b/index.js
@@ -183,23 +183,29 @@
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
     module.exports = f (require ('sanctuary-def'),
+                        require ('sanctuary-either'),
+                        require ('sanctuary-maybe'),
                         require ('sanctuary-show'),
                         require ('sanctuary-type-classes'),
                         require ('sanctuary-type-identifiers'));
   } else if (typeof define === 'function' && define.amd != null) {
     define (['sanctuary-def',
+             'sanctuary-either',
+             'sanctuary-maybe',
              'sanctuary-show',
              'sanctuary-type-classes',
              'sanctuary-type-identifiers'],
             f);
   } else {
     self.sanctuary = f (self.sanctuaryDef,
+                        self.sanctuaryEither,
+                        self.sanctuaryMaybe,
                         self.sanctuaryShow,
                         self.sanctuaryTypeClasses,
                         self.sanctuaryTypeIdentifiers);
   }
 
-} (function($, show, Z, type) {
+} (function($, Either, Maybe, show, Z, type) {
 
   'use strict';
 
@@ -223,6 +229,18 @@
     } (require ('.')));
     /* eslint-enable no-unused-vars */
   }
+
+  //  Left :: a -> Either a b
+  var Left = Either.Left;
+
+  //  Right :: b -> Either a b
+  var Right = Either.Right;
+
+  //  Nothing :: Maybe a
+  var Nothing = Maybe.Nothing;
+
+  //  Just :: a -> Maybe a
+  var Just = Maybe.Just;
 
   //  B :: (b -> c) -> (a -> b) -> a -> c
   function B(f) {
@@ -295,13 +313,6 @@
     return r.value;
   }
 
-  //  readmeUrl :: String -> String
-  function readmeUrl(id) {
-    var version = '0.14.1';  // updated programmatically
-    return 'https://github.com/sanctuary-js/sanctuary/tree/v' + version +
-           '#' + id;
-  }
-
   //  :: Type
   var a = $.TypeVariable ('a');
   var b = $.TypeVariable ('b');
@@ -322,25 +333,19 @@
   var p = $.BinaryTypeVariable ('p');
   var s = $.BinaryTypeVariable ('s');
 
-  //  eitherTypeIdent :: String
-  var eitherTypeIdent = 'sanctuary/Either';
-
   //  $Either :: Type -> Type -> Type
   var $Either = $.BinaryType
-    (eitherTypeIdent)
-    (readmeUrl ('EitherType'))
-    (typeEq (eitherTypeIdent))
+    ('sanctuary/Either')
+    ('https://github.com/sanctuary-js/sanctuary-either')
+    (typeEq ('sanctuary-either/Either@1'))
     (either (of (Array)) (K ([])))
     (either (K ([])) (of (Array)));
 
-  //  maybeTypeIdent :: String
-  var maybeTypeIdent = 'sanctuary/Maybe';
-
   //  $Maybe :: Type -> Type
   var $Maybe = $.UnaryType
-    (maybeTypeIdent)
-    (readmeUrl ('MaybeType'))
-    (typeEq (maybeTypeIdent))
+    ('sanctuary/Maybe')
+    ('https://github.com/sanctuary-js/sanctuary-maybe')
+    (typeEq ('sanctuary-maybe/Maybe@1'))
     (maybe ([]) (of (Array)));
 
   //  TypeRep :: Type -> Type
@@ -502,7 +507,7 @@
   //.
   //. ```javascript
   //. > S.type (S.Just (42))
-  //. {namespace: Just ('sanctuary'), name: 'Maybe', version: 0}
+  //. {namespace: Just ('sanctuary-maybe'), name: 'Maybe', version: 1}
   //.
   //. > S.type ([1, 2, 3])
   //. {namespace: Nothing, name: 'Array', version: 0}
@@ -1335,7 +1340,7 @@
   //. [[1, 2, 3]]
   //.
   //. > S.join (S.Just (S.Just (1)))
-  //. S.Just (1)
+  //. Just (1)
   //. ```
   //.
   //. Replacing `Chain m => m` with `Function x` produces the W combinator
@@ -1411,7 +1416,7 @@
   //.
   //. ```javascript
   //. > S.duplicate (S.Just (1))
-  //. S.Just (S.Just (1))
+  //. Just (Just (1))
   //.
   //. > S.duplicate ([1])
   //. [[1]]
@@ -1734,10 +1739,9 @@
   //. ### Maybe type
   //.
   //. The Maybe type represents optional values: a value of type `Maybe a` is
-  //. either a Just whose value is of type `a` or Nothing (with no value).
+  //. either Nothing (the empty value) or a Just whose value is of type `a`.
   //.
-  //. The Maybe type satisfies the [Ord][], [Monoid][], [Monad][],
-  //. [Alternative][], [Traversable][], and [Extend][] specifications.
+  //. The implementation is provided by [sanctuary-maybe][].
 
   //# MaybeType :: Type -> Type
   //.
@@ -1745,432 +1749,29 @@
 
   //# Maybe :: TypeRep Maybe
   //.
-  //. The [type representative][] for the Maybe type.
-  var Maybe = {prototype: _Maybe.prototype};
-
-  Maybe.prototype.constructor = Maybe;
-
-  function _Maybe(tag, value) {
-    this.isNothing = tag === 'Nothing';
-    this.isJust = tag === 'Just';
-    if (this.isJust) this.value = value;
-
-    //  Add "fantasy-land/concat" method conditionally so that Just('abc')
-    //  satisfies the requirements of Semigroup but Just(123) does not.
-    if (this.isNothing || Z.Semigroup.test (this.value)) {
-      this['fantasy-land/concat'] = Maybe$prototype$concat;
-    }
-
-    if (this.isNothing || Z.Setoid.test (this.value)) {
-      this['fantasy-land/equals'] = Maybe$prototype$equals;
-    }
-
-    if (this.isNothing || Z.Ord.test (this.value)) {
-      this['fantasy-land/lte'] = Maybe$prototype$lte;
-    }
-  }
+  //. Maybe [type representative][].
 
   //# Nothing :: Maybe a
   //.
-  //. Nothing.
+  //. The empty value of type `Maybe a`.
   //.
   //. ```javascript
   //. > S.Nothing
   //. Nothing
   //. ```
-  var Nothing = new _Maybe ('Nothing');
 
   //# Just :: a -> Maybe a
   //.
-  //. Takes a value of any type and returns a Just with the given value.
+  //. Constructs a value of type `Maybe a` from a value of type `a`.
   //.
   //. ```javascript
   //. > S.Just (42)
   //. Just (42)
   //. ```
-  function Just(x) {
-    return new _Maybe ('Just', x);
-  }
   _.Just = {
     consts: {},
     types: [a, $Maybe (a)],
     impl: Just
-  };
-
-  //# Maybe.@@type :: String
-  //.
-  //. Maybe type identifier, `'sanctuary/Maybe'`.
-  Maybe['@@type'] = maybeTypeIdent;
-
-  //# Maybe.fantasy-land/empty :: () -> Maybe a
-  //.
-  //. Returns Nothing.
-  //.
-  //. It is idiomatic to use [`empty`](#empty) rather than use this function
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.empty (S.Maybe)
-  //. Nothing
-  //. ```
-  Maybe['fantasy-land/empty'] = function() { return Nothing; };
-
-  //# Maybe.fantasy-land/of :: a -> Maybe a
-  //.
-  //. Takes a value of any type and returns a Just with the given value.
-  //.
-  //. It is idiomatic to use [`of`](#of) rather than use this function
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.of (S.Maybe) (42)
-  //. Just (42)
-  //. ```
-  Maybe['fantasy-land/of'] = Just;
-
-  //# Maybe.fantasy-land/zero :: () -> Maybe a
-  //.
-  //. Returns Nothing.
-  //.
-  //. It is idiomatic to use [`zero`](#zero) rather than use this function
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.zero (S.Maybe)
-  //. Nothing
-  //. ```
-  Maybe['fantasy-land/zero'] = function() { return Nothing; };
-
-  //# Maybe#isNothing :: Maybe a ~> Boolean
-  //.
-  //. `true` if `this` is Nothing; `false` if `this` is a Just.
-  //.
-  //. ```javascript
-  //. > S.Nothing.isNothing
-  //. true
-  //.
-  //. > (S.Just (42)).isNothing
-  //. false
-  //. ```
-
-  //# Maybe#isJust :: Maybe a ~> Boolean
-  //.
-  //. `true` if `this` is a Just; `false` if `this` is Nothing.
-  //.
-  //. ```javascript
-  //. > (S.Just (42)).isJust
-  //. true
-  //.
-  //. > S.Nothing.isJust
-  //. false
-  //. ```
-
-  //# Maybe#@@show :: Maybe a ~> () -> String
-  //.
-  //. Returns the string representation of the Maybe.
-  //.
-  //. ```javascript
-  //. > S.show (S.Nothing)
-  //. 'Nothing'
-  //.
-  //. > S.show (S.Just ([1, 2, 3]))
-  //. 'Just ([1, 2, 3])'
-  //. ```
-  Maybe.prototype['@@show'] = function() {
-    return this.isJust ? 'Just (' + show (this.value) + ')' : 'Nothing';
-  };
-
-  //# Maybe#inspect :: Maybe a ~> () -> String
-  //.
-  //. Returns the string representation of the Maybe. This method is used by
-  //. `util.inspect` and the REPL to format a Maybe for display.
-  //.
-  //. See also [`Maybe#@@show`][].
-  //.
-  //. ```javascript
-  //. > S.Nothing.inspect ()
-  //. 'Nothing'
-  //.
-  //. > (S.Just ([1, 2, 3])).inspect ()
-  //. 'Just ([1, 2, 3])'
-  //. ```
-  Maybe.prototype.inspect = function() { return show (this); };
-
-  //# Maybe#fantasy-land/equals :: Setoid a => Maybe a ~> Maybe a -> Boolean
-  //.
-  //. Takes a value `m` of the same type and returns `true` if:
-  //.
-  //.   - `this` and `m` are both Nothing; or
-  //.
-  //.   - `this` and `m` are both Justs, and their values are equal according
-  //.     to [`Z.equals`][].
-  //.
-  //. It is idiomatic to use [`equals`](#equals) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.equals (S.Nothing) (S.Nothing)
-  //. true
-  //.
-  //. > S.equals (S.Just ([1, 2, 3])) (S.Just ([1, 2, 3]))
-  //. true
-  //.
-  //. > S.equals (S.Just ([1, 2, 3])) (S.Just ([3, 2, 1]))
-  //. false
-  //.
-  //. > S.equals (S.Just ([1, 2, 3])) (S.Nothing)
-  //. false
-  //. ```
-  function Maybe$prototype$equals(other) {
-    return this.isNothing ? other.isNothing
-                          : other.isJust && Z.equals (this.value, other.value);
-  }
-
-  //# Maybe#fantasy-land/lte :: Ord a => Maybe a ~> Maybe a -> Boolean
-  //.
-  //. Takes a value `m` of the same type and returns `true` if:
-  //.
-  //.   - `this` is Nothing; or
-  //.
-  //.   - `this` and `m` are both Justs and the value of `this` is less than
-  //.     or equal to the value of `m` according to [`Z.lte`][].
-  //.
-  //. It is idiomatic to use [`lte`](#lte) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.lte (S.Just (1)) (S.Nothing)
-  //. true
-  //.
-  //. > S.lte (S.Just (1)) (S.Just (0))
-  //. true
-  //.
-  //. > S.lte (S.Just (1)) (S.Just (1))
-  //. true
-  //.
-  //. > S.lte (S.Just (1)) (S.Just (2))
-  //. false
-  //. ```
-  function Maybe$prototype$lte(other) {
-    return this.isNothing || other.isJust && Z.lte (this.value, other.value);
-  }
-
-  //# Maybe#fantasy-land/concat :: Semigroup a => Maybe a ~> Maybe a -> Maybe a
-  //.
-  //. Returns the result of concatenating two Maybe values of the same type.
-  //. `a` must have a [Semigroup][].
-  //.
-  //. If `this` is Nothing and the argument is Nothing, this method returns
-  //. Nothing.
-  //.
-  //. If `this` is a Just and the argument is a Just, this method returns a
-  //. Just whose value is the result of concatenating this Just's value and
-  //. the given Just's value.
-  //.
-  //. Otherwise, this method returns the Just.
-  //.
-  //. It is idiomatic to use [`concat`](#concat) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.concat (S.Nothing) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.concat (S.Just ([1, 2, 3])) (S.Just ([4, 5, 6]))
-  //. Just ([1, 2, 3, 4, 5, 6])
-  //.
-  //. > S.concat (S.Nothing) (S.Just ([1, 2, 3]))
-  //. Just ([1, 2, 3])
-  //.
-  //. > S.concat (S.Just ([1, 2, 3])) (S.Nothing)
-  //. Just ([1, 2, 3])
-  //. ```
-  function Maybe$prototype$concat(other) {
-    return this.isNothing ?
-      other :
-      other.isNothing ? this : Just (Z.concat (this.value, other.value));
-  }
-
-  //# Maybe#fantasy-land/filter :: Maybe a ~> (a -> Boolean) -> Maybe a
-  //.
-  //. Takes a predicate and returns `this` if `this` is a Just and this Just's
-  //. value satisfies the given predicate; Nothing otherwise.
-  //.
-  //. It is idiomatic to use [`filter`](#filter) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.filter (S.odd) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.filter (S.odd) (S.Just (0))
-  //. Nothing
-  //.
-  //. > S.filter (S.odd) (S.Just (1))
-  //. Just (1)
-  //. ```
-  Maybe.prototype['fantasy-land/filter'] = function(pred) {
-    return this.isJust && pred (this.value) ? this : Nothing;
-  };
-
-  //# Maybe#fantasy-land/map :: Maybe a ~> (a -> b) -> Maybe b
-  //.
-  //. Takes a function and returns `this` if `this` is Nothing; otherwise
-  //. it returns a Just whose value is the result of applying the function
-  //. to this Just's value.
-  //.
-  //. It is idiomatic to use [`map`](#map) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.map (Math.sqrt) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.map (Math.sqrt) (S.Just (9))
-  //. Just (3)
-  //. ```
-  Maybe.prototype['fantasy-land/map'] = function(f) {
-    return this.isJust ? Just (f (this.value)) : this;
-  };
-
-  //# Maybe#fantasy-land/ap :: Maybe a ~> Maybe (a -> b) -> Maybe b
-  //.
-  //. Takes a Maybe and returns Nothing unless `this` is a Just *and* the
-  //. argument is a Just, in which case it returns a Just whose value is
-  //. the result of applying the given Just's value to this Just's value.
-  //.
-  //. It is idiomatic to use [`ap`](#ap) rather than use this method directly.
-  //.
-  //. ```javascript
-  //. > S.ap (S.Nothing) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.ap (S.Nothing) (S.Just (9))
-  //. Nothing
-  //.
-  //. > S.ap (S.Just (Math.sqrt)) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.ap (S.Just (Math.sqrt)) (S.Just (9))
-  //. Just (3)
-  //. ```
-  Maybe.prototype['fantasy-land/ap'] = function(other) {
-    return other.isJust ? Z.map (other.value, this) : other;
-  };
-
-  //# Maybe#fantasy-land/chain :: Maybe a ~> (a -> Maybe b) -> Maybe b
-  //.
-  //. Takes a function and returns `this` if `this` is Nothing; otherwise
-  //. it returns the result of applying the function to this Just's value.
-  //.
-  //. It is idiomatic to use [`chain`](#chain) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.chain (S.parseFloat) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.chain (S.parseFloat) (S.Just ('xxx'))
-  //. Nothing
-  //.
-  //. > S.chain (S.parseFloat) (S.Just ('12.34'))
-  //. Just (12.34)
-  //. ```
-  Maybe.prototype['fantasy-land/chain'] = function(f) {
-    return this.isJust ? f (this.value) : this;
-  };
-
-  //# Maybe#fantasy-land/alt :: Maybe a ~> Maybe a -> Maybe a
-  //.
-  //. Chooses between `this` and the other Maybe provided as an argument.
-  //. Returns `this` if `this` is a Just; the other Maybe otherwise.
-  //.
-  //. It is idiomatic to use [`alt`](#alt) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.alt (S.Nothing) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.alt (S.Nothing) (S.Just (1))
-  //. Just (1)
-  //.
-  //. > S.alt (S.Just (2)) (S.Nothing)
-  //. Just (2)
-  //.
-  //. > S.alt (S.Just (3)) (S.Just (4))
-  //. Just (3)
-  //. ```
-  Maybe.prototype['fantasy-land/alt'] = function(other) {
-    return this.isJust ? this : other;
-  };
-
-  //# Maybe#fantasy-land/reduce :: Maybe a ~> ((b, a) -> b, b) -> b
-  //.
-  //. Takes a function and an initial value of any type, and returns:
-  //.
-  //.   - the initial value if `this` is Nothing; otherwise
-  //.
-  //.   - the result of applying the function to the initial value and this
-  //.     Just's value.
-  //.
-  //. It is idiomatic to use [`reduce`](#reduce) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.reduce (S.curry2 (Math.pow)) (10) (S.Nothing)
-  //. 10
-  //.
-  //. > S.reduce (S.curry2 (Math.pow)) (10) (S.Just (3))
-  //. 1000
-  //. ```
-  Maybe.prototype['fantasy-land/reduce'] = function(f, x) {
-    return this.isJust ? f (x, this.value) : x;
-  };
-
-  //# Maybe#fantasy-land/traverse :: Applicative f => Maybe a ~> (TypeRep f, a -> f b) -> f (Maybe b)
-  //.
-  //. Takes the type representative of some [Applicative][] and a function
-  //. which returns a value of that Applicative, and returns:
-  //.
-  //.   - the result of applying the type representative's [`of`][] function to
-  //.     `this` if `this` is Nothing; otherwise
-  //.
-  //.   - the result of mapping [`Just`](#Just) over the result of applying the
-  //.     first function to this Just's value.
-  //.
-  //. It is idiomatic to use [`traverse`](#traverse) rather than use this
-  //. method directly.
-  //.
-  //. ```javascript
-  //. > S.traverse (Array) (S.words) (S.Nothing)
-  //. [Nothing]
-  //.
-  //. > S.traverse (Array) (S.words) (S.Just ('foo bar baz'))
-  //. [Just ('foo'), Just ('bar'), Just ('baz')]
-  //. ```
-  Maybe.prototype['fantasy-land/traverse'] = function(typeRep, f) {
-    return this.isJust ? Z.map (Just, f (this.value)) : Z.of (typeRep, this);
-  };
-
-  //# Maybe#fantasy-land/extend :: Maybe a ~> (Maybe a -> b) -> Maybe b
-  //.
-  //. Takes a function and returns `this` if `this` is Nothing; otherwise
-  //. it returns a Just whose value is the result of applying the function
-  //. to `this`.
-  //.
-  //. It is idiomatic to use [`extend`](#extend) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.extend (x => x.value + 1) (S.Nothing)
-  //. Nothing
-  //.
-  //. > S.extend (x => x.value + 1) (S.Just (42))
-  //. Just (43)
-  //. ```
-  Maybe.prototype['fantasy-land/extend'] = function(f) {
-    return this.isJust ? Just (f (this)) : this;
   };
 
   //# isNothing :: Maybe a -> Boolean
@@ -2465,8 +2066,7 @@
   //. `Either a b` is either a Left whose value is of type `a` or a Right whose
   //. value is of type `b`.
   //.
-  //. The Either type satisfies the [Ord][], [Semigroup][], [Monad][],
-  //. [Alt][], [Traversable][], [Extend][], and [Bifunctor][] specifications.
+  //. The implementation is provided by [sanctuary-either][].
 
   //# EitherType :: Type -> Type -> Type
   //.
@@ -2474,43 +2074,16 @@
 
   //# Either :: TypeRep Either
   //.
-  //. The [type representative][] for the Either type.
-  var Either = {prototype: _Either.prototype};
-
-  Either.prototype.constructor = Either;
-
-  function _Either(tag, value) {
-    this.isLeft = tag === 'Left';
-    this.isRight = tag === 'Right';
-    this.value = value;
-
-    //  Add "fantasy-land/concat" method conditionally so that Left('abc')
-    //  and Right('abc') satisfy the requirements of Semigroup but Left(123)
-    //  and Right(123) do not.
-    if (Z.Semigroup.test (this.value)) {
-      this['fantasy-land/concat'] = Either$prototype$concat;
-    }
-
-    if (Z.Setoid.test (this.value)) {
-      this['fantasy-land/equals'] = Either$prototype$equals;
-    }
-
-    if (Z.Ord.test (this.value)) {
-      this['fantasy-land/lte'] = Either$prototype$lte;
-    }
-  }
+  //. Either [type representative][].
 
   //# Left :: a -> Either a b
   //.
-  //. Takes a value of any type and returns a Left with the given value.
+  //. Constructs a value of type `Either a b` from a value of type `a`.
   //.
   //. ```javascript
   //. > S.Left ('Cannot divide by zero')
   //. Left ('Cannot divide by zero')
   //. ```
-  function Left(x) {
-    return new _Either ('Left', x);
-  }
   _.Left = {
     consts: {},
     types: [a, $Either (a) (b)],
@@ -2519,380 +2092,16 @@
 
   //# Right :: b -> Either a b
   //.
-  //. Takes a value of any type and returns a Right with the given value.
+  //. Constructs a value of type `Either a b` from a value of type `b`.
   //.
   //. ```javascript
   //. > S.Right (42)
   //. Right (42)
   //. ```
-  function Right(x) {
-    return new _Either ('Right', x);
-  }
   _.Right = {
     consts: {},
     types: [b, $Either (a) (b)],
     impl: Right
-  };
-
-  //# Either.@@type :: String
-  //.
-  //. Either type identifier, `'sanctuary/Either'`.
-  Either['@@type'] = eitherTypeIdent;
-
-  //# Either.fantasy-land/of :: b -> Either a b
-  //.
-  //. Takes a value of any type and returns a Right with the given value.
-  //.
-  //. It is idiomatic to use [`of`](#of) rather than use this function
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.of (S.Either) (42)
-  //. Right (42)
-  //. ```
-  Either['fantasy-land/of'] = Right;
-
-  //# Either#isLeft :: Either a b ~> Boolean
-  //.
-  //. `true` if `this` is a Left; `false` if `this` is a Right.
-  //.
-  //. ```javascript
-  //. > (S.Left ('Cannot divide by zero')).isLeft
-  //. true
-  //.
-  //. > (S.Right (42)).isLeft
-  //. false
-  //. ```
-
-  //# Either#isRight :: Either a b ~> Boolean
-  //.
-  //. `true` if `this` is a Right; `false` if `this` is a Left.
-  //.
-  //. ```javascript
-  //. > (S.Right (42)).isRight
-  //. true
-  //.
-  //. > (S.Left ('Cannot divide by zero')).isRight
-  //. false
-  //. ```
-
-  //# Either#@@show :: Either a b ~> () -> String
-  //.
-  //. Returns the string representation of the Either.
-  //.
-  //. ```javascript
-  //. > S.show (S.Left ('Cannot divide by zero'))
-  //. 'Left ("Cannot divide by zero")'
-  //.
-  //. > S.show (S.Right ([1, 2, 3]))
-  //. 'Right ([1, 2, 3])'
-  //. ```
-  Either.prototype['@@show'] = function() {
-    return (this.isLeft ? 'Left' : 'Right') + ' (' + show (this.value) + ')';
-  };
-
-  //# Either#inspect :: Either a b ~> () -> String
-  //.
-  //. Returns the string representation of the Either. This method is used by
-  //. `util.inspect` and the REPL to format a Either for display.
-  //.
-  //. See also [`Either#@@show`][].
-  //.
-  //. ```javascript
-  //. > (S.Left ('Cannot divide by zero')).inspect ()
-  //. 'Left ("Cannot divide by zero")'
-  //.
-  //. > (S.Right ([1, 2, 3])).inspect ()
-  //. 'Right ([1, 2, 3])'
-  //. ```
-  Either.prototype.inspect = function() { return show (this); };
-
-  //# Either#fantasy-land/equals :: (Setoid a, Setoid b) => Either a b ~> Either a b -> Boolean
-  //.
-  //. Takes a value `e` of the same type and returns `true` if:
-  //.
-  //.   - `this` and `e` are both Lefts or both Rights, and their values are
-  //.     equal according to [`Z.equals`][].
-  //.
-  //. It is idiomatic to use [`equals`](#equals) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.equals (S.Right ([1, 2, 3])) (S.Right ([1, 2, 3]))
-  //. true
-  //.
-  //. > S.equals (S.Right ([1, 2, 3])) (S.Left ([1, 2, 3]))
-  //. false
-  //. ```
-  function Either$prototype$equals(other) {
-    return this.isLeft === other.isLeft && Z.equals (this.value, other.value);
-  }
-
-  //# Either#fantasy-land/lte :: (Ord a, Ord b) => Either a b ~> Either a b -> Boolean
-  //.
-  //. Takes a value `e` of the same type and returns `true` if:
-  //.
-  //.   - `this` is a Left and `e` is a Right; or
-  //.
-  //.   - `this` and `e` are both Lefts or both Rights, and the value of `this`
-  //.     is less than or equal to the value of `e` according to [`Z.lte`][].
-  //.
-  //. It is idiomatic to use [`lte`](#lte) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.lte (S.Left (0)) (S.Left (0))
-  //. true
-  //.
-  //. > S.lte (S.Left (0)) (S.Left (1))
-  //. false
-  //.
-  //. > S.lte (S.Left (0)) (S.Right (0))
-  //. false
-  //.
-  //. > S.lte (S.Right (0)) (S.Left (0))
-  //. true
-  //.
-  //. > S.lte (S.Right (0)) (S.Right (0))
-  //. true
-  //.
-  //. > S.lte (S.Right (0)) (S.Right (1))
-  //. false
-  //. ```
-  function Either$prototype$lte(other) {
-    return this.isLeft === other.isLeft ?
-      Z.lte (this.value, other.value) :
-      this.isLeft;
-  }
-
-  //# Either#fantasy-land/concat :: (Semigroup a, Semigroup b) => Either a b ~> Either a b -> Either a b
-  //.
-  //. Returns the result of concatenating two Either values of the same type.
-  //. `a` must have a [Semigroup][], as must `b`.
-  //.
-  //. If `this` is a Left and the argument is a Left, this method returns a
-  //. Left whose value is the result of concatenating this Left's value and
-  //. the given Left's value.
-  //.
-  //. If `this` is a Right and the argument is a Right, this method returns a
-  //. Right whose value is the result of concatenating this Right's value and
-  //. the given Right's value.
-  //.
-  //. Otherwise, this method returns the Right.
-  //.
-  //. It is idiomatic to use [`concat`](#concat) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.concat (S.Left ('abc')) (S.Left ('def'))
-  //. Left ('abcdef')
-  //.
-  //. > S.concat (S.Right ([1, 2, 3])) (S.Right ([4, 5, 6]))
-  //. Right ([1, 2, 3, 4, 5, 6])
-  //.
-  //. > S.concat (S.Left ('abc')) (S.Right ([1, 2, 3]))
-  //. Right ([1, 2, 3])
-  //.
-  //. > S.concat (S.Right ([1, 2, 3])) (S.Left ('abc'))
-  //. Right ([1, 2, 3])
-  //. ```
-  function Either$prototype$concat(other) {
-    return this.isLeft ?
-      other.isLeft ? Left (Z.concat (this.value, other.value)) : other :
-      other.isLeft ? this : Right (Z.concat (this.value, other.value));
-  }
-
-  //# Either#fantasy-land/map :: Either a b ~> (b -> c) -> Either a c
-  //.
-  //. Takes a function and returns `this` if `this` is a Left; otherwise it
-  //. returns a Right whose value is the result of applying the function to
-  //. this Right's value.
-  //.
-  //. It is idiomatic to use [`map`](#map) rather than use this method
-  //. directly.
-  //.
-  //. See also [`Either#fantasy-land/bimap`][].
-  //.
-  //. ```javascript
-  //. > S.map (Math.sqrt) (S.Left ('Cannot divide by zero'))
-  //. Left ('Cannot divide by zero')
-  //.
-  //. > S.map (Math.sqrt) (S.Right (9))
-  //. Right (3)
-  //. ```
-  Either.prototype['fantasy-land/map'] = function(f) {
-    return this.isRight ? Right (f (this.value)) : this;
-  };
-
-  //# Either#fantasy-land/bimap :: Either a b ~> (a -> c, b -> d) -> Either c d
-  //.
-  //. Takes two functions and returns:
-  //.
-  //.   - a Left whose value is the result of applying the first function
-  //.     to this Left's value if `this` is a Left; otherwise
-  //.
-  //.   - a Right whose value is the result of applying the second function
-  //.     to this Right's value.
-  //.
-  //. Similar to [`Either#fantasy-land/map`][], but supports mapping over the
-  //. left side as well as the right side.
-  //.
-  //. It is idiomatic to use [`bimap`](#bimap) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.bimap (S.toUpper) (S.add (1)) (S.Left ('abc'))
-  //. Left ('ABC')
-  //.
-  //. > S.bimap (S.toUpper) (S.add (1)) (S.Right (42))
-  //. Right (43)
-  //. ```
-  Either.prototype['fantasy-land/bimap'] = function(f, g) {
-    return this.isLeft ? Left (f (this.value)) : Right (g (this.value));
-  };
-
-  //# Either#fantasy-land/ap :: Either a b ~> Either a (b -> c) -> Either a c
-  //.
-  //. Takes an Either and returns a Left unless `this` is a Right *and* the
-  //. argument is a Right, in which case it returns a Right whose value is
-  //. the result of applying the given Right's value to this Right's value.
-  //.
-  //. It is idiomatic to use [`ap`](#ap) rather than use this method directly.
-  //.
-  //. ```javascript
-  //. > S.ap (S.Left ('No such function')) (S.Left ('Cannot divide by zero'))
-  //. Left ('No such function')
-  //.
-  //. > S.ap (S.Left ('No such function')) (S.Right (9))
-  //. Left ('No such function')
-  //.
-  //. > S.ap (S.Right (Math.sqrt)) (S.Left ('Cannot divide by zero'))
-  //. Left ('Cannot divide by zero')
-  //.
-  //. > S.ap (S.Right (Math.sqrt)) (S.Right (9))
-  //. Right (3)
-  //. ```
-  Either.prototype['fantasy-land/ap'] = function(other) {
-    return other.isRight ? Z.map (other.value, this) : other;
-  };
-
-  //# Either#fantasy-land/chain :: Either a b ~> (b -> Either a c) -> Either a c
-  //.
-  //. Takes a function and returns `this` if `this` is a Left; otherwise
-  //. it returns the result of applying the function to this Right's value.
-  //.
-  //. It is idiomatic to use [`chain`](#chain) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > const sqrt = n =>
-  //. .   n < 0 ? S.Left ('Cannot represent square root of negative number')
-  //. .         : S.Right (Math.sqrt (n))
-  //.
-  //. > S.chain (sqrt) (S.Left ('Cannot divide by zero'))
-  //. Left ('Cannot divide by zero')
-  //.
-  //. > S.chain (sqrt) (S.Right (-1))
-  //. Left ('Cannot represent square root of negative number')
-  //.
-  //. > S.chain (sqrt) (S.Right (25))
-  //. Right (5)
-  //. ```
-  Either.prototype['fantasy-land/chain'] = function(f) {
-    return this.isRight ? f (this.value) : this;
-  };
-
-  //# Either#fantasy-land/alt :: Either a b ~> Either a b -> Either a b
-  //.
-  //. Chooses between `this` and the other Either provided as an argument.
-  //. Returns `this` if `this` is a Right; the other Either otherwise.
-  //.
-  //. It is idiomatic to use [`alt`](#alt) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.alt (S.Left ('A')) (S.Left ('B'))
-  //. Left ('B')
-  //.
-  //. > S.alt (S.Left ('C')) (S.Right (1))
-  //. Right (1)
-  //.
-  //. > S.alt (S.Right (2)) (S.Left ('D'))
-  //. Right (2)
-  //.
-  //. > S.alt (S.Right (3)) (S.Right (4))
-  //. Right (3)
-  //. ```
-  Either.prototype['fantasy-land/alt'] = function(other) {
-    return this.isRight ? this : other;
-  };
-
-  //# Either#fantasy-land/reduce :: Either a b ~> ((c, b) -> c, c) -> c
-  //.
-  //. Takes a function and an initial value of any type, and returns:
-  //.
-  //.   - the initial value if `this` is a Left; otherwise
-  //.
-  //.   - the result of applying the function to the initial value and this
-  //.     Right's value.
-  //.
-  //. It is idiomatic to use [`reduce`](#reduce) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.reduce (S.curry2 (Math.pow)) (10) (S.Left ('Cannot divide by zero'))
-  //. 10
-  //.
-  //. > S.reduce (S.curry2 (Math.pow)) (10) (S.Right (3))
-  //. 1000
-  //. ```
-  Either.prototype['fantasy-land/reduce'] = function(f, x) {
-    return this.isRight ? f (x, this.value) : x;
-  };
-
-  //# Either#fantasy-land/traverse :: Applicative f => Either a b ~> (TypeRep f, b -> f c) -> f (Either a c)
-  //.
-  //. Takes the type representative of some [Applicative][] and a function
-  //. which returns a value of that Applicative, and returns:
-  //.
-  //.   - the result of applying the type representative's [`of`][] function to
-  //.     `this` if `this` is a Left; otherwise
-  //.
-  //.   - the result of mapping [`Right`](#Right) over the result of applying
-  //.     the first function to this Right's value.
-  //.
-  //. It is idiomatic to use [`traverse`](#traverse) rather than use this
-  //. method directly.
-  //.
-  //. ```javascript
-  //. > S.traverse (Array) (S.words) (S.Left ('Request failed'))
-  //. [Left ('Request failed')]
-  //.
-  //. > S.traverse (Array) (S.words) (S.Right ('foo bar baz'))
-  //. [Right ('foo'), Right ('bar'), Right ('baz')]
-  //. ```
-  Either.prototype['fantasy-land/traverse'] = function(typeRep, f) {
-    return this.isRight ? Z.map (Right, f (this.value)) : Z.of (typeRep, this);
-  };
-
-  //# Either#fantasy-land/extend :: Either a b ~> (Either a b -> c) -> Either a c
-  //.
-  //. Takes a function and returns `this` if `this` is a Left; otherwise it
-  //. returns a Right whose value is the result of applying the function to
-  //. `this`.
-  //.
-  //. It is idiomatic to use [`extend`](#extend) rather than use this method
-  //. directly.
-  //.
-  //. ```javascript
-  //. > S.extend (x => x.value + 1) (S.Left ('Cannot divide by zero'))
-  //. Left ('Cannot divide by zero')
-  //.
-  //. > S.extend (x => x.value + 1) (S.Right (42))
-  //. Right (43)
-  //. ```
-  Either.prototype['fantasy-land/extend'] = function(f) {
-    return this.isLeft ? this : Right (f (this));
   };
 
   //# isLeft :: Either a b -> Boolean
@@ -5210,30 +4419,20 @@
 
 }));
 
-//. [Alt]:                  v:fantasyland/fantasy-land#alt
-//. [Alternative]:          v:fantasyland/fantasy-land#alternative
-//. [Applicative]:          v:fantasyland/fantasy-land#applicative
 //. [Apply]:                v:fantasyland/fantasy-land#apply
-//. [Bifunctor]:            v:fantasyland/fantasy-land#bifunctor
 //. [BinaryType]:           v:sanctuary-js/sanctuary-def#BinaryType
 //. [Chain]:                v:fantasyland/fantasy-land#chain
 //. [Either]:               #either-type
-//. [Extend]:               v:fantasyland/fantasy-land#extend
 //. [Fantasy Land]:         v:fantasyland/fantasy-land
 //. [Foldable]:             v:fantasyland/fantasy-land#foldable
 //. [Haskell]:              https://www.haskell.org/
 //. [Kleisli]:              https://en.wikipedia.org/wiki/Kleisli_category
 //. [Maybe]:                #maybe-type
-//. [Monad]:                v:fantasyland/fantasy-land#monad
-//. [Monoid]:               v:fantasyland/fantasy-land#monoid
 //. [Nullable]:             v:sanctuary-js/sanctuary-def#Nullable
-//. [Ord]:                  v:fantasyland/fantasy-land#ord
 //. [PureScript]:           http://www.purescript.org/
 //. [Ramda]:                http://ramdajs.com/
 //. [RegexFlags]:           v:sanctuary-js/sanctuary-def#RegexFlags
-//. [Semigroup]:            v:fantasyland/fantasy-land#semigroup
 //. [Semigroupoid]:         v:fantasyland/fantasy-land#semigroupoid
-//. [Traversable]:          v:fantasyland/fantasy-land#traversable
 //. [UnaryType]:            v:sanctuary-js/sanctuary-def#UnaryType
 //. [`$.test`]:             v:sanctuary-js/sanctuary-def#test
 //. [`Z.alt`]:              v:sanctuary-js/sanctuary-type-classes#alt
@@ -5271,18 +4470,14 @@
 //. [`Z.takeWhile`]:        v:sanctuary-js/sanctuary-type-classes#takeWhile
 //. [`Z.traverse`]:         v:sanctuary-js/sanctuary-type-classes#traverse
 //. [`Z.zero`]:             v:sanctuary-js/sanctuary-type-classes#zero
-//. [`of`]:                 v:fantasyland/fantasy-land#of-method
 //. [`show`]:               v:sanctuary-js/sanctuary-show#show
 //. [equivalence]:          https://en.wikipedia.org/wiki/Equivalence_relation
 //. [iff]:                  https://en.wikipedia.org/wiki/If_and_only_if
 //. [parseInt]:             https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
 //. [sanctuary-def]:        v:sanctuary-js/sanctuary-def
+//. [sanctuary-either]:     v:sanctuary-js/sanctuary-either
+//. [sanctuary-maybe]:      v:sanctuary-js/sanctuary-maybe
 //. [stable sort]:          https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
 //. [thrush]:               https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown
 //. [type identifier]:      v:sanctuary-js/sanctuary-type-identifiers
 //. [type representative]:  v:fantasyland/fantasy-land#type-representatives
-//.
-//. [`Either#@@show`]:                  #Either.prototype.@@show
-//. [`Either#fantasy-land/bimap`]:      #Either.prototype.fantasy-land/bimap
-//. [`Either#fantasy-land/map`]:        #Either.prototype.fantasy-land/map
-//. [`Maybe#@@show`]:                   #Maybe.prototype.@@show

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,9 @@ var dependencies = [
   'sanctuary-show',
   'sanctuary-type-identifiers',
   'sanctuary-type-classes',
-  'sanctuary-def'
+  'sanctuary-def',
+  'sanctuary-either',
+  'sanctuary-maybe'
 ];
 
 eq (S.sort (dependencies))

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "sanctuary-def": "0.17.0",
+    "sanctuary-either": "1.0.0",
+    "sanctuary-maybe": "1.0.0",
     "sanctuary-show": "1.0.0",
     "sanctuary-type-classes": "9.0.0",
     "sanctuary-type-identifiers": "2.0.1"

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euf -o pipefail
-
-node_modules/.bin/sanctuary-prepublish "$@"
-
-sed "s/ version = '.*';/ version = '$VERSION';/" index.js >index.js.updated
-mv index.js.updated index.js
-git add index.js

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -97,9 +97,4 @@ suite ('Left', function() {
     eq (S.show (S.Left ('abc'))) ('Left ("abc")');
   });
 
-  test ('"inspect" method', function() {
-    eq ((S.Left ('abc')).inspect.length) (0);
-    eq ((S.Left ('abc')).inspect ()) ('Left ("abc")');
-  });
-
 });

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -97,9 +97,4 @@ suite ('Right', function() {
     eq (S.show (S.Right ([1, 2, 3]))) ('Right ([1, 2, 3])');
   });
 
-  test ('"inspect" method', function() {
-    eq ((S.Right ([1, 2, 3])).inspect.length) (0);
-    eq ((S.Right ([1, 2, 3])).inspect ()) ('Right ([1, 2, 3])');
-  });
-
 });

--- a/test/Maybe/Just.js
+++ b/test/Maybe/Just.js
@@ -89,9 +89,4 @@ suite ('Just', function() {
     eq (S.show (S.Just ([1, 2, 3]))) ('Just ([1, 2, 3])');
   });
 
-  test ('"inspect" method', function() {
-    eq ((S.Just ([1, 2, 3])).inspect.length) (0);
-    eq ((S.Just ([1, 2, 3])).inspect ()) ('Just ([1, 2, 3])');
-  });
-
 });

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -76,9 +76,4 @@ suite ('Nothing', function() {
     eq (S.show (S.Nothing)) ('Nothing');
   });
 
-  test ('"inspect" method', function() {
-    eq (S.Nothing.inspect.length) (0);
-    eq (S.Nothing.inspect ()) ('Nothing');
-  });
-
 });

--- a/test/type.js
+++ b/test/type.js
@@ -43,13 +43,13 @@ test ('type', function() {
      ({namespace: S.Nothing, name: 'String', version: 0});
 
   eq (S.type (S.Left (42)))
-     ({namespace: S.Just ('sanctuary'), name: 'Either', version: 0});
+     ({namespace: S.Just ('sanctuary-either'), name: 'Either', version: 1});
   eq (S.type (S.Right (42)))
-     ({namespace: S.Just ('sanctuary'), name: 'Either', version: 0});
+     ({namespace: S.Just ('sanctuary-either'), name: 'Either', version: 1});
   eq (S.type (S.Nothing))
-     ({namespace: S.Just ('sanctuary'), name: 'Maybe', version: 0});
+     ({namespace: S.Just ('sanctuary-maybe'), name: 'Maybe', version: 1});
   eq (S.type (S.Just (42)))
-     ({namespace: S.Just ('sanctuary'), name: 'Maybe', version: 0});
+     ({namespace: S.Just ('sanctuary-maybe'), name: 'Maybe', version: 1});
 
   function Gizmo() {}
   Gizmo['@@type'] = 'gadgets/Gizmo@42';


### PR DESCRIPTION
Now that [sanctuary-maybe][1] and [sanctuary-either][2] have been published we can depend on those packages and remove the Maybe and Either implementations from this project. :D


[1]: https://github.com/sanctuary-js/sanctuary-maybe
[2]: https://github.com/sanctuary-js/sanctuary-either
