### PR TITLE
fantasy-land: flip S.alt argument order

### DIFF
--- a/index.js
+++ b/index.js
@@ -1204,25 +1204,31 @@
 
   //# alt :: Alt f => f a -> f a -> f a
   //.
-  //. Curried version of [`Z.alt`][].
+  //. Curried version of [`Z.alt`][] with arguments flipped to facilitate
+  //. partial application.
   //.
   //. ```javascript
-  //. > S.alt (S.Nothing) (S.Just (1))
-  //. Just (1)
+  //. > S.alt (S.Just ('default')) (S.Nothing)
+  //. Just ('default')
   //.
-  //. > S.alt (S.Just (2)) (S.Just (3))
-  //. Just (2)
+  //. > S.alt (S.Just ('default')) (S.Just ('hello'))
+  //. Just ('hello')
   //.
-  //. > S.alt (S.Left ('X')) (S.Right (1))
+  //. > S.alt (S.Right (0)) (S.Left ('X'))
+  //. Right (0)
+  //.
+  //. > S.alt (S.Right (0)) (S.Right (1))
   //. Right (1)
-  //.
-  //. > S.alt (S.Right (2)) (S.Right (3))
-  //. Right (2)
   //. ```
+  function alt(y) {
+    return function(x) {
+      return Z.alt (x, y);
+    };
+  }
   _.alt = {
     consts: {f: [Z.Alt]},
     types: [f (a), f (a), f (a)],
-    impl: curry2 (Z.alt)
+    impl: alt
   };
 
   //# zero :: Plus f => TypeRep f -> f a

--- a/test/alt.js
+++ b/test/alt.js
@@ -12,17 +12,17 @@ test ('alt', () => {
   eq (S.show (S.alt)) ('alt :: Alt f => f a -> f a -> f a');
 
   eq (S.alt ([]) ([])) ([]);
-  eq (S.alt ([]) ([1, 2, 3])) ([1, 2, 3]);
   eq (S.alt ([1, 2, 3]) ([])) ([1, 2, 3]);
-  eq (S.alt ([1, 2, 3]) ([4, 5, 6])) ([1, 2, 3, 4, 5, 6]);
+  eq (S.alt ([]) ([1, 2, 3])) ([1, 2, 3]);
+  eq (S.alt ([4, 5, 6]) ([1, 2, 3])) ([1, 2, 3, 4, 5, 6]);
   eq (S.alt ({}) ({})) ({});
-  eq (S.alt ({}) ({a: 1, b: 2, c: 3})) ({a: 1, b: 2, c: 3});
   eq (S.alt ({a: 1, b: 2, c: 3}) ({})) ({a: 1, b: 2, c: 3});
-  eq (S.alt ({a: 1, b: 2, c: 3}) ({d: 4, e: 5, f: 6})) ({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
-  eq (S.alt ({a: 1, b: 2, c: 3}) ({c: 4, d: 5, e: 6})) ({a: 1, b: 2, c: 4, d: 5, e: 6});
+  eq (S.alt ({}) ({a: 1, b: 2, c: 3})) ({a: 1, b: 2, c: 3});
+  eq (S.alt ({d: 4, e: 5, f: 6}) ({a: 1, b: 2, c: 3})) ({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
+  eq (S.alt ({c: 4, d: 5, e: 6}) ({a: 1, b: 2, c: 3})) ({a: 1, b: 2, c: 4, d: 5, e: 6});
   eq (S.alt (S.Nothing) (S.Nothing)) (S.Nothing);
-  eq (S.alt (S.Nothing) (S.Just (1))) (S.Just (1));
-  eq (S.alt (S.Just (2)) (S.Nothing)) (S.Just (2));
-  eq (S.alt (S.Just (3)) (S.Just (4))) (S.Just (3));
+  eq (S.alt (S.Just (1)) (S.Nothing)) (S.Just (1));
+  eq (S.alt (S.Nothing) (S.Just (2))) (S.Just (2));
+  eq (S.alt (S.Just (4)) (S.Just (3))) (S.Just (3));
 
 });


### PR DESCRIPTION
The “default” argument should come first, as it's more likely to be known in advance.
