### PR TITLE
test: add trivial tests for Maybe and Either data constructors

### DIFF
--- a/test/Just.js
+++ b/test/Just.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('Just', () => {
+
+  eq (typeof S.Just) ('function');
+  eq (S.Just.length) (1);
+  eq (S.show (S.Just)) ('Just :: a -> Maybe a');
+
+  eq (S.Just (42)) (S.Just (42));
+
+});

--- a/test/Left.js
+++ b/test/Left.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('Left', () => {
+
+  eq (typeof S.Left) ('function');
+  eq (S.Left.length) (1);
+  eq (S.show (S.Left)) ('Left :: a -> Either a b');
+
+  eq (S.Left (42)) (S.Left (42));
+
+});

--- a/test/Nothing.js
+++ b/test/Nothing.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('Nothing', () => {
+
+  eq (typeof S.Nothing) ('object');
+  eq (S.show (S.Nothing)) ('Nothing');
+
+  eq (S.Nothing) (S.Nothing);
+
+});

--- a/test/Right.js
+++ b/test/Right.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('Right', () => {
+
+  eq (typeof S.Right) ('function');
+  eq (S.Right.length) (1);
+  eq (S.show (S.Right)) ('Right :: b -> Either a b');
+
+  eq (S.Right (42)) (S.Right (42));
+
+});


### PR DESCRIPTION
I went slightly too far in #602. This pull request reinstates the trivial tests for the data constructors.
