### PR TITLE
docs(foldMap): added an extra example to foldMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -3338,6 +3338,9 @@
   //. ```javascript
   //. > S.foldMap (String) (f => f.name) ([Math.sin, Math.cos, Math.tan])
   //. 'sincostan'
+  //.
+  //. > S.foldMap (Array) (x => [x + 1, x + 2]) ([10, 20, 30])
+  //. [11, 12, 21, 22, 31, 32]
   //. ```
   _.foldMap = {
     consts: {b: [Z.Monoid], f: [Z.Foldable]},


### PR DESCRIPTION
I think foldMap is a great function that has many usages.
However it lacks more examples and people is not used to the concept of giving a typeRep, this tries to make the function more easy to understand with an extra example that uses array.