### PR TITLE
pair: add S.pair

### DIFF
--- a/index.js
+++ b/index.js
@@ -1992,6 +1992,25 @@
     impl: Pair
   };
 
+  //# pair :: (a -> b -> c) -> Pair a b -> c
+  //.
+  //. Case analysis for the `Pair a b` type.
+  //.
+  //. ```javascript
+  //. > S.pair (S.concat) (S.Pair ('foo') ('bar'))
+  //. 'foobar'
+  //. ```
+  function pair(f) {
+    return function(pair) {
+      return f (pair.fst) (pair.snd);
+    };
+  }
+  _.pair = {
+    consts: {},
+    types: [Fn (a) (Fn (b) (c)), $Pair (a) (b), c],
+    impl: pair
+  };
+
   //# fst :: Pair a b -> a
   //.
   //. `fst (Pair (x) (y))` is equivalent to `x`.
@@ -2003,7 +2022,7 @@
   _.fst = {
     consts: {},
     types: [$Pair (a) (b), a],
-    impl: Pair.fst
+    impl: pair (K)
   };
 
   //# snd :: Pair a b -> b
@@ -2017,7 +2036,7 @@
   _.snd = {
     consts: {},
     types: [$Pair (a) (b), b],
-    impl: Pair.snd
+    impl: pair (C (K))
   };
 
   //# swap :: Pair a b -> Pair b a
@@ -2031,7 +2050,7 @@
   _.swap = {
     consts: {},
     types: [$Pair (a) (b), $Pair (b) (a)],
-    impl: Pair.swap
+    impl: pair (C (Pair))
   };
 
   //. ### Maybe type

--- a/test/pair~.js
+++ b/test/pair~.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('pair', () => {
+
+  eq (typeof S.pair) ('function');
+  eq (S.pair.length) (1);
+  eq (S.show (S.pair)) ('pair :: (a -> b -> c) -> Pair a b -> c');
+
+  eq (S.pair (S.concat) (S.Pair ('foo') ('bar'))) ('foobar');
+
+});


### PR DESCRIPTION
This function is similar to the functions added in #592 and #593. The fact that `fst`, `snd`, and `swap` can be defined in terms of `pair` demonstrates the foundational nature of `pair`.

__test/pair~.js__ is horribly named for compatibility with case-insensitive file systems. ;)

/cc @puffnfresh
