### PR TITLE
sanctuary-def@0.18.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-def": "0.17.2",
+    "sanctuary-def": "0.18.1",
     "sanctuary-either": "1.0.0",
     "sanctuary-maybe": "1.0.0",
     "sanctuary-pair": "1.0.0",

--- a/index.js
+++ b/index.js
@@ -605,6 +605,7 @@
   //. . $.Boolean,
   //. . $.Date,
   //. . $.Error,
+  //. . $.HtmlElement,
   //. . $.Null,
   //. . $.Number,
   //. . $.Object,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run lint && sanctuary-test && npm run doctest"
   },
   "dependencies": {
-    "sanctuary-def": "0.17.2",
+    "sanctuary-def": "0.18.1",
     "sanctuary-either": "1.0.0",
     "sanctuary-maybe": "1.0.0",
     "sanctuary-pair": "1.0.0",

--- a/test/I.js
+++ b/test/I.js
@@ -18,4 +18,12 @@ test ('I', function() {
   eq (properties.idempotent (S.I)) (true);
   eq (properties.involution (S.I)) (true);
 
+  if (typeof document !== 'undefined') {
+    //  eslint-disable-next-line no-undef
+    var a = document.createElement ('a');
+    var href = S.prop ('href');
+    eq (href (a)) ('');
+    eq (href (S.I (a))) ('');
+  }
+
 });


### PR DESCRIPTION
  - <https://github.com/sanctuary-js/sanctuary-def/releases/tag/v0.18.0>
  - <https://github.com/sanctuary-js/sanctuary-def/releases/tag/v0.18.1>

While discussing browser usage in #409, @JAForbes wrote:

> I think we should also explain why such a type isn't included by default.

I don't think we had a good reason for not including a type such as [`$.HtmlElement`][1] in the default environment. With this pull request `S.I (document.body)` works out of the box, saving us from documenting how one could define this type oneself. :)

/cc @krainboltgreene


[1]: https://github.com/sanctuary-js/sanctuary-def#HtmlElement
