### PR TITLE
test: use ES6 syntax

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "root": true,
+  "extends": ["../node_modules/sanctuary-style/eslint-es6.json"],
+  "env": {"node": true},
+  "globals": {"suite": false, "test": false},
+  "rules": {
+    "max-len": ["off"]
+  }
+}

--- a/test/EitherType.js
+++ b/test/EitherType.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('EitherType', function() {
+test ('EitherType', () => {
 
   eq (typeof S.EitherType) ('function');
   eq (S.EitherType.length) (1);

--- a/test/I.js
+++ b/test/I.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var properties = require ('./properties');
+const eq = require ('./internal/eq');
+const properties = require ('./properties');
 
 
-test ('I', function() {
+test ('I', () => {
 
   eq (typeof S.I) ('function');
   eq (S.I.length) (1);
@@ -20,8 +20,8 @@ test ('I', function() {
 
   if (typeof document !== 'undefined') {
     //  eslint-disable-next-line no-undef
-    var a = document.createElement ('a');
-    var href = S.prop ('href');
+    const a = document.createElement ('a');
+    const href = S.prop ('href');
     eq (href (a)) ('');
     eq (href (S.I (a))) ('');
   }

--- a/test/K.js
+++ b/test/K.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('K', function() {
+test ('K', () => {
 
   eq (typeof S.K) ('function');
   eq (S.K.length) (1);

--- a/test/MaybeType.js
+++ b/test/MaybeType.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('MaybeType', function() {
+test ('MaybeType', () => {
 
   eq (typeof S.MaybeType) ('function');
   eq (S.MaybeType.length) (1);

--- a/test/NODE_ENV.js
+++ b/test/NODE_ENV.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var fs = require ('fs');
-var path = require ('path');
-var vm = require ('vm');
+const fs = require ('fs');
+const path = require ('path');
+const vm = require ('vm');
 
-var $$version = (require ('sanctuary-def/package.json')).version;
+const $$version = (require ('sanctuary-def/package.json')).version;
 
-var eq = require ('./internal/eq');
-var throws = require ('./internal/throws');
+const eq = require ('./internal/eq');
+const throws = require ('./internal/throws');
 
 
-suite ('NODE_ENV', function() {
+suite ('NODE_ENV', () => {
 
-  var source = fs.readFileSync (path.join (__dirname, '..', 'index.js'), 'utf8');
+  const source = fs.readFileSync (path.join (__dirname, '..', 'index.js'), 'utf8');
 
-  var expected = new TypeError ([
+  const expected = new TypeError ([
     'Invalid value',
     '',
     'add :: FiniteNumber -> FiniteNumber -> FiniteNumber',
@@ -26,68 +26,68 @@ suite ('NODE_ENV', function() {
     'The value at position 1 is not a member of ‘FiniteNumber’.',
     '',
     'See https://github.com/sanctuary-js/sanctuary-def/tree/v' + $$version + '#FiniteNumber for information about the sanctuary-def/FiniteNumber type.',
-    ''
+    '',
   ].join ('\n'));
 
-  test ('typeof process === "undefined"', function() {
-    var context = {
+  test ('typeof process === "undefined"', () => {
+    const context = {
       module: {exports: {}},
-      require: require
+      require: require,
     };
     vm.runInNewContext (source, context);
 
-    throws (function() { context.module.exports.add ('foo'); }) (expected);
+    throws (() => { context.module.exports.add ('foo'); }) (expected);
   });
 
-  test ('typeof process !== "undefined" && process == null', function() {
-    var context = {
+  test ('typeof process !== "undefined" && process == null', () => {
+    const context = {
       module: {exports: {}},
       process: null,
-      require: require
+      require: require,
     };
     vm.runInNewContext (source, context);
 
-    throws (function() { context.module.exports.add ('foo'); }) (expected);
+    throws (() => { context.module.exports.add ('foo'); }) (expected);
   });
 
-  test ('typeof process !== "undefined" && process != null && process.env == null', function() {
-    var context = {
+  test ('typeof process !== "undefined" && process != null && process.env == null', () => {
+    const context = {
       module: {exports: {}},
       process: {},
-      require: require
+      require: require,
     };
     vm.runInNewContext (source, context);
 
-    throws (function() { context.module.exports.add ('foo'); }) (expected);
+    throws (() => { context.module.exports.add ('foo'); }) (expected);
   });
 
-  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV == null', function() {
-    var context = {
+  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV == null', () => {
+    const context = {
       module: {exports: {}},
       process: {env: {}},
-      require: require
+      require: require,
     };
     vm.runInNewContext (source, context);
 
-    throws (function() { context.module.exports.add ('foo'); }) (expected);
+    throws (() => { context.module.exports.add ('foo'); }) (expected);
   });
 
-  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV !== "production"', function() {
-    var context = {
+  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV !== "production"', () => {
+    const context = {
       module: {exports: {}},
       process: {env: {NODE_ENV: 'XXX'}},
-      require: require
+      require: require,
     };
     vm.runInNewContext (source, context);
 
-    throws (function() { context.module.exports.add ('foo'); }) (expected);
+    throws (() => { context.module.exports.add ('foo'); }) (expected);
   });
 
-  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV === "production"', function() {
-    var context = {
+  test ('typeof process !== "undefined" && process != null && process.env != null && process.env.NODE_ENV === "production"', () => {
+    const context = {
       module: {exports: {}},
       process: {env: {NODE_ENV: 'production'}},
-      require: require
+      require: require,
     };
     vm.runInNewContext (source, context);
 

--- a/test/Pair.js
+++ b/test/Pair.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('Pair', function() {
+test ('Pair', () => {
 
   eq (typeof S.Pair) ('function');
   eq (S.Pair.length) (1);

--- a/test/PairType.js
+++ b/test/PairType.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('PairType', function() {
+test ('PairType', () => {
 
   eq (typeof S.PairType) ('function');
   eq (S.PairType.length) (1);

--- a/test/T.js
+++ b/test/T.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('T', function() {
+test ('T', () => {
 
   eq (typeof S.T) ('function');
   eq (S.T.length) (1);

--- a/test/add.js
+++ b/test/add.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('add', function() {
+test ('add', () => {
 
   eq (typeof S.add) ('function');
   eq (S.add.length) (1);

--- a/test/all.js
+++ b/test/all.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('all', function() {
+test ('all', () => {
 
   eq (typeof S.all) ('function');
   eq (S.all.length) (1);

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('allPass', function() {
+test ('allPass', () => {
 
   eq (typeof S.allPass) ('function');
   eq (S.allPass.length) (1);
@@ -24,8 +20,8 @@ test ('allPass', function() {
   eq (S.allPass (Cons (S.test (/a/)) (Cons (S.test (/b/)) (Cons (S.test (/c/)) (Nil)))) ('abacus')) (true);
   eq (S.allPass (Cons (S.test (/a/)) (Cons (S.test (/b/)) (Cons (S.test (/c/)) (Nil)))) ('banana')) (false);
 
-  var e = false;
-  eq (S.allPass ([S.test (/a/), function() { e = true; }]) ('monkey')) (false);
+  let e = false;
+  eq (S.allPass ([S.test (/a/), () => e = true]) ('monkey')) (false);
   eq (e) (false);
 
 });

--- a/test/alt.js
+++ b/test/alt.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('alt', function() {
+test ('alt', () => {
 
   eq (typeof S.alt) ('function');
   eq (S.alt.length) (1);

--- a/test/and.js
+++ b/test/and.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('and', function() {
+test ('and', () => {
 
   eq (typeof S.and) ('function');
   eq (S.and.length) (1);

--- a/test/any.js
+++ b/test/any.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('any', function() {
+test ('any', () => {
 
   eq (typeof S.any) ('function');
   eq (S.any.length) (1);

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('anyPass', function() {
+test ('anyPass', () => {
 
   eq (typeof S.anyPass) ('function');
   eq (S.anyPass.length) (1);
@@ -24,8 +20,8 @@ test ('anyPass', function() {
   eq (S.anyPass (Cons (S.test (/a/)) (Cons (S.test (/b/)) (Cons (S.test (/c/)) (Nil)))) ('dolphin')) (false);
   eq (S.anyPass (Cons (S.test (/a/)) (Cons (S.test (/b/)) (Cons (S.test (/c/)) (Nil)))) ('narwhal')) (true);
 
-  var e = false;
-  eq (S.anyPass ([S.test (/a/), function() { e = true; }]) ('narwhal')) (true);
+  let e = false;
+  eq (S.anyPass ([S.test (/a/), () => e = true]) ('narwhal')) (true);
   eq (e) (false);
 
 });

--- a/test/ap.js
+++ b/test/ap.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('ap', function() {
+test ('ap', () => {
 
   eq (typeof S.ap) ('function');
   eq (S.ap.length) (1);

--- a/test/apFirst.js
+++ b/test/apFirst.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('apFirst', function() {
+test ('apFirst', () => {
 
   eq (typeof S.apFirst) ('function');
   eq (S.apFirst.length) (1);

--- a/test/apSecond.js
+++ b/test/apSecond.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('apSecond', function() {
+test ('apSecond', () => {
 
   eq (typeof S.apSecond) ('function');
   eq (S.apSecond.length) (1);

--- a/test/append.js
+++ b/test/append.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('append', function() {
+test ('append', () => {
 
   eq (typeof S.append) ('function');
   eq (S.append.length) (1);

--- a/test/array.js
+++ b/test/array.js
@@ -1,37 +1,29 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('array', function() {
+test ('array', () => {
 
   eq (typeof S.array) ('function');
   eq (S.array.length) (1);
   eq (S.show (S.array)) ('array :: b -> (a -> Array a -> b) -> Array a -> b');
 
-  var size = S.array (0) (function(head) {
-    return function(tail) {
-      return 1 + size (tail);
-    };
-  });
+  const size = S.array (0) (head => tail => 1 + size (tail));
   eq (size ([])) (0);
   eq (size (['foo'])) (1);
   eq (size (['foo', 'bar'])) (2);
   eq (size (['foo', 'bar', 'baz'])) (3);
 
-  var reverse = S.array ([]) (function(head) {
-    return function(tail) {
-      return S.append (head) (reverse (tail));
-    };
-  });
+  const reverse = S.array ([]) (head => tail => S.append (head) (reverse (tail)));
   eq (reverse ([])) ([]);
   eq (reverse (['foo'])) (['foo']);
   eq (reverse (['foo', 'bar'])) (['bar', 'foo']);
   eq (reverse (['foo', 'bar', 'baz'])) (['baz', 'bar', 'foo']);
 
-  var tail = S.array (S.Nothing) (S.K (S.Just));
+  const tail = S.array (S.Nothing) (S.K (S.Just));
   eq (tail ([])) (S.Nothing);
   eq (tail (['foo'])) (S.Just ([]));
   eq (tail (['foo', 'bar'])) (S.Just (['bar']));

--- a/test/at.js
+++ b/test/at.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('at', function() {
+test ('at', () => {
 
   eq (typeof S.at) ('function');
   eq (S.at.length) (1);

--- a/test/bimap.js
+++ b/test/bimap.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('bimap', function() {
+test ('bimap', () => {
 
   eq (typeof S.bimap) ('function');
   eq (S.bimap.length) (1);

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('boolean', function() {
+test ('boolean', () => {
 
   eq (typeof S.boolean) ('function');
   eq (S.boolean.length) (1);

--- a/test/chain.js
+++ b/test/chain.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('chain', function() {
+test ('chain', () => {
 
   eq (typeof S.chain) ('function');
   eq (S.chain.length) (1);

--- a/test/chainRec.js
+++ b/test/chainRec.js
@@ -1,31 +1,32 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var map = require ('./internal/map');
+const eq = require ('./internal/eq');
+const map = require ('./internal/map');
 
 
-test ('chainRec', function() {
+test ('chainRec', () => {
 
   eq (typeof S.chainRec) ('function');
   eq (S.chainRec.length) (1);
   eq (S.show (S.chainRec)) ('chainRec :: ChainRec m => TypeRep m -> (a -> m (Either a b)) -> a -> m b');
 
-  function permute(s) {
-    return s.length === 2 ? map (S.Right) ([s + '!', s + '?'])
-                          : map (S.Left) ([s + 'o', s + 'n']);
-  }
-  eq (S.chainRec (Array) (permute) ('')) (['oo!', 'oo?', 'on!', 'on?', 'no!', 'no?', 'nn!', 'nn?']);
+  eq (S.chainRec (Array)
+                 (s => s.length === 2 ? map (S.Right) ([s + '!', s + '?'])
+                                      : map (S.Left) ([s + 'o', s + 'n']))
+                 (''))
+     (['oo!', 'oo?', 'on!', 'on?', 'no!', 'no?', 'nn!', 'nn?']);
 
   //  The following test case is concerned with stack usage rather than with
   //  the correctness of the result. This test case is a slightly modified
   //  version of one from sanctuary-type-classes. The "stop" value is lower
   //  to prevent the execution time from exceeding the test runner's timeout.
-  function stepper(n) {
-    return n === 3000 ? map (S.Right) (function(env) { return n + env.inc; })
-                      : map (S.Left) (function(env) { return n + env.step; });
-  }
-  eq (S.chainRec (Function) (stepper) (0) ({step: 2, inc: 100})) (3100);
+  eq (S.chainRec (Function)
+                 (n => n === 3000 ? map (S.Right) (env => n + env.inc)
+                                  : map (S.Left) (env => n + env.step))
+                 (0)
+                 ({step: 2, inc: 100}))
+     (3100);
 
 });

--- a/test/clamp.js
+++ b/test/clamp.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('clamp', function() {
+test ('clamp', () => {
 
   eq (typeof S.clamp) ('function');
   eq (S.clamp.length) (1);

--- a/test/complement.js
+++ b/test/complement.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('complement', function() {
+test ('complement', () => {
 
   eq (typeof S.complement) ('function');
   eq (S.complement.length) (1);

--- a/test/compose.js
+++ b/test/compose.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('compose', function() {
+test ('compose', () => {
 
   eq (typeof S.compose) ('function');
   eq (S.compose.length) (1);

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('concat', function() {
+test ('concat', () => {
 
   eq (typeof S.concat) ('function');
   eq (S.concat.length) (1);

--- a/test/contramap.js
+++ b/test/contramap.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('contramap', function() {
+test ('contramap', () => {
 
   eq (typeof S.contramap) ('function');
   eq (S.contramap.length) (1);

--- a/test/create.js
+++ b/test/create.js
@@ -1,32 +1,32 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var throws = require ('./internal/throws');
-
-
-//  FooTrue42 :: Type
-var FooTrue42 = $.EnumType ('my-package/FooTrue42') ('') (['foo', true, 42]);
-
-//  customEnv :: Array Type
-var customEnv = S.env.concat ([FooTrue42]);
-
-var checkedDefaultEnv   = S.create ({checkTypes: true, env: S.env});
-var checkedCustomEnv    = S.create ({checkTypes: true, env: customEnv});
-var uncheckedDefaultEnv = S.create ({checkTypes: false, env: S.env});
-var uncheckedCustomEnv  = S.create ({checkTypes: false, env: customEnv});
+const eq = require ('./internal/eq');
+const throws = require ('./internal/throws');
 
 
-test ('create', function() {
+//    FooTrue42 :: Type
+const FooTrue42 = $.EnumType ('my-package/FooTrue42') ('') (['foo', true, 42]);
+
+//    customEnv :: Array Type
+const customEnv = S.env.concat ([FooTrue42]);
+
+const checkedDefaultEnv   = S.create ({checkTypes: true, env: S.env});
+const checkedCustomEnv    = S.create ({checkTypes: true, env: customEnv});
+const uncheckedDefaultEnv = S.create ({checkTypes: false, env: S.env});
+const uncheckedCustomEnv  = S.create ({checkTypes: false, env: customEnv});
+
+
+test ('create', () => {
 
   eq (typeof S.create) ('function');
   eq (S.create.length) (1);
   eq (S.show (S.create)) ('create :: { checkTypes :: Boolean, env :: Array Any } -> Object');
 
-  var expected = S.sort (Object.keys (S));
+  const expected = S.sort (Object.keys (S));
   eq (S.sort (Object.keys (checkedDefaultEnv))) (expected);
   eq (S.sort (Object.keys (checkedCustomEnv))) (expected);
   eq (S.sort (Object.keys (uncheckedDefaultEnv))) (expected);
@@ -45,7 +45,7 @@ test ('create', function() {
   eq (uncheckedDefaultEnv.add (1) (42)) (S.add (1) (42));
   eq (uncheckedDefaultEnv.add (1) ('XXX')) ('1XXX');
 
-  throws (function() { S.I (['foo', 'foo', 42]); })
+  throws (() => { S.I (['foo', 'foo', 42]); })
          (new TypeError ('Type-variable constraint violation\n' +
                          '\n' +
                          'I :: a -> a\n' +

--- a/test/curry2.js
+++ b/test/curry2.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Z = require ('sanctuary-type-classes');
+const Z = require ('sanctuary-type-classes');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('curry2', function() {
+test ('curry2', () => {
 
   eq (typeof S.curry2) ('function');
   eq (S.curry2.length) (1);

--- a/test/curry3.js
+++ b/test/curry3.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('curry3', function() {
+test ('curry3', () => {
 
   eq (typeof S.curry3) ('function');
   eq (S.curry3.length) (1);
   eq (S.show (S.curry3)) ('curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d');
 
-  eq (S.curry3 (function(x, y, z) { return x + y + z; }) ('x') ('y') ('z')) ('xyz');
+  eq (S.curry3 ((x, y, z) => x + y + z) ('x') ('y') ('z')) ('xyz');
 
 });

--- a/test/curry4.js
+++ b/test/curry4.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('curry4', function() {
+test ('curry4', () => {
 
   eq (typeof S.curry4) ('function');
   eq (S.curry4.length) (1);
   eq (S.show (S.curry4)) ('curry4 :: ((a, b, c, d) -> e) -> a -> b -> c -> d -> e');
 
-  eq (S.curry4 (function(w, x, y, z) { return w + x + y + z; }) ('w') ('x') ('y') ('z')) ('wxyz');
+  eq (S.curry4 ((w, x, y, z) => w + x + y + z) ('w') ('x') ('y') ('z')) ('wxyz');
 
 });

--- a/test/curry5.js
+++ b/test/curry5.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('curry5', function() {
+test ('curry5', () => {
 
   eq (typeof S.curry5) ('function');
   eq (S.curry5.length) (1);
   eq (S.show (S.curry5)) ('curry5 :: ((a, b, c, d, e) -> r) -> a -> b -> c -> d -> e -> r');
 
-  eq (S.curry5 (function(v, w, x, y, z) { return v + w + x + y + z; }) ('v') ('w') ('x') ('y') ('z')) ('vwxyz');
+  eq (S.curry5 ((v, w, x, y, z) => v + w + x + y + z) ('v') ('w') ('x') ('y') ('z')) ('vwxyz');
 
 });

--- a/test/div.js
+++ b/test/div.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('div', function() {
+test ('div', () => {
 
   eq (typeof S.div) ('function');
   eq (S.div.length) (1);

--- a/test/drop.js
+++ b/test/drop.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('drop', function() {
+test ('drop', () => {
 
   eq (typeof S.drop) ('function');
   eq (S.drop.length) (1);

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('dropLast', function() {
+test ('dropLast', () => {
 
   eq (typeof S.dropLast) ('function');
   eq (S.dropLast.length) (1);

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('dropWhile', function() {
+test ('dropWhile', () => {
 
   eq (typeof S.dropWhile) ('function');
   eq (S.dropWhile.length) (1);

--- a/test/duplicate.js
+++ b/test/duplicate.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('duplicate', function() {
+test ('duplicate', () => {
 
   eq (typeof S.duplicate) ('function');
   eq (S.duplicate.length) (1);

--- a/test/either.js
+++ b/test/either.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('either', function() {
+test ('either', () => {
 
   eq (typeof S.either) ('function');
   eq (S.either.length) (1);

--- a/test/eitherToMaybe.js
+++ b/test/eitherToMaybe.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('eitherToMaybe', function() {
+test ('eitherToMaybe', () => {
 
   eq (typeof S.eitherToMaybe) ('function');
   eq (S.eitherToMaybe.length) (1);

--- a/test/elem.js
+++ b/test/elem.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('elem', function() {
+test ('elem', () => {
 
   eq (typeof S.elem) ('function');
   eq (S.elem.length) (1);

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('empty', function() {
+test ('empty', () => {
 
   eq (typeof S.empty) ('function');
   eq (S.empty.length) (1);

--- a/test/encase.js
+++ b/test/encase.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var factorial = require ('./internal/factorial');
+const eq = require ('./internal/eq');
+const factorial = require ('./internal/factorial');
 
 
-test ('encase', function() {
+test ('encase', () => {
 
   eq (typeof S.encase) ('function');
   eq (S.encase.length) (1);

--- a/test/encase2.js
+++ b/test/encase2.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var rem = require ('./internal/rem');
+const eq = require ('./internal/eq');
+const rem = require ('./internal/rem');
 
 
-test ('encase2', function() {
+test ('encase2', () => {
 
   eq (typeof S.encase2) ('function');
   eq (S.encase2.length) (1);

--- a/test/encase3.js
+++ b/test/encase3.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var area = require ('./internal/area');
-var eq = require ('./internal/eq');
+const area = require ('./internal/area');
+const eq = require ('./internal/eq');
 
 
-test ('encase3', function() {
+test ('encase3', () => {
 
   eq (typeof S.encase3) ('function');
   eq (S.encase3.length) (1);

--- a/test/encaseEither.js
+++ b/test/encaseEither.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var factorial = require ('./internal/factorial');
+const eq = require ('./internal/eq');
+const factorial = require ('./internal/factorial');
 
 
-test ('encaseEither', function() {
+test ('encaseEither', () => {
 
   eq (typeof S.encaseEither) ('function');
   eq (S.encaseEither.length) (1);

--- a/test/encaseEither2.js
+++ b/test/encaseEither2.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var rem = require ('./internal/rem');
+const eq = require ('./internal/eq');
+const rem = require ('./internal/rem');
 
 
-test ('encaseEither2', function() {
+test ('encaseEither2', () => {
 
   eq (typeof S.encaseEither2) ('function');
   eq (S.encaseEither2.length) (1);

--- a/test/encaseEither3.js
+++ b/test/encaseEither3.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var area = require ('./internal/area');
-var eq = require ('./internal/eq');
+const area = require ('./internal/area');
+const eq = require ('./internal/eq');
 
 
-test ('encaseEither3', function() {
+test ('encaseEither3', () => {
 
   eq (typeof S.encaseEither3) ('function');
   eq (S.encaseEither3.length) (1);

--- a/test/env.js
+++ b/test/env.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('env', function() {
+test ('env', () => {
 
   eq (typeof S.env) ('object');
   eq (S.is ($.Array ($.Type)) (S.env)) (true);

--- a/test/equals.js
+++ b/test/equals.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('equals', function() {
+test ('equals', () => {
 
   eq (typeof S.equals) ('function');
   eq (S.equals.length) (1);

--- a/test/even.js
+++ b/test/even.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('even', function() {
+test ('even', () => {
 
   eq (typeof S.even) ('function');
   eq (S.even.length) (1);

--- a/test/extend.js
+++ b/test/extend.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Identity = require ('sanctuary-identity');
+const Identity = require ('sanctuary-identity');
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('extend', function() {
+test ('extend', () => {
 
   eq (typeof S.extend) ('function');
   eq (S.extend.length) (1);

--- a/test/extract.js
+++ b/test/extract.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Identity = require ('sanctuary-identity');
+const Identity = require ('sanctuary-identity');
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('extract', function() {
+test ('extract', () => {
 
   eq (typeof S.extract) ('function');
   eq (S.extract.length) (1);

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('filter', function() {
+test ('filter', () => {
 
   eq (typeof S.filter) ('function');
   eq (S.filter.length) (1);

--- a/test/find.js
+++ b/test/find.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('find', function() {
+test ('find', () => {
 
   eq (typeof S.find) ('function');
   eq (S.find.length) (1);

--- a/test/flip.js
+++ b/test/flip.js
@@ -1,17 +1,13 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-var map = require ('./internal/map');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
+const map = require ('./internal/map');
 
 
-test ('flip', function() {
+test ('flip', () => {
 
   eq (typeof S.flip) ('function');
   eq (S.flip.length) (1);

--- a/test/foldMap.js
+++ b/test/foldMap.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('foldMap', function() {
+test ('foldMap', () => {
 
   eq (typeof S.foldMap) ('function');
   eq (S.foldMap.length) (1);
   eq (S.show (S.foldMap)) ('foldMap :: (Monoid b, Foldable f) => TypeRep b -> (a -> b) -> f a -> b');
 
-  function repeat(n) { return (new Array (n + 1)).join (String (n)); }
+  const repeat = n => (new Array (n + 1)).join (String (n));
   eq (S.foldMap (String) (repeat) ([])) ('');
   eq (S.foldMap (String) (repeat) ([1])) ('1');
   eq (S.foldMap (String) (repeat) ([1, 2])) ('122');

--- a/test/fromEither.js
+++ b/test/fromEither.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('fromEither', function() {
+test ('fromEither', () => {
 
   eq (typeof S.fromEither) ('function');
   eq (S.fromEither.length) (1);

--- a/test/fromMaybe.js
+++ b/test/fromMaybe.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('fromMaybe', function() {
+test ('fromMaybe', () => {
 
   eq (typeof S.fromMaybe) ('function');
   eq (S.fromMaybe.length) (1);

--- a/test/fromMaybe_.js
+++ b/test/fromMaybe_.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('fromMaybe_', function() {
+test ('fromMaybe_', () => {
 
   eq (typeof S.fromMaybe_) ('function');
   eq (S.fromMaybe_.length) (1);
   eq (S.show (S.fromMaybe_)) ('fromMaybe_ :: (() -> a) -> Maybe a -> a');
 
-  eq (S.fromMaybe_ (function() { return 0; }) (S.Nothing)) (0);
-  eq (S.fromMaybe_ (function() { return 0; }) (S.Just (42))) (42);
+  eq (S.fromMaybe_ (() => 0) (S.Nothing)) (0);
+  eq (S.fromMaybe_ (() => 0) (S.Just (42))) (42);
 
-  var count = 0;
-  eq (S.fromMaybe_ (function() { return count += 1; }) (S.Just (42))) (42);
+  let count = 0;
+  eq (S.fromMaybe_ (() => count += 1) (S.Just (42))) (42);
   eq (count) (0);
 
 });

--- a/test/fromPairs.js
+++ b/test/fromPairs.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('fromPairs', function() {
+test ('fromPairs', () => {
 
   eq (typeof S.fromPairs) ('function');
   eq (S.fromPairs.length) (1);

--- a/test/fst.js
+++ b/test/fst.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('fst', function() {
+test ('fst', () => {
 
   eq (typeof S.fst) ('function');
   eq (S.fst.length) (1);

--- a/test/get.js
+++ b/test/get.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var vm = require ('vm');
+const vm = require ('vm');
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('get', function() {
+test ('get', () => {
 
   eq (typeof S.get) ('function');
   eq (S.get.length) (1);

--- a/test/gets.js
+++ b/test/gets.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var vm = require ('vm');
+const vm = require ('vm');
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('gets', function() {
+test ('gets', () => {
 
   eq (typeof S.gets) ('function');
   eq (S.gets.length) (1);

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -1,39 +1,27 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('groupBy', function() {
+test ('groupBy', () => {
 
   eq (typeof S.groupBy) ('function');
   eq (S.groupBy.length) (1);
   eq (S.show (S.groupBy)) ('groupBy :: (a -> a -> Boolean) -> Array a -> Array (Array a)');
 
-  function productsOf3(x) {
-    return function(y) {
-      return x * y % 3 === 0;
-    };
-  }
-
-  function zeroSum(x) {
-    return function(y) {
-      return x + y === 0;
-    };
-  }
-
-  eq (S.groupBy (productsOf3) ([])) ([]);
-  eq (S.groupBy (productsOf3) ([1, 2, 3, 4, 5, 6, 7, 8, 9])) ([[1], [2, 3], [4], [5, 6], [7], [8, 9]]);
+  eq (S.groupBy (x => y => x * y % 3 === 0) ([])) ([]);
+  eq (S.groupBy (x => y => x * y % 3 === 0) ([1, 2, 3, 4, 5, 6, 7, 8, 9])) ([[1], [2, 3], [4], [5, 6], [7], [8, 9]]);
   eq (S.groupBy (equals) ([1, 1, 2, 1, 1])) ([[1, 1], [2], [1, 1]]);
-  eq (S.groupBy (zeroSum) ([2, -3, 3, 3, 3, 4, -4, 4])) ([[2], [-3, 3, 3, 3], [4, -4], [4]]);
+  eq (S.groupBy (x => y => x + y === 0) ([2, -3, 3, 3, 3, 4, -4, 4])) ([[2], [-3, 3, 3, 3], [4, -4], [4]]);
 
-  jsc.assert (jsc.forall ('nat -> nat -> bool', 'array nat', function(f, xs) {
-    var lhs = S.join (S.groupBy (f) (xs));
-    var rhs = xs;
+  jsc.assert (jsc.forall ('nat -> nat -> bool', 'array nat', (f, xs) => {
+    const lhs = S.join (S.groupBy (f) (xs));
+    const rhs = xs;
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/gt.js
+++ b/test/gt.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('gt', function() {
+test ('gt', () => {
 
   eq (typeof S.gt) ('function');
   eq (S.gt.length) (1);

--- a/test/gte.js
+++ b/test/gte.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('gte', function() {
+test ('gte', () => {
 
   eq (typeof S.gte) ('function');
   eq (S.gte.length) (1);

--- a/test/head.js
+++ b/test/head.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('head', function() {
+test ('head', () => {
 
   eq (typeof S.head) ('function');
   eq (S.head.length) (1);

--- a/test/id.js
+++ b/test/id.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('id', function() {
+test ('id', () => {
 
   eq (typeof S.id) ('function');
   eq (S.id.length) (1);

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('ifElse', function() {
+test ('ifElse', () => {
 
   eq (typeof S.ifElse) ('function');
   eq (S.ifElse.length) (1);

--- a/test/init.js
+++ b/test/init.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('init', function() {
+test ('init', () => {
 
   eq (typeof S.init) ('function');
   eq (S.init.length) (1);

--- a/test/insert.js
+++ b/test/insert.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('insert', function() {
+test ('insert', () => {
 
   eq (typeof S.insert) ('function');
   eq (S.insert.length) (1);
@@ -18,10 +18,10 @@ test ('insert', function() {
   eq (S.insert ('b') (2) ({a: 1})) ({a: 1, b: 2});
   eq (S.insert ('c') (3) ({a: 1, b: 2, c: 4})) ({a: 1, b: 2, c: 3});
 
-  jsc.assert (jsc.forall (jsc.string, jsc.number, jsc.dict (jsc.number), function(key, val, map) {
-    var insert = S.insert (key) (val);
-    var lhs = insert (insert (map));
-    var rhs = insert (map);
+  jsc.assert (jsc.forall (jsc.string, jsc.number, jsc.dict (jsc.number), (key, val, map) => {
+    const insert = S.insert (key) (val);
+    const lhs = insert (insert (map));
+    const rhs = insert (map);
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/internal/List.js
+++ b/test/internal/List.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var FL = require ('fantasy-land');
-var $ = require ('sanctuary-def');
-var show = require ('sanctuary-show');
-var Z = require ('sanctuary-type-classes');
-var type = require ('sanctuary-type-identifiers');
+const FL = require ('fantasy-land');
+const $ = require ('sanctuary-def');
+const show = require ('sanctuary-show');
+const Z = require ('sanctuary-type-classes');
+const type = require ('sanctuary-type-identifiers');
 
-var eq = require ('./eq');
+const eq = require ('./eq');
 
 
-var List = {prototype: _List.prototype};
+const List = {prototype: _List.prototype};
 
 List.prototype.constructor = List;
 
@@ -24,20 +24,18 @@ function _List(tag, head, tail) {
 
 List['@@type'] = 'sanctuary/List';
 
-//  Type :: Type -> Type
+//    Type :: Type -> Type
 List.Type = $.UnaryType
   (List['@@type'])
   ('')
-  (function(x) { return type (x) === List['@@type']; })
-  (function(list) {
-     return Z.reduce (function(xs, x) { xs.push (x); return xs; }, [], list);
-   });
+  (x => type (x) === List['@@type'])
+  (list => Z.reduce ((xs, x) => ((xs.push (x), xs)), [], list));
 
-//  Nil :: List a
-var Nil = List.Nil = new _List ('Nil');
+//    Nil :: List a
+const Nil = List.Nil = new _List ('Nil');
 
-//  Cons :: a -> List a -> List a
-var Cons = List.Cons = function Cons(head) {
+//    Cons :: a -> List a -> List a
+const Cons = List.Cons = function Cons(head) {
   eq (arguments.length) (Cons.length);
   return function Cons$1(tail) {
     eq (arguments.length) (Cons$1.length);
@@ -45,9 +43,9 @@ var Cons = List.Cons = function Cons(head) {
   };
 };
 
-List[FL.empty] = function() { return Nil; };
+List[FL.empty] = () => Nil;
 
-List[FL.of] = function(x) { return Cons (x) (Nil); };
+List[FL.of] = x => Cons (x) (Nil);
 
 List[FL.zero] = List[FL.empty];
 

--- a/test/internal/Sum.js
+++ b/test/internal/Sum.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var FL = require ('fantasy-land');
-var $ = require ('sanctuary-def');
-var show = require ('sanctuary-show');
-var Z = require ('sanctuary-type-classes');
-var type = require ('sanctuary-type-identifiers');
+const FL = require ('fantasy-land');
+const $ = require ('sanctuary-def');
+const show = require ('sanctuary-show');
+const Z = require ('sanctuary-type-classes');
+const type = require ('sanctuary-type-identifiers');
 
 
-//  Sum :: Number -> Sum
+//    Sum :: Number -> Sum
 function Sum(value) {
   if (!(this instanceof Sum)) return new Sum (value);
   this.value = value;
@@ -15,13 +15,13 @@ function Sum(value) {
 
 Sum['@@type'] = 'sanctuary/Sum';
 
-//  Type :: Type
+//    Type :: Type
 Sum.Type = $.NullaryType
   (Sum['@@type'])
   ('')
-  (function(x) { return type (x) === Sum['@@type']; });
+  (x => type (x) === Sum['@@type']);
 
-Sum[FL.empty] = function() { return Sum (0); };
+Sum[FL.empty] = () => Sum (0);
 
 Sum.prototype[FL.equals] = function(other) {
   return Z.equals (this.value, other.value);

--- a/test/internal/area.js
+++ b/test/internal/area.js
@@ -1,15 +1,11 @@
 'use strict';
 
-//  area :: Number -> Number -> Number -> Number !
-module.exports = function area(a) {
-  return function(b) {
-    return function(c) {
-      if (Math.max (a, b, c) < (a + b + c) / 2) {
-        var s = (a + b + c) / 2;
-        return Math.sqrt (s * (s - a) * (s - b) * (s - c));
-      } else {
-        throw new Error ('Impossible triangle');
-      }
-    };
-  };
+//    area :: Number -> Number -> Number -> Number !
+module.exports = a => b => c => {
+  if (Math.max (a, b, c) < (a + b + c) / 2) {
+    const s = (a + b + c) / 2;
+    return Math.sqrt (s * (s - a) * (s - b) * (s - c));
+  } else {
+    throw new Error ('Impossible triangle');
+  }
 };

--- a/test/internal/concat.js
+++ b/test/internal/concat.js
@@ -1,8 +1,0 @@
-'use strict';
-
-var Z = require ('sanctuary-type-classes');
-
-var curry2 = require ('./curry2');
-
-//  concat :: Semigroup a => a -> a -> a
-module.exports = curry2 (Z.concat);

--- a/test/internal/curry2.js
+++ b/test/internal/curry2.js
@@ -1,10 +1,4 @@
 'use strict';
 
-//  curry2 :: ((a, b) -> c) -> a -> b -> c
-module.exports = function curry2(f) {
-  return function(x) {
-    return function(y) {
-      return f (x, y);
-    };
-  };
-};
+//    curry2 :: ((a, b) -> c) -> a -> b -> c
+module.exports = f => x => y => f (x, y);

--- a/test/internal/eq.js
+++ b/test/internal/eq.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var assert = require ('assert');
+const assert = require ('assert');
 
-var show = require ('sanctuary-show');
+const show = require ('sanctuary-show');
 
-var equals = require ('./equals');
+const equals = require ('./equals');
 
-//  eq :: a -> b -> Undefined !
+//    eq :: a -> b -> Undefined !
 module.exports = function eq(actual) {
   assert.strictEqual (arguments.length, eq.length);
   return function eq$1(expected) {

--- a/test/internal/equals.js
+++ b/test/internal/equals.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Z = require ('sanctuary-type-classes');
+const Z = require ('sanctuary-type-classes');
 
-var curry2 = require ('./curry2');
+const curry2 = require ('./curry2');
 
-//  equals :: a -> b -> Boolean
+//    equals :: a -> b -> Boolean
 module.exports = curry2 (Z.equals);

--- a/test/internal/factorial.js
+++ b/test/internal/factorial.js
@@ -1,6 +1,6 @@
 'use strict';
 
-//  factorial :: Number -> Number !
+//    factorial :: Number -> Number !
 module.exports = function factorial(n) {
   if (n < 0) {
     throw new Error ('Cannot determine factorial of negative number');

--- a/test/internal/map.js
+++ b/test/internal/map.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Z = require ('sanctuary-type-classes');
+const Z = require ('sanctuary-type-classes');
 
-var curry2 = require ('./curry2');
+const curry2 = require ('./curry2');
 
-//  map :: Functor f => (a -> b) -> f a -> f b
+//    map :: Functor f => (a -> b) -> f a -> f b
 module.exports = curry2 (Z.map);

--- a/test/internal/pair.js
+++ b/test/internal/pair.js
@@ -1,8 +1,0 @@
-'use strict';
-
-//  pair :: a -> b -> Pair a b
-module.exports = function pair(x) {
-  return function(y) {
-    return [x, y];
-  };
-};

--- a/test/internal/rem.js
+++ b/test/internal/rem.js
@@ -1,12 +1,10 @@
 'use strict';
 
-//  rem :: Number -> Number -> Number !
-module.exports = function rem(x) {
-  return function(y) {
-    if (y === 0) {
-      throw new Error ('Cannot divide by zero');
-    } else {
-      return x % y;
-    }
-  };
+//    rem :: Number -> Number -> Number !
+module.exports = x => y => {
+  if (y === 0) {
+    throw new Error ('Cannot divide by zero');
+  } else {
+    return x % y;
+  }
 };

--- a/test/internal/sanctuary.js
+++ b/test/internal/sanctuary.js
@@ -1,30 +1,28 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
-var type = require ('sanctuary-type-identifiers');
+const $ = require ('sanctuary-def');
+const type = require ('sanctuary-type-identifiers');
 
-var S = require ('../..');
+const S = require ('../..');
 
-var List = require ('./List');
-var Sum = require ('./Sum');
+const List = require ('./List');
+const Sum = require ('./Sum');
 
 
-//  UnaryType :: String -> Type
-function UnaryType(typeIdent) {
-  return $.UnaryType
-    (typeIdent)
-    ('')
-    (function(x) { return type (x) === typeIdent; })
-    (function(v) { return [v.value]; })
-    ($.Unknown);
-}
+//    UnaryType :: String -> Type
+const UnaryType = typeIdent =>
+  $.UnaryType (typeIdent)
+              ('')
+              (x => type (x) === typeIdent)
+              (v => [v.value])
+              ($.Unknown);
 
-//  env :: Array Type
-var env = S.env.concat ([
+//    env :: Array Type
+const env = S.env.concat ([
   UnaryType ('sanctuary/Compose'),
   UnaryType ('sanctuary-identity/Identity@1'),
   List.Type ($.Unknown),
-  Sum.Type
+  Sum.Type,
 ]);
 
 module.exports = S.create ({checkTypes: true, env: env});

--- a/test/internal/throws.js
+++ b/test/internal/throws.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var assert = require ('assert');
+const assert = require ('assert');
 
-var equals = require ('./equals');
+const equals = require ('./equals');
 
-//  throws :: (() -> Undefined !) -> Error -> Undefined !
+//    throws :: (() -> Undefined !) -> Error -> Undefined !
 module.exports = function throws(thunk) {
   assert.strictEqual (arguments.length, throws.length);
   return function throws$1(expected) {

--- a/test/invert.js
+++ b/test/invert.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var Sum = require ('./internal/Sum');
-var eq = require ('./internal/eq');
+const Sum = require ('./internal/Sum');
+const eq = require ('./internal/eq');
 
 
-test ('invert', function() {
+test ('invert', () => {
 
   eq (typeof S.invert) ('function');
   eq (S.invert.length) (1);

--- a/test/is.js
+++ b/test/is.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var Sum = require ('./internal/Sum');
-var eq = require ('./internal/eq');
+const Sum = require ('./internal/Sum');
+const eq = require ('./internal/eq');
 
 
-test ('is', function() {
+test ('is', () => {
 
   eq (typeof S.is) ('function');
   eq (S.is.length) (1);
@@ -38,7 +38,7 @@ test ('is', function() {
   eq (S.is (S.EitherType ($.String) ($.Integer)) (S.Left (''))) (true);
   eq (S.is (S.EitherType ($.String) ($.Integer)) (S.Right (0))) (true);
 
-  var a = $.TypeVariable ('a');
+  const a = $.TypeVariable ('a');
 
   eq (S.is ($.Array (a)) ([])) (true);
   eq (S.is ($.Array (a)) ([1, 2, 3])) (true);

--- a/test/isJust.js
+++ b/test/isJust.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('isJust', function() {
+test ('isJust', () => {
 
   eq (typeof S.isJust) ('function');
   eq (S.isJust.length) (1);

--- a/test/isLeft.js
+++ b/test/isLeft.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('isLeft', function() {
+test ('isLeft', () => {
 
   eq (typeof S.isLeft) ('function');
   eq (S.isLeft.length) (1);

--- a/test/isNothing.js
+++ b/test/isNothing.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('isNothing', function() {
+test ('isNothing', () => {
 
   eq (typeof S.isNothing) ('function');
   eq (S.isNothing.length) (1);

--- a/test/isRight.js
+++ b/test/isRight.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('isRight', function() {
+test ('isRight', () => {
 
   eq (typeof S.isRight) ('function');
   eq (S.isRight.length) (1);

--- a/test/join.js
+++ b/test/join.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('join', function() {
+test ('join', () => {
 
   eq (typeof S.join) ('function');
   eq (S.join.length) (1);

--- a/test/joinWith.js
+++ b/test/joinWith.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('joinWith', function() {
+test ('joinWith', () => {
 
   eq (typeof S.joinWith) ('function');
   eq (S.joinWith.length) (1);

--- a/test/justs.js
+++ b/test/justs.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('justs', function() {
+test ('justs', () => {
 
   eq (typeof S.justs) ('function');
   eq (S.justs.length) (1);

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('keys', function() {
+test ('keys', () => {
 
   eq (typeof S.keys) ('function');
   eq (S.keys.length) (1);
@@ -14,8 +14,8 @@ test ('keys', function() {
   eq (S.sort (S.keys ({}))) ([]);
   eq (S.sort (S.keys ({a: 1, b: 2, c: 3}))) (['a', 'b', 'c']);
 
-  var proto = {a: 1, b: 2};
-  var obj = Object.create (proto);
+  const proto = {a: 1, b: 2};
+  const obj = Object.create (proto);
   obj.c = 3;
   obj.d = 4;
 

--- a/test/last.js
+++ b/test/last.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('last', function() {
+test ('last', () => {
 
   eq (typeof S.last) ('function');
   eq (S.last.length) (1);

--- a/test/lefts.js
+++ b/test/lefts.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('lefts', function() {
+test ('lefts', () => {
 
   eq (typeof S.lefts) ('function');
   eq (S.lefts.length) (1);

--- a/test/lift2.js
+++ b/test/lift2.js
@@ -1,18 +1,15 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('lift2', function() {
+test ('lift2', () => {
 
   eq (typeof S.lift2) ('function');
   eq (S.lift2.length) (1);
   eq (S.show (S.lift2)) ('lift2 :: Apply f => (a -> b -> c) -> f a -> f b -> f c');
-
-  //  positive :: Number -> Boolean
-  function positive(n) { return n > 0; }
 
   eq (S.lift2 (S.add) (S.Just (3)) (S.Just (3))) (S.Just (6));
   eq (S.lift2 (S.add) (S.Nothing) (S.Just (3))) (S.Nothing);
@@ -23,9 +20,9 @@ test ('lift2', function() {
   eq (S.lift2 (S.add) ([1, 2]) ([10, 20])) ([11, 21, 12, 22]);
   eq (S.lift2 (S.add) ([]) ([1, 2])) ([]);
 
-  eq (S.lift2 (S.and) (S.even) (positive) (42)) (true);
-  eq (S.lift2 (S.and) (S.even) (positive) (43)) (false);
-  eq (S.lift2 (S.and) (S.even) (positive) (-42)) (false);
-  eq (S.lift2 (S.and) (S.even) (positive) (-43)) (false);
+  eq (S.lift2 (S.and) (S.even) (S.gt (0)) (42)) (true);
+  eq (S.lift2 (S.and) (S.even) (S.gt (0)) (43)) (false);
+  eq (S.lift2 (S.and) (S.even) (S.gt (0)) (-42)) (false);
+  eq (S.lift2 (S.and) (S.even) (S.gt (0)) (-43)) (false);
 
 });

--- a/test/lift3.js
+++ b/test/lift3.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var area = require ('./internal/area');
-var eq = require ('./internal/eq');
+const area = require ('./internal/area');
+const eq = require ('./internal/eq');
 
 
-test ('lift3', function() {
+test ('lift3', () => {
 
   eq (typeof S.lift3) ('function');
   eq (S.lift3.length) (1);

--- a/test/lines.js
+++ b/test/lines.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('lines', function() {
+test ('lines', () => {
 
   eq (typeof S.lines) ('function');
   eq (S.lines.length) (1);

--- a/test/lt.js
+++ b/test/lt.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('lt', function() {
+test ('lt', () => {
 
   eq (typeof S.lt) ('function');
   eq (S.lt.length) (1);

--- a/test/lte.js
+++ b/test/lte.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('lte', function() {
+test ('lte', () => {
 
   eq (typeof S.lte) ('function');
   eq (S.lte.length) (1);

--- a/test/map.js
+++ b/test/map.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('map', function() {
+test ('map', () => {
 
   eq (typeof S.map) ('function');
   eq (S.map.length) (1);

--- a/test/mapLeft.js
+++ b/test/mapLeft.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('mapLeft', function() {
+test ('mapLeft', () => {
 
   eq (typeof S.mapLeft) ('function');
   eq (S.mapLeft.length) (1);

--- a/test/mapMaybe.js
+++ b/test/mapMaybe.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('mapMaybe', function() {
+test ('mapMaybe', () => {
 
   eq (typeof S.mapMaybe) ('function');
   eq (S.mapMaybe.length) (1);

--- a/test/match.js
+++ b/test/match.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('match', function() {
+test ('match', () => {
 
   eq (typeof S.match) ('function');
   eq (S.match.length) (1);
   eq (S.show (S.match)) ('match :: NonGlobalRegExp -> String -> Maybe { groups :: Array (Maybe String), match :: String }');
 
-  var scheme = '([a-z][a-z0-9+.-]*)';
-  var authentication = '(.*?):(.*?)@';
-  var hostname = '(.*?)';
-  var port = ':([0-9]*)';
-  var pattern = S.regex ('') (scheme + '://(?:' + authentication + ')?' + hostname + '(?:' + port + ')?(?!\\S)');
+  const scheme = '([a-z][a-z0-9+.-]*)';
+  const authentication = '(.*?):(.*?)@';
+  const hostname = '(.*?)';
+  const port = ':([0-9]*)';
+  const pattern = S.regex ('') (scheme + '://(?:' + authentication + ')?' + hostname + '(?:' + port + ')?(?!\\S)');
 
   eq (S.match (pattern) ('URL: N/A'))
      (S.Nothing);
@@ -31,10 +31,10 @@ test ('match', function() {
      (S.Just ({match: 'http://user:pass@example.com:80',
               groups: [S.Just ('http'), S.Just ('user'), S.Just ('pass'), S.Just ('example.com'), S.Just ('80')]}));
 
-  jsc.assert (jsc.forall (jsc.string, function(s) {
-    var p = '([A-Za-z]+)';
-    var lhs = S.head (S.matchAll (S.regex ('g') (p)) (s));
-    var rhs = S.match (S.regex ('') (p)) (s);
+  jsc.assert (jsc.forall (jsc.string, s => {
+    const p = '([A-Za-z]+)';
+    const lhs = S.head (S.matchAll (S.regex ('g') (p)) (s));
+    const rhs = S.match (S.regex ('') (p)) (s);
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/matchAll.js
+++ b/test/matchAll.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('matchAll', function() {
+test ('matchAll', () => {
 
   eq (typeof S.matchAll) ('function');
   eq (S.matchAll.length) (1);
   eq (S.show (S.matchAll)) ('matchAll :: GlobalRegExp -> String -> Array { groups :: Array (Maybe String), match :: String }');
 
-  var pattern = S.regex ('g') ('<(h[1-6])(?: id="([^"]*)")?>([^<]*)</\\1>');
+  const pattern = S.regex ('g') ('<(h[1-6])(?: id="([^"]*)")?>([^<]*)</\\1>');
 
   eq (S.matchAll (pattern) ('')) ([]);
 

--- a/test/max.js
+++ b/test/max.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('max', function() {
+test ('max', () => {
 
   eq (typeof S.max) ('function');
   eq (S.max.length) (1);

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('maybe', function() {
+test ('maybe', () => {
 
   eq (typeof S.maybe) ('function');
   eq (S.maybe.length) (1);

--- a/test/maybeToEither.js
+++ b/test/maybeToEither.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('maybeToEither', function() {
+test ('maybeToEither', () => {
 
   eq (typeof S.maybeToEither) ('function');
   eq (S.maybeToEither.length) (1);

--- a/test/maybeToNullable.js
+++ b/test/maybeToNullable.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('maybeToNullable', function() {
+test ('maybeToNullable', () => {
 
   eq (typeof S.maybeToNullable) ('function');
   eq (S.maybeToNullable.length) (1);

--- a/test/maybe_.js
+++ b/test/maybe_.js
@@ -1,22 +1,22 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var factorial = require ('./internal/factorial');
+const eq = require ('./internal/eq');
+const factorial = require ('./internal/factorial');
 
 
-test ('maybe_', function() {
+test ('maybe_', () => {
 
   eq (typeof S.maybe_) ('function');
   eq (S.maybe_.length) (1);
   eq (S.show (S.maybe_)) ('maybe_ :: (() -> b) -> (a -> b) -> Maybe a -> b');
 
-  eq (S.maybe_ (function() { return factorial (10); }) (Math.sqrt) (S.Nothing)) (3628800);
-  eq (S.maybe_ (function() { return factorial (10); }) (Math.sqrt) (S.Just (9))) (3);
+  eq (S.maybe_ (() => factorial (10)) (Math.sqrt) (S.Nothing)) (3628800);
+  eq (S.maybe_ (() => factorial (10)) (Math.sqrt) (S.Just (9))) (3);
 
-  var count = 0;
-  eq (S.maybe_ (function() { return count += 1; }) (Math.sqrt) (S.Just (9))) (3);
+  let count = 0;
+  eq (S.maybe_ (() => count += 1) (Math.sqrt) (S.Just (9))) (3);
   eq (count) (0);
 
 });

--- a/test/mean.js
+++ b/test/mean.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('mean', function() {
+test ('mean', () => {
 
   eq (typeof S.mean) ('function');
   eq (S.mean.length) (1);

--- a/test/min.js
+++ b/test/min.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('min', function() {
+test ('min', () => {
 
   eq (typeof S.min) ('function');
   eq (S.min.length) (1);

--- a/test/mult.js
+++ b/test/mult.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('mult', function() {
+test ('mult', () => {
 
   eq (typeof S.mult) ('function');
   eq (S.mult.length) (1);

--- a/test/negate.js
+++ b/test/negate.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('negate', function() {
+test ('negate', () => {
 
   eq (typeof S.negate) ('function');
   eq (S.negate.length) (1);

--- a/test/none.js
+++ b/test/none.js
@@ -1,19 +1,15 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('none', function() {
+test ('none', () => {
 
   eq (typeof S.none) ('function');
   eq (S.none.length) (1);
@@ -39,17 +35,17 @@ test ('none', function() {
   eq (S.none (S.gt (0)) (S.Just (0))) (true);
   eq (S.none (S.gt (0)) (S.Just (1))) (false);
 
-  jsc.assert (jsc.forall (jsc.array (jsc.integer), function(xs) {
-    var p = S.odd;
-    var lhs = S.none (p) (xs);
-    var rhs = S.not (S.any (p) (xs));
+  jsc.assert (jsc.forall (jsc.array (jsc.integer), xs => {
+    const p = S.odd;
+    const lhs = S.none (p) (xs);
+    const rhs = S.not (S.any (p) (xs));
     return equals (lhs) (rhs);
   }), {tests: 1000});
 
-  jsc.assert (jsc.forall (jsc.array (jsc.integer), function(xs) {
-    var p = S.odd;
-    var lhs = S.none (p) (xs);
-    var rhs = S.all (S.complement (p)) (xs);
+  jsc.assert (jsc.forall (jsc.array (jsc.integer), xs => {
+    const p = S.odd;
+    const lhs = S.none (p) (xs);
+    const rhs = S.all (S.complement (p)) (xs);
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/not.js
+++ b/test/not.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('not', function() {
+test ('not', () => {
 
   eq (typeof S.not) ('function');
   eq (S.not.length) (1);

--- a/test/odd.js
+++ b/test/odd.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('odd', function() {
+test ('odd', () => {
 
   eq (typeof S.odd) ('function');
   eq (S.odd.length) (1);

--- a/test/of.js
+++ b/test/of.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Identity = require ('sanctuary-identity');
+const Identity = require ('sanctuary-identity');
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('of', function() {
+test ('of', () => {
 
   eq (typeof S.of) ('function');
   eq (S.of.length) (1);

--- a/test/on.js
+++ b/test/on.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var rem = require ('./internal/rem');
+const eq = require ('./internal/eq');
+const rem = require ('./internal/rem');
 
 
-test ('on', function() {
+test ('on', () => {
 
   eq (typeof S.on) ('function');
   eq (S.on.length) (1);

--- a/test/or.js
+++ b/test/or.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('or', function() {
+test ('or', () => {
 
   eq (typeof S.or) ('function');
   eq (S.or.length) (1);

--- a/test/pairs.js
+++ b/test/pairs.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('pairs', function() {
+test ('pairs', () => {
 
   eq (typeof S.pairs) ('function');
   eq (S.pairs.length) (1);
@@ -14,8 +14,8 @@ test ('pairs', function() {
   eq (S.sort (S.pairs ({}))) ([]);
   eq (S.sort (S.pairs ({a: 1, b: 2, c: 3}))) ([S.Pair ('a') (1), S.Pair ('b') (2), S.Pair ('c') (3)]);
 
-  var proto = {a: 1, b: 2};
-  var obj = Object.create (proto);
+  const proto = {a: 1, b: 2};
+  const obj = Object.create (proto);
   obj.c = 3;
   obj.d = 4;
 

--- a/test/parseDate.js
+++ b/test/parseDate.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('parseDate', function() {
+test ('parseDate', () => {
 
   eq (typeof S.parseDate) ('function');
   eq (S.parseDate.length) (1);

--- a/test/parseFloat.js
+++ b/test/parseFloat.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('parseFloat', function() {
+test ('parseFloat', () => {
 
   eq (typeof S.parseFloat) ('function');
   eq (S.parseFloat.length) (1);

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var throws = require ('./internal/throws');
+const eq = require ('./internal/eq');
+const throws = require ('./internal/throws');
 
 
-test ('parseInt', function() {
+test ('parseInt', () => {
 
   eq (typeof S.parseInt) ('function');
   eq (S.parseInt.length) (1);
@@ -90,7 +90,7 @@ test ('parseInt', function() {
   eq (S.parseInt (36) ('[')) (S.Nothing);
 
   // Throws if radix is not in [2 .. 36]
-  throws (function() { S.parseInt (1); })
+  throws (() => { S.parseInt (1); })
          (new TypeError ('Invalid value\n' +
                          '\n' +
                          'parseInt :: Radix -> String -> Maybe Integer\n' +
@@ -101,7 +101,7 @@ test ('parseInt', function() {
                          '\n' +
                          'The value at position 1 is not a member of ‘Radix’.\n'));
 
-  throws (function() { S.parseInt (37); })
+  throws (() => { S.parseInt (37); })
          (new TypeError ('Invalid value\n' +
                          '\n' +
                          'parseInt :: Radix -> String -> Maybe Integer\n' +

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var $ = require ('sanctuary-def');
+const $ = require ('sanctuary-def');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('parseJson', function() {
+test ('parseJson', () => {
 
   eq (typeof S.parseJson) ('function');
   eq (S.parseJson.length) (1);

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('pipe', function() {
+test ('pipe', () => {
 
   eq (typeof S.pipe) ('function');
   eq (S.pipe.length) (1);

--- a/test/pipeK.js
+++ b/test/pipeK.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('pipeK', function() {
+test ('pipeK', () => {
 
   eq (typeof S.pipeK) ('function');
   eq (S.pipeK.length) (1);

--- a/test/pow.js
+++ b/test/pow.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('pow', function() {
+test ('pow', () => {
 
   eq (typeof S.pow) ('function');
   eq (S.pow.length) (1);

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('prepend', function() {
+test ('prepend', () => {
 
   eq (typeof S.prepend) ('function');
   eq (S.prepend.length) (1);

--- a/test/product.js
+++ b/test/product.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('product', function() {
+test ('product', () => {
 
   eq (typeof S.product) ('function');
   eq (S.product.length) (1);

--- a/test/promap.js
+++ b/test/promap.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('promap', function() {
+test ('promap', () => {
 
   eq (typeof S.promap) ('function');
   eq (S.promap.length) (1);
   eq (S.show (S.promap)) ('promap :: Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d');
 
-  var before = S.map (S.prop ('length'));
-  var after = S.join (S.mult);
+  const before = S.map (S.prop ('length'));
+  const after = S.join (S.mult);
   eq (S.promap (before) (after) (S.sum) (['foo', 'bar', 'baz', 'quux'])) (169);
 
   eq (S.promap (Math.abs) (S.add (1)) (Math.sqrt) (-100)) (11);

--- a/test/prop.js
+++ b/test/prop.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var throws = require ('./internal/throws');
+const eq = require ('./internal/eq');
+const throws = require ('./internal/throws');
 
 
-test ('prop', function() {
+test ('prop', () => {
 
   eq (typeof S.prop) ('function');
   eq (S.prop.length) (1);
   eq (S.show (S.prop)) ('prop :: String -> a -> b');
 
-  throws (function() { S.prop ('xxx') ([1, 2, 3]); })
+  throws (() => { S.prop ('xxx') ([1, 2, 3]); })
          (new TypeError ('‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not'));
 
   eq (S.prop ('a') ({a: 0, b: 1})) (0);
@@ -21,10 +21,10 @@ test ('prop', function() {
   eq (S.prop ('x') (Object.create ({x: 1, y: 2}))) (1);
   eq (S.prop ('global') (/x/g)) (true);
 
-  throws (function() { S.prop ('valueOf') (null); })
+  throws (() => { S.prop ('valueOf') (null); })
          (new TypeError ('‘prop’ expected object to have a property named ‘valueOf’; null does not'));
 
-  throws (function() { S.prop ('valueOf') (undefined); })
+  throws (() => { S.prop ('valueOf') (undefined); })
          (new TypeError ('‘prop’ expected object to have a property named ‘valueOf’; undefined does not'));
 
 });

--- a/test/properties.js
+++ b/test/properties.js
@@ -1,22 +1,16 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var equals = require ('./internal/equals');
+const equals = require ('./internal/equals');
 
 
-var basic = jsc.sum ([jsc.integer, jsc.string, jsc.bool, jsc.falsy]);
+const basic = jsc.sum ([jsc.integer, jsc.string, jsc.bool, jsc.falsy]);
 
-var useful = jsc.sum ([basic, jsc.array (basic), jsc.dict (basic), jsc.fn (basic)]);
+const useful = jsc.sum ([basic, jsc.array (basic), jsc.dict (basic), jsc.fn (basic)]);
 
-exports.idempotent = function(f) {
-  return jsc.checkForall (useful, function(x) {
-    return equals (f (f (x))) (f (x));
-  });
-};
+exports.idempotent = f =>
+  jsc.checkForall (useful, x => equals (f (f (x))) (f (x)));
 
-exports.involution = function(f) {
-  return jsc.checkForall (useful, function(x) {
-    return equals (f (f (x))) (x);
-  });
-};
+exports.involution = f =>
+  jsc.checkForall (useful, x => equals (f (f (x))) (x));

--- a/test/props.js
+++ b/test/props.js
@@ -1,28 +1,28 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var throws = require ('./internal/throws');
+const eq = require ('./internal/eq');
+const throws = require ('./internal/throws');
 
 
-test ('props', function() {
+test ('props', () => {
 
   eq (typeof S.props) ('function');
   eq (S.props.length) (1);
   eq (S.show (S.props)) ('props :: Array String -> a -> b');
 
-  throws (function() { S.props (['a', 'b', 'c']) ([1, 2, 3]); })
+  throws (() => { S.props (['a', 'b', 'c']) ([1, 2, 3]); })
          (new TypeError ('‘props’ expected object to have a property at ["a", "b", "c"]; [1, 2, 3] does not'));
 
   eq (S.props (['a', 'b', 'c']) ({a: {b: {c: 1}}})) (1);
   eq (S.props (['a', 'b', 'c', '0']) ({a: {b: {c: [2, 4, 6]}}})) (2);
   eq (S.props (['a', 'b', 'c']) (Object.create ({a: {b: {c: 1}}}))) (1);
 
-  throws (function() { S.props (['valueOf']) (null); })
+  throws (() => { S.props (['valueOf']) (null); })
          (new TypeError ('‘props’ expected object to have a property at ["valueOf"]; null does not'));
 
-  throws (function() { S.props (['valueOf']) (undefined); })
+  throws (() => { S.props (['valueOf']) (undefined); })
          (new TypeError ('‘props’ expected object to have a property at ["valueOf"]; undefined does not'));
 
 });

--- a/test/range.js
+++ b/test/range.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('range', function() {
+test ('range', () => {
 
   eq (typeof S.range) ('function');
   eq (S.range.length) (1);

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('reduce', function() {
+test ('reduce', () => {
 
   eq (typeof S.reduce) ('function');
   eq (S.reduce.length) (1);

--- a/test/regex.js
+++ b/test/regex.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('regex', function() {
+test ('regex', () => {
 
   eq (typeof S.regex) ('function');
   eq (S.regex.length) (1);

--- a/test/regexEscape.js
+++ b/test/regexEscape.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('regexEscape', function() {
+test ('regexEscape', () => {
 
   eq (typeof S.regexEscape) ('function');
   eq (S.regexEscape.length) (1);
@@ -15,12 +15,20 @@ test ('regexEscape', function() {
 
   eq (S.regexEscape ('-=*{XYZ}*=-')) ('\\-=\\*\\{XYZ\\}\\*=\\-');
 
-  jsc.assert (jsc.forall (jsc.string, function(s) {
-    return S.test (S.regex ('') (S.regexEscape (s))) (s);
-  }), {tests: 1000});
+  jsc.assert (
+    jsc.forall (
+      jsc.string,
+      s => S.test (S.regex ('') (S.regexEscape (s))) (s)
+    ),
+    {tests: 1000}
+  );
 
-  jsc.assert (jsc.forall (jsc.string, function(s) {
-    return S.test (S.regex ('') ('^' + S.regexEscape (s) + '$')) (s);
-  }), {tests: 1000});
+  jsc.assert (
+    jsc.forall (
+      jsc.string,
+      s => S.test (S.regex ('') ('^' + S.regexEscape (s) + '$')) (s)
+    ),
+    {tests: 1000}
+  );
 
 });

--- a/test/reject.js
+++ b/test/reject.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('reject', function() {
+test ('reject', () => {
 
   eq (typeof S.reject) ('function');
   eq (S.reject.length) (1);

--- a/test/remove.js
+++ b/test/remove.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('remove', function() {
+test ('remove', () => {
 
   eq (typeof S.remove) ('function');
   eq (S.remove.length) (1);
@@ -18,10 +18,10 @@ test ('remove', function() {
   eq (S.remove ('b') ({a: 1})) ({a: 1});
   eq (S.remove ('c') ({a: 1, b: 2, c: 3})) ({a: 1, b: 2});
 
-  jsc.assert (jsc.forall (jsc.string, jsc.dict (jsc.number), function(key, map) {
-    var remove = S.remove (key);
-    var lhs = remove (remove (map));
-    var rhs = remove (map);
+  jsc.assert (jsc.forall (jsc.string, jsc.dict (jsc.number), (key, map) => {
+    const remove = S.remove (key);
+    const lhs = remove (remove (map));
+    const rhs = remove (map);
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('reverse', function() {
+test ('reverse', () => {
 
   eq (typeof S.reverse) ('function');
   eq (S.reverse.length) (1);

--- a/test/rights.js
+++ b/test/rights.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('rights', function() {
+test ('rights', () => {
 
   eq (typeof S.rights) ('function');
   eq (S.rights.length) (1);

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Identity = require ('sanctuary-identity');
+const Identity = require ('sanctuary-identity');
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('sequence', function() {
+test ('sequence', () => {
 
   eq (typeof S.sequence) ('function');
   eq (S.sequence.length) (1);

--- a/test/show.js
+++ b/test/show.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('show', function() {
+test ('show', () => {
 
   eq (typeof S.show) ('function');
   eq (S.show.length) (1);

--- a/test/singleton.js
+++ b/test/singleton.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('singleton', function() {
+test ('singleton', () => {
 
   eq (typeof S.singleton) ('function');
   eq (S.singleton.length) (1);

--- a/test/size.js
+++ b/test/size.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var List = require ('./internal/List');
-var eq = require ('./internal/eq');
-
-
-var Cons = List.Cons;
-var Nil = List.Nil;
+const {Nil, Cons} = require ('./internal/List');
+const eq = require ('./internal/eq');
 
 
-test ('size', function() {
+test ('size', () => {
 
   eq (typeof S.size) ('function');
   eq (S.size.length) (1);

--- a/test/slice.js
+++ b/test/slice.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('slice', function() {
+test ('slice', () => {
 
   eq (typeof S.slice) ('function');
   eq (S.slice.length) (1);

--- a/test/snd.js
+++ b/test/snd.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('snd', function() {
+test ('snd', () => {
 
   eq (typeof S.snd) ('function');
   eq (S.snd.length) (1);

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('sort', function() {
+test ('sort', () => {
 
   eq (typeof S.sort) ('function');
   eq (S.sort.length) (1);

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('sortBy', function() {
+test ('sortBy', () => {
 
   eq (typeof S.sortBy) ('function');
   eq (S.sortBy.length) (1);
@@ -17,10 +17,10 @@ test ('sortBy', function() {
   eq (S.sortBy (S.I) (['five', 'six', 'seven'])) (['five', 'seven', 'six']);
   eq (S.sortBy (S.prop ('length')) (['five', 'six', 'seven'])) (['six', 'five', 'seven']);
 
-  var _7s = {rank: 7, suit: 's'};
-  var _5h = {rank: 5, suit: 'h'};
-  var _2h = {rank: 2, suit: 'h'};
-  var _5s = {rank: 5, suit: 's'};
+  const _7s = {rank: 7, suit: 's'};
+  const _5h = {rank: 5, suit: 'h'};
+  const _2h = {rank: 2, suit: 'h'};
+  const _5s = {rank: 5, suit: 's'};
   eq (S.sortBy (S.prop ('rank')) ([_7s, _5h, _2h, _5s])) ([_2h, _5h, _5s, _7s]);
   eq (S.sortBy (S.prop ('rank')) ([_7s, _5s, _2h, _5h])) ([_2h, _5s, _5h, _7s]);
   eq (S.sortBy (S.prop ('suit')) ([_7s, _5h, _2h, _5s])) ([_5h, _2h, _7s, _5s]);

--- a/test/splitOn.js
+++ b/test/splitOn.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('splitOn', function() {
+test ('splitOn', () => {
 
   eq (typeof S.splitOn) ('function');
   eq (S.splitOn.length) (1);
@@ -21,14 +21,14 @@ test ('splitOn', function() {
   eq (S.splitOn (':') ('foo:bar:baz')) (['foo', 'bar', 'baz']);
   eq (S.splitOn ('::') ('foo::bar::baz')) (['foo', 'bar', 'baz']);
 
-  jsc.assert (jsc.forall (jsc.asciistring, function(t) {
-    var min = 0;
-    var max = t.length;
-    var i = jsc.random (min, max);
-    var j = jsc.random (min, max);
-    var s = t.slice (Math.min (i, j), Math.max (i, j));
-    var lhs = S.joinWith (s) (S.splitOn (s) (t));
-    var rhs = t;
+  jsc.assert (jsc.forall (jsc.asciistring, t => {
+    const min = 0;
+    const max = t.length;
+    const i = jsc.random (min, max);
+    const j = jsc.random (min, max);
+    const s = t.slice (Math.min (i, j), Math.max (i, j));
+    const lhs = S.joinWith (s) (S.splitOn (s) (t));
+    const rhs = t;
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/splitOnRegex.js
+++ b/test/splitOnRegex.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var jsc = require ('jsverify');
+const jsc = require ('jsverify');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
-var equals = require ('./internal/equals');
+const eq = require ('./internal/eq');
+const equals = require ('./internal/equals');
 
 
-test ('splitOnRegex', function() {
+test ('splitOnRegex', () => {
 
   eq (typeof S.splitOnRegex) ('function');
   eq (S.splitOnRegex.length) (1);
@@ -48,14 +48,14 @@ test ('splitOnRegex', function() {
   eq (S.splitOnRegex (/./g) ('')) (['']);
   eq (S.splitOnRegex (/./g) ('hello')) (['', '', '', '', '', '']);
 
-  jsc.assert (jsc.forall (jsc.asciistring, function(t) {
-    var min = 0;
-    var max = t.length;
-    var i = jsc.random (min, max);
-    var j = jsc.random (min, max);
-    var s = t.slice (Math.min (i, j), Math.max (i, j));
-    var lhs = S.joinWith (s) (S.splitOnRegex (S.regex ('g') (S.regexEscape (s))) (t));
-    var rhs = t;
+  jsc.assert (jsc.forall (jsc.asciistring, t => {
+    const min = 0;
+    const max = t.length;
+    const i = jsc.random (min, max);
+    const j = jsc.random (min, max);
+    const s = t.slice (Math.min (i, j), Math.max (i, j));
+    const lhs = S.joinWith (s) (S.splitOnRegex (S.regex ('g') (S.regexEscape (s))) (t));
+    const rhs = t;
     return equals (lhs) (rhs);
   }), {tests: 1000});
 

--- a/test/stripPrefix.js
+++ b/test/stripPrefix.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('stripPrefix', function() {
+test ('stripPrefix', () => {
 
   eq (typeof S.stripPrefix) ('function');
   eq (S.stripPrefix.length) (1);

--- a/test/stripSuffix.js
+++ b/test/stripSuffix.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('stripSuffix', function() {
+test ('stripSuffix', () => {
 
   eq (typeof S.stripSuffix) ('function');
   eq (S.stripSuffix.length) (1);

--- a/test/sub.js
+++ b/test/sub.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('sub', function() {
+test ('sub', () => {
 
   eq (typeof S.sub) ('function');
   eq (S.sub.length) (1);

--- a/test/sum.js
+++ b/test/sum.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('sum', function() {
+test ('sum', () => {
 
   eq (typeof S.sum) ('function');
   eq (S.sum.length) (1);

--- a/test/swap.js
+++ b/test/swap.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('swap', function() {
+test ('swap', () => {
 
   eq (typeof S.swap) ('function');
   eq (S.swap.length) (1);

--- a/test/tagBy.js
+++ b/test/tagBy.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('tagBy', function() {
+test ('tagBy', () => {
 
   eq (typeof S.tagBy) ('function');
   eq (S.tagBy.length) (1);

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('tail', function() {
+test ('tail', () => {
 
   eq (typeof S.tail) ('function');
   eq (S.tail.length) (1);

--- a/test/take.js
+++ b/test/take.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('take', function() {
+test ('take', () => {
 
   eq (typeof S.take) ('function');
   eq (S.take.length) (1);

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('takeLast', function() {
+test ('takeLast', () => {
 
   eq (typeof S.takeLast) ('function');
   eq (S.takeLast.length) (1);

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('takeWhile', function() {
+test ('takeWhile', () => {
 
   eq (typeof S.takeWhile) ('function');
   eq (S.takeWhile.length) (1);

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('test', function() {
+test ('test', () => {
 
   eq (typeof S.test) ('function');
   eq (S.test.length) (1);
@@ -14,7 +14,7 @@ test ('test', function() {
   eq (S.test (/^a/) ('abacus')) (true);
   eq (S.test (/^a/) ('banana')) (false);
 
-  var pattern = /x/g;
+  const pattern = /x/g;
   eq (pattern.lastIndex) (0);
   eq (S.test (pattern) ('xyz')) (true);
   eq (pattern.lastIndex) (0);

--- a/test/toEither.js
+++ b/test/toEither.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('toEither', function() {
+test ('toEither', () => {
 
   eq (typeof S.toEither) ('function');
   eq (S.toEither.length) (1);

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('toLower', function() {
+test ('toLower', () => {
 
   eq (typeof S.toLower) ('function');
   eq (S.toLower.length) (1);

--- a/test/toMaybe.js
+++ b/test/toMaybe.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('toMaybe', function() {
+test ('toMaybe', () => {
 
   eq (typeof S.toMaybe) ('function');
   eq (S.toMaybe.length) (1);

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('toUpper', function() {
+test ('toUpper', () => {
 
   eq (typeof S.toUpper) ('function');
   eq (S.toUpper.length) (1);

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Identity = require ('sanctuary-identity');
+const Identity = require ('sanctuary-identity');
 
-var S = require ('./internal/sanctuary');
+const S = require ('./internal/sanctuary');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('traverse', function() {
+test ('traverse', () => {
 
   eq (typeof S.traverse) ('function');
   eq (S.traverse.length) (1);

--- a/test/trim.js
+++ b/test/trim.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('trim', function() {
+test ('trim', () => {
 
   eq (typeof S.trim) ('function');
   eq (S.trim.length) (1);

--- a/test/type.js
+++ b/test/type.js
@@ -1,18 +1,19 @@
 'use strict';
 
-var vm = require ('vm');
+const vm = require ('vm');
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('type', function() {
+test ('type', () => {
 
   eq (typeof S.type) ('function');
   eq (S.type.length) (1);
   eq (S.show (S.type)) ('type :: Any -> { name :: String, namespace :: Maybe String, version :: NonNegativeInteger }');
 
+  // eslint-disable-next-line prefer-rest-params
   eq (S.type (function() { return arguments; } ()))
      ({namespace: S.Nothing, name: 'Arguments', version: 0});
   eq (S.type ([]))
@@ -23,7 +24,7 @@ test ('type', function() {
      ({namespace: S.Nothing, name: 'Date', version: 0});
   eq (S.type (new TypeError ()))
      ({namespace: S.Nothing, name: 'Error', version: 0});
-  eq (S.type (function() {}))
+  eq (S.type (() => {}))
      ({namespace: S.Nothing, name: 'Function', version: 0});
   eq (S.type (null))
      ({namespace: S.Nothing, name: 'Null', version: 0});

--- a/test/unchecked.js
+++ b/test/unchecked.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('unchecked', function() {
+test ('unchecked', () => {
 
   eq (S.unchecked.add (2) (2)) (4);
   eq (S.unchecked.add (2) ('2')) ('22');

--- a/test/unfoldr.js
+++ b/test/unfoldr.js
@@ -1,19 +1,17 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('unfoldr', function() {
+test ('unfoldr', () => {
 
   eq (typeof S.unfoldr) ('function');
   eq (S.unfoldr.length) (1);
   eq (S.show (S.unfoldr)) ('unfoldr :: (b -> Maybe (Pair a b)) -> b -> Array a');
 
-  function f(n) {
-    return n >= 5 ? S.Nothing : S.Just (S.Pair (n) (n + 1));
-  }
+  const f = n => n >= 5 ? S.Nothing : S.Just (S.Pair (n) (n + 1));
   eq (S.unfoldr (f) (5)) ([]);
   eq (S.unfoldr (f) (4)) ([4]);
   eq (S.unfoldr (f) (1)) ([1, 2, 3, 4]);

--- a/test/unless.js
+++ b/test/unless.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('unless', function() {
+test ('unless', () => {
 
   eq (typeof S.unless) ('function');
   eq (S.unless.length) (1);

--- a/test/unlines.js
+++ b/test/unlines.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('unlines', function() {
+test ('unlines', () => {
 
   eq (typeof S.unlines) ('function');
   eq (S.unlines.length) (1);

--- a/test/unwords.js
+++ b/test/unwords.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('unwords', function() {
+test ('unwords', () => {
 
   eq (typeof S.unwords) ('function');
   eq (S.unwords.length) (1);

--- a/test/values.js
+++ b/test/values.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('values', function() {
+test ('values', () => {
 
   eq (typeof S.values) ('function');
   eq (S.values.length) (1);
@@ -14,8 +14,8 @@ test ('values', function() {
   eq (S.sort (S.values ({}))) ([]);
   eq (S.sort (S.values ({a: 1, b: 2, c: 3}))) ([1, 2, 3]);
 
-  var proto = {a: 1, b: 2};
-  var obj = Object.create (proto);
+  const proto = {a: 1, b: 2};
+  const obj = Object.create (proto);
   obj.c = 3;
   obj.d = 4;
 

--- a/test/when.js
+++ b/test/when.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('when', function() {
+test ('when', () => {
 
   eq (typeof S.when) ('function');
   eq (S.when.length) (1);

--- a/test/words.js
+++ b/test/words.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('words', function() {
+test ('words', () => {
 
   eq (typeof S.words) ('function');
   eq (S.words.length) (1);

--- a/test/zero.js
+++ b/test/zero.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('zero', function() {
+test ('zero', () => {
 
   eq (typeof S.zero) ('function');
   eq (S.zero.length) (1);

--- a/test/zip.js
+++ b/test/zip.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var eq = require ('./internal/eq');
+const eq = require ('./internal/eq');
 
 
-test ('zip', function() {
+test ('zip', () => {
 
   eq (typeof S.zip) ('function');
   eq (S.zip.length) (1);

--- a/test/zipWith.js
+++ b/test/zipWith.js
@@ -1,19 +1,17 @@
 'use strict';
 
-var S = require ('..');
+const S = require ('..');
 
-var concat = require ('./internal/concat');
-var eq = require ('./internal/eq');
-var pair = require ('./internal/pair');
+const eq = require ('./internal/eq');
 
 
-test ('zipWith', function() {
+test ('zipWith', () => {
 
   eq (typeof S.zipWith) ('function');
   eq (S.zipWith.length) (1);
   eq (S.show (S.zipWith)) ('zipWith :: (a -> b -> c) -> Array a -> Array b -> Array c');
 
-  eq (S.zipWith (concat) (['a', 'b']) (['x', 'y', 'z'])) (['ax', 'by']);
-  eq (S.zipWith (pair) ([1, 3, 5]) ([2, 4])) ([[1, 2], [3, 4]]);
+  eq (S.zipWith (x => y => x + y) (['a', 'b']) (['x', 'y', 'z'])) (['ax', 'by']);
+  eq (S.zipWith (x => y => [x, y]) ([1, 3, 5]) ([2, 4])) ([[1, 2], [3, 4]]);
 
 });


### PR DESCRIPTION
Now that we're no longer running tests in browsers (#603) we're no longer restricted to ES5 syntax.
