### PR TITLE
pair: integrate sanctuary-pair

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
         "Left": false,
         "Nil": false,
         "Nothing": false,
+        "Pair": false,
         "R": false,
         "Right": false,
         "S": false,

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "sanctuary-def": "0.17.0",
     "sanctuary-either": "1.0.0",
     "sanctuary-maybe": "1.0.0",
+    "sanctuary-pair": "1.0.0",
     "sanctuary-show": "1.0.0",
     "sanctuary-type-classes": "9.0.0",
     "sanctuary-type-identifiers": "2.0.1"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,8 @@ var dependencies = [
   'sanctuary-type-classes',
   'sanctuary-def',
   'sanctuary-either',
-  'sanctuary-maybe'
+  'sanctuary-maybe',
+  'sanctuary-pair'
 ];
 
 eq (S.sort (dependencies))

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sanctuary-def": "0.17.0",
     "sanctuary-either": "1.0.0",
     "sanctuary-maybe": "1.0.0",
+    "sanctuary-pair": "1.0.0",
     "sanctuary-show": "1.0.0",
     "sanctuary-type-classes": "9.0.0",
     "sanctuary-type-identifiers": "2.0.1"

--- a/test/Pair.js
+++ b/test/Pair.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require ('..');
+
+var eq = require ('./internal/eq');
+
+
+test ('Pair', function() {
+
+  eq (typeof S.Pair) ('function');
+  eq (S.Pair.length) (1);
+  eq (S.show (S.Pair)) ('Pair :: a -> b -> Pair a b');
+
+  eq (S.Pair ('foo') (42)) (S.Pair ('foo') (42));
+
+});

--- a/test/PairType.js
+++ b/test/PairType.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var $ = require ('sanctuary-def');
+
+var S = require ('..');
+
+var eq = require ('./internal/eq');
+
+
+test ('PairType', function() {
+
+  eq (typeof S.PairType) ('function');
+  eq (S.PairType.length) (1);
+  eq (S.show (S.PairType)) ('Pair :: Type -> Type -> Type');
+
+  eq (S.is (S.PairType ($.String) ($.Number)) (S.Pair ('hi') (0.25))) (true);
+  eq (S.is (S.PairType ($.String) ($.Number)) (S.Pair ('hi') ('hi'))) (false);
+  eq (S.is (S.PairType ($.String) ($.Number)) (S.Pair (0.25) (0.25))) (false);
+  eq (S.is (S.PairType ($.String) ($.Number)) (S.Pair (null) (null))) (false);
+  eq (S.is (S.PairType ($.String) ($.Number)) (null)) (false);
+
+});

--- a/test/fromPairs.js
+++ b/test/fromPairs.js
@@ -9,11 +9,15 @@ test ('fromPairs', function() {
 
   eq (typeof S.fromPairs) ('function');
   eq (S.fromPairs.length) (1);
-  eq (S.show (S.fromPairs)) ('fromPairs :: Foldable f => f (Array2 String a) -> StrMap a');
+  eq (S.show (S.fromPairs)) ('fromPairs :: Foldable f => f (Pair String a) -> StrMap a');
 
-  eq (S.fromPairs ([])) ({});
-  eq (S.fromPairs ([['a', 1], ['b', 2], ['c', 3]])) ({a: 1, b: 2, c: 3});
-  eq (S.fromPairs ({x: ['a', 1], y: ['b', 2], z: ['c', 3]})) ({a: 1, b: 2, c: 3});
-  eq (S.fromPairs ([['x', 1], ['x', 2]])) ({x: 2});
+  eq (S.fromPairs ([]))
+     ({});
+  eq (S.fromPairs ([S.Pair ('a') (1), S.Pair ('b') (2), S.Pair ('c') (3)]))
+     ({a: 1, b: 2, c: 3});
+  eq (S.fromPairs ({x: S.Pair ('a') (1), y: S.Pair ('b') (2), z: S.Pair ('c') (3)}))
+     ({a: 1, b: 2, c: 3});
+  eq (S.fromPairs ([S.Pair ('x') (1), S.Pair ('x') (2)]))
+     ({x: 2});
 
 });

--- a/test/fst.js
+++ b/test/fst.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require ('..');
+
+var eq = require ('./internal/eq');
+
+
+test ('fst', function() {
+
+  eq (typeof S.fst) ('function');
+  eq (S.fst.length) (1);
+  eq (S.show (S.fst)) ('fst :: Pair a b -> a');
+
+  eq (S.fst (S.Pair ('foo') (42))) ('foo');
+
+});

--- a/test/pairs.js
+++ b/test/pairs.js
@@ -9,16 +9,16 @@ test ('pairs', function() {
 
   eq (typeof S.pairs) ('function');
   eq (S.pairs.length) (1);
-  eq (S.show (S.pairs)) ('pairs :: StrMap a -> Array (Array2 String a)');
+  eq (S.show (S.pairs)) ('pairs :: StrMap a -> Array (Pair String a)');
 
   eq (S.sort (S.pairs ({}))) ([]);
-  eq (S.sort (S.pairs ({a: 1, b: 2, c: 3}))) ([['a', 1], ['b', 2], ['c', 3]]);
+  eq (S.sort (S.pairs ({a: 1, b: 2, c: 3}))) ([S.Pair ('a') (1), S.Pair ('b') (2), S.Pair ('c') (3)]);
 
   var proto = {a: 1, b: 2};
   var obj = Object.create (proto);
   obj.c = 3;
   obj.d = 4;
 
-  eq (S.sort (S.pairs (obj))) ([['c', 3], ['d', 4]]);
+  eq (S.sort (S.pairs (obj))) ([S.Pair ('c') (3), S.Pair ('d') (4)]);
 
 });

--- a/test/snd.js
+++ b/test/snd.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require ('..');
+
+var eq = require ('./internal/eq');
+
+
+test ('snd', function() {
+
+  eq (typeof S.snd) ('function');
+  eq (S.snd.length) (1);
+  eq (S.show (S.snd)) ('snd :: Pair a b -> b');
+
+  eq (S.snd (S.Pair ('foo') (42))) (42);
+
+});

--- a/test/swap.js
+++ b/test/swap.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var S = require ('..');
+
+var eq = require ('./internal/eq');
+
+
+test ('swap', function() {
+
+  eq (typeof S.swap) ('function');
+  eq (S.swap.length) (1);
+  eq (S.show (S.swap)) ('swap :: Pair a b -> Pair b a');
+
+  eq (S.swap (S.Pair ('foo') (42))) (S.Pair (42) ('foo'));
+
+});

--- a/test/unfoldr.js
+++ b/test/unfoldr.js
@@ -9,10 +9,10 @@ test ('unfoldr', function() {
 
   eq (typeof S.unfoldr) ('function');
   eq (S.unfoldr.length) (1);
-  eq (S.show (S.unfoldr)) ('unfoldr :: (b -> Maybe (Array2 a b)) -> b -> Array a');
+  eq (S.show (S.unfoldr)) ('unfoldr :: (b -> Maybe (Pair a b)) -> b -> Array a');
 
   function f(n) {
-    return n >= 5 ? S.Nothing : S.Just ([n, n + 1]);
+    return n >= 5 ? S.Nothing : S.Just (S.Pair (n) (n + 1));
   }
   eq (S.unfoldr (f) (5)) ([]);
   eq (S.unfoldr (f) (4)) ([4]);

--- a/test/zip.js
+++ b/test/zip.js
@@ -9,9 +9,11 @@ test ('zip', function() {
 
   eq (typeof S.zip) ('function');
   eq (S.zip.length) (1);
-  eq (S.show (S.zip)) ('zip :: Array a -> Array b -> Array (Array2 a b)');
+  eq (S.show (S.zip)) ('zip :: Array a -> Array b -> Array (Pair a b)');
 
-  eq (S.zip (['a', 'b']) (['x', 'y', 'z'])) ([['a', 'x'], ['b', 'y']]);
-  eq (S.zip ([1, 3, 5]) ([2, 4])) ([[1, 2], [3, 4]]);
+  eq (S.zip (['a', 'b']) (['x', 'y', 'z']))
+     ([S.Pair ('a') ('x'), S.Pair ('b') ('y')]);
+  eq (S.zip ([1, 3, 5]) ([2, 4]))
+     ([S.Pair (1) (2), S.Pair (3) (4)]);
 
 });


### PR DESCRIPTION
This pull request adds [sanctuary-pair][1] as a dependency, re-exports its functions, and updates several existing functions to use `Pair a b` rather than `Array2 a b`.

```diff
$ git show -U0 index.js | grep '//#'
+  //# PairType :: Type -> Type -> Type
+  //# Pair :: a -> b -> Pair a b
+  //# fst :: Pair a b -> a
+  //# snd :: Pair a b -> b
+  //# swap :: Pair a b -> Pair b a
-  //# unfoldr :: (b -> Maybe (Array2 a b)) -> b -> Array a
+  //# unfoldr :: (b -> Maybe (Pair a b)) -> b -> Array a
-  //# zip :: Array a -> Array b -> Array (Array2 a b)
+  //# zip :: Array a -> Array b -> Array (Pair a b)
-  //# pairs :: StrMap a -> Array (Array2 String a)
+  //# pairs :: StrMap a -> Array (Pair String a)
-  //# fromPairs :: Foldable f => f (Array2 String a) -> StrMap a
+  //# fromPairs :: Foldable f => f (Pair String a) -> StrMap a
```


[1]: https://github.com/sanctuary-js/sanctuary-pair
