### PR TITLE
test: remove unnecessary assertions

### DIFF
--- a/test/I.js
+++ b/test/I.js
@@ -8,8 +8,6 @@ const properties = require ('./properties');
 
 test ('I', () => {
 
-  eq (typeof S.I) ('function');
-  eq (S.I.length) (1);
   eq (S.show (S.I)) ('I :: a -> a');
 
   eq (S.I ([1, 2, 3])) ([1, 2, 3]);

--- a/test/Just.js
+++ b/test/Just.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('Just', () => {
 
-  eq (typeof S.Just) ('function');
-  eq (S.Just.length) (1);
   eq (S.show (S.Just)) ('Just :: a -> Maybe a');
 
   eq (S.Just (42)) (S.Just (42));

--- a/test/K.js
+++ b/test/K.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('K', () => {
 
-  eq (typeof S.K) ('function');
-  eq (S.K.length) (1);
   eq (S.show (S.K)) ('K :: a -> b -> a');
 
   eq (S.K (21) ([])) (21);

--- a/test/Left.js
+++ b/test/Left.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('Left', () => {
 
-  eq (typeof S.Left) ('function');
-  eq (S.Left.length) (1);
   eq (S.show (S.Left)) ('Left :: a -> Either a b');
 
   eq (S.Left (42)) (S.Left (42));

--- a/test/Nothing.js
+++ b/test/Nothing.js
@@ -7,7 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('Nothing', () => {
 
-  eq (typeof S.Nothing) ('object');
   eq (S.show (S.Nothing)) ('Nothing');
 
   eq (S.Nothing) (S.Nothing);

--- a/test/Pair.js
+++ b/test/Pair.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('Pair', () => {
 
-  eq (typeof S.Pair) ('function');
-  eq (S.Pair.length) (1);
   eq (S.show (S.Pair)) ('Pair :: a -> b -> Pair a b');
 
   eq (S.Pair ('foo') (42)) (S.Pair ('foo') (42));

--- a/test/Right.js
+++ b/test/Right.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('Right', () => {
 
-  eq (typeof S.Right) ('function');
-  eq (S.Right.length) (1);
   eq (S.show (S.Right)) ('Right :: b -> Either a b');
 
   eq (S.Right (42)) (S.Right (42));

--- a/test/T.js
+++ b/test/T.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('T', () => {
 
-  eq (typeof S.T) ('function');
-  eq (S.T.length) (1);
   eq (S.show (S.T)) ('T :: a -> (a -> b) -> b');
 
   eq (S.T ('!') (S.concat ('foo'))) ('foo!');

--- a/test/add.js
+++ b/test/add.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('add', () => {
 
-  eq (typeof S.add) ('function');
-  eq (S.add.length) (1);
   eq (S.show (S.add)) ('add :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.add (1) (1)) (2);

--- a/test/all.js
+++ b/test/all.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('all', () => {
 
-  eq (typeof S.all) ('function');
-  eq (S.all.length) (1);
   eq (S.show (S.all)) ('all :: Foldable f => (a -> Boolean) -> f a -> Boolean');
 
   eq (S.all (S.gt (0)) ([])) (true);

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('allPass', () => {
 
-  eq (typeof S.allPass) ('function');
-  eq (S.allPass.length) (1);
   eq (S.show (S.allPass)) ('allPass :: Foldable f => f (a -> Boolean) -> a -> Boolean');
 
   eq (S.allPass ([]) ('abacus')) (true);

--- a/test/alt.js
+++ b/test/alt.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('alt', () => {
 
-  eq (typeof S.alt) ('function');
-  eq (S.alt.length) (1);
   eq (S.show (S.alt)) ('alt :: Alt f => f a -> f a -> f a');
 
   eq (S.alt ([]) ([])) ([]);

--- a/test/and.js
+++ b/test/and.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('and', () => {
 
-  eq (typeof S.and) ('function');
-  eq (S.and.length) (1);
   eq (S.show (S.and)) ('and :: Boolean -> Boolean -> Boolean');
 
   eq (S.and (false) (false)) (false);

--- a/test/any.js
+++ b/test/any.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('any', () => {
 
-  eq (typeof S.any) ('function');
-  eq (S.any.length) (1);
   eq (S.show (S.any)) ('any :: Foldable f => (a -> Boolean) -> f a -> Boolean');
 
   eq (S.any (S.gt (0)) ([])) (false);

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('anyPass', () => {
 
-  eq (typeof S.anyPass) ('function');
-  eq (S.anyPass.length) (1);
   eq (S.show (S.anyPass)) ('anyPass :: Foldable f => f (a -> Boolean) -> a -> Boolean');
 
   eq (S.anyPass ([]) ('dolphin')) (false);

--- a/test/ap.js
+++ b/test/ap.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('ap', () => {
 
-  eq (typeof S.ap) ('function');
-  eq (S.ap.length) (1);
   eq (S.show (S.ap)) ('ap :: Apply f => f (a -> b) -> f a -> f b');
 
   eq (S.ap ([]) ([])) ([]);

--- a/test/apFirst.js
+++ b/test/apFirst.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('apFirst', () => {
 
-  eq (typeof S.apFirst) ('function');
-  eq (S.apFirst.length) (1);
   eq (S.show (S.apFirst)) ('apFirst :: Apply f => f a -> f b -> f a');
 
   eq (S.apFirst ([1, 2]) ([3, 4])) ([1, 1, 2, 2]);

--- a/test/apSecond.js
+++ b/test/apSecond.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('apSecond', () => {
 
-  eq (typeof S.apSecond) ('function');
-  eq (S.apSecond.length) (1);
   eq (S.show (S.apSecond)) ('apSecond :: Apply f => f a -> f b -> f b');
 
   eq (S.apSecond ([1, 2]) ([3, 4])) ([3, 4, 3, 4]);

--- a/test/append.js
+++ b/test/append.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('append', () => {
 
-  eq (typeof S.append) ('function');
-  eq (S.append.length) (1);
   eq (S.show (S.append)) ('append :: (Applicative f, Semigroup f) => a -> f a -> f a');
 
   eq (S.append (3) ([])) ([3]);

--- a/test/array.js
+++ b/test/array.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('array', () => {
 
-  eq (typeof S.array) ('function');
-  eq (S.array.length) (1);
   eq (S.show (S.array)) ('array :: b -> (a -> Array a -> b) -> Array a -> b');
 
   const size = S.array (0) (head => tail => 1 + size (tail));

--- a/test/bimap.js
+++ b/test/bimap.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('bimap', () => {
 
-  eq (typeof S.bimap) ('function');
-  eq (S.bimap.length) (1);
   eq (S.show (S.bimap)) ('bimap :: Bifunctor p => (a -> b) -> (c -> d) -> p a c -> p b d');
 
   eq (S.bimap (S.toUpper) (S.add (1)) (S.Left ('xxx'))) (S.Left ('XXX'));

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('boolean', () => {
 
-  eq (typeof S.boolean) ('function');
-  eq (S.boolean.length) (1);
   eq (S.show (S.boolean)) ('boolean :: a -> a -> Boolean -> a');
 
   eq (S.boolean ('no') ('yes') (false)) ('no');

--- a/test/chain.js
+++ b/test/chain.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('chain', () => {
 
-  eq (typeof S.chain) ('function');
-  eq (S.chain.length) (1);
   eq (S.show (S.chain)) ('chain :: Chain m => (a -> m b) -> m a -> m b');
 
   eq (S.chain (S.I) ([[1, 2], [3, 4], [5, 6]])) ([1, 2, 3, 4, 5, 6]);

--- a/test/chainRec.js
+++ b/test/chainRec.js
@@ -8,8 +8,6 @@ const map = require ('./internal/map');
 
 test ('chainRec', () => {
 
-  eq (typeof S.chainRec) ('function');
-  eq (S.chainRec.length) (1);
   eq (S.show (S.chainRec)) ('chainRec :: ChainRec m => TypeRep (m b) -> (a -> m (Either a b)) -> a -> m b');
 
   eq (S.chainRec (Array)

--- a/test/clamp.js
+++ b/test/clamp.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('clamp', () => {
 
-  eq (typeof S.clamp) ('function');
-  eq (S.clamp.length) (1);
   eq (S.show (S.clamp)) ('clamp :: Ord a => a -> a -> a -> a');
 
   eq (S.clamp (0) (100) (-1)) (0);

--- a/test/complement.js
+++ b/test/complement.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('complement', () => {
 
-  eq (typeof S.complement) ('function');
-  eq (S.complement.length) (1);
   eq (S.show (S.complement)) ('complement :: (a -> Boolean) -> a -> Boolean');
 
   eq (S.complement (S.odd) (1)) (false);

--- a/test/compose.js
+++ b/test/compose.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('compose', () => {
 
-  eq (typeof S.compose) ('function');
-  eq (S.compose.length) (1);
   eq (S.show (S.compose)) ('compose :: Semigroupoid s => s b c -> s a b -> s a c');
 
   eq (S.compose (S.mult (2)) (S.add (1)) (20)) (42);

--- a/test/concat.js
+++ b/test/concat.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('concat', () => {
 
-  eq (typeof S.concat) ('function');
-  eq (S.concat.length) (1);
   eq (S.show (S.concat)) ('concat :: Semigroup a => a -> a -> a');
 
   eq (S.concat ([]) ([])) ([]);

--- a/test/contramap.js
+++ b/test/contramap.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('contramap', () => {
 
-  eq (typeof S.contramap) ('function');
-  eq (S.contramap.length) (1);
   eq (S.show (S.contramap)) ('contramap :: Contravariant f => (b -> a) -> f a -> f b');
 
   eq (S.contramap (S.prop ('length')) (Math.sqrt) ('Sanctuary')) (3);

--- a/test/create.js
+++ b/test/create.js
@@ -22,8 +22,6 @@ const uncheckedCustomEnv  = S.create ({checkTypes: false, env: customEnv});
 
 test ('create', () => {
 
-  eq (typeof S.create) ('function');
-  eq (S.create.length) (1);
   eq (S.show (S.create)) ('create :: { checkTypes :: Boolean, env :: Array Any } -> Object');
 
   const expected = S.sort (Object.keys (S));

--- a/test/curry2.js
+++ b/test/curry2.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('curry2', () => {
 
-  eq (typeof S.curry2) ('function');
-  eq (S.curry2.length) (1);
   eq (S.show (S.curry2)) ('curry2 :: ((a, b) -> c) -> a -> b -> c');
 
   eq (S.curry2 (Z.concat) ('foo') ('bar')) ('foobar');

--- a/test/curry3.js
+++ b/test/curry3.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('curry3', () => {
 
-  eq (typeof S.curry3) ('function');
-  eq (S.curry3.length) (1);
   eq (S.show (S.curry3)) ('curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d');
 
   eq (S.curry3 ((x, y, z) => x + y + z) ('x') ('y') ('z')) ('xyz');

--- a/test/curry4.js
+++ b/test/curry4.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('curry4', () => {
 
-  eq (typeof S.curry4) ('function');
-  eq (S.curry4.length) (1);
   eq (S.show (S.curry4)) ('curry4 :: ((a, b, c, d) -> e) -> a -> b -> c -> d -> e');
 
   eq (S.curry4 ((w, x, y, z) => w + x + y + z) ('w') ('x') ('y') ('z')) ('wxyz');

--- a/test/curry5.js
+++ b/test/curry5.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('curry5', () => {
 
-  eq (typeof S.curry5) ('function');
-  eq (S.curry5.length) (1);
   eq (S.show (S.curry5)) ('curry5 :: ((a, b, c, d, e) -> r) -> a -> b -> c -> d -> e -> r');
 
   eq (S.curry5 ((v, w, x, y, z) => v + w + x + y + z) ('v') ('w') ('x') ('y') ('z')) ('vwxyz');

--- a/test/div.js
+++ b/test/div.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('div', () => {
 
-  eq (typeof S.div) ('function');
-  eq (S.div.length) (1);
   eq (S.show (S.div)) ('div :: NonZeroFiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.map (S.div (2)) ([0, 1, 2, 3])) ([0, 0.5, 1, 1.5]);

--- a/test/drop.js
+++ b/test/drop.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('drop', () => {
 
-  eq (typeof S.drop) ('function');
-  eq (S.drop.length) (1);
   eq (S.show (S.drop)) ('drop :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.drop (0) ([1, 2, 3, 4, 5])) (S.Just ([1, 2, 3, 4, 5]));

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('dropLast', () => {
 
-  eq (typeof S.dropLast) ('function');
-  eq (S.dropLast.length) (1);
   eq (S.show (S.dropLast)) ('dropLast :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.dropLast (0) ([1, 2, 3, 4, 5])) (S.Just ([1, 2, 3, 4, 5]));

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('dropWhile', () => {
 
-  eq (typeof S.dropWhile) ('function');
-  eq (S.dropWhile.length) (1);
   eq (S.show (S.dropWhile)) ('dropWhile :: (a -> Boolean) -> Array a -> Array a');
 
   eq (S.dropWhile (S.odd) ([3, 3, 3, 7, 6, 3, 5, 4])) ([6, 3, 5, 4]);

--- a/test/duplicate.js
+++ b/test/duplicate.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('duplicate', () => {
 
-  eq (typeof S.duplicate) ('function');
-  eq (S.duplicate.length) (1);
   eq (S.show (S.duplicate)) ('duplicate :: Extend w => w a -> w (w a)');
 
   eq (S.duplicate ([])) ([]);

--- a/test/either.js
+++ b/test/either.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('either', () => {
 
-  eq (typeof S.either) ('function');
-  eq (S.either.length) (1);
   eq (S.show (S.either)) ('either :: (a -> c) -> (b -> c) -> Either a b -> c');
 
   eq (S.either (S.prop ('length')) (Math.sqrt) (S.Left ('abc'))) (3);

--- a/test/eitherToMaybe.js
+++ b/test/eitherToMaybe.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('eitherToMaybe', () => {
 
-  eq (typeof S.eitherToMaybe) ('function');
-  eq (S.eitherToMaybe.length) (1);
   eq (S.show (S.eitherToMaybe)) ('eitherToMaybe :: Either a b -> Maybe b');
 
   eq (S.eitherToMaybe (S.Left ('Cannot divide by zero'))) (S.Nothing);

--- a/test/elem.js
+++ b/test/elem.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('elem', () => {
 
-  eq (typeof S.elem) ('function');
-  eq (S.elem.length) (1);
   eq (S.show (S.elem)) ('elem :: (Setoid a, Foldable f) => a -> f a -> Boolean');
 
   eq (S.elem ('c') (['a', 'b', 'c'])) (true);

--- a/test/empty.js
+++ b/test/empty.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('empty', () => {
 
-  eq (typeof S.empty) ('function');
-  eq (S.empty.length) (1);
   eq (S.show (S.empty)) ('empty :: Monoid a => TypeRep a -> a');
 
   eq (S.empty (String)) ('');

--- a/test/encase.js
+++ b/test/encase.js
@@ -10,8 +10,6 @@ const rem = require ('./internal/rem');
 
 test ('encase', () => {
 
-  eq (typeof S.encase) ('function');
-  eq (S.encase.length) (1);
   eq (S.show (S.encase)) ('encase :: (a -> b) -> a -> Either Error b');
 
   //    safeFactorial :: Number -> Maybe Number

--- a/test/env.js
+++ b/test/env.js
@@ -9,7 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('env', () => {
 
-  eq (typeof S.env) ('object');
   eq (S.is ($.Array ($.Type)) (S.env)) (true);
 
 });

--- a/test/equals.js
+++ b/test/equals.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('equals', () => {
 
-  eq (typeof S.equals) ('function');
-  eq (S.equals.length) (1);
   eq (S.show (S.equals)) ('equals :: Setoid a => a -> a -> Boolean');
 
   eq (S.equals (S.Nothing) (S.Nothing)) (true);

--- a/test/even.js
+++ b/test/even.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('even', () => {
 
-  eq (typeof S.even) ('function');
-  eq (S.even.length) (1);
   eq (S.show (S.even)) ('even :: Integer -> Boolean');
 
   eq (S.even (0)) (true);

--- a/test/extend.js
+++ b/test/extend.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('extend', () => {
 
-  eq (typeof S.extend) ('function');
-  eq (S.extend.length) (1);
   eq (S.show (S.extend)) ('extend :: Extend w => (w a -> b) -> w a -> w b');
 
   eq (S.extend (S.joinWith ('')) ([])) ([]);

--- a/test/extract.js
+++ b/test/extract.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('extract', () => {
 
-  eq (typeof S.extract) ('function');
-  eq (S.extract.length) (1);
   eq (S.show (S.extract)) ('extract :: Comonad w => w a -> a');
 
   eq (S.extract (Identity (42))) (42);

--- a/test/filter.js
+++ b/test/filter.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('filter', () => {
 
-  eq (typeof S.filter) ('function');
-  eq (S.filter.length) (1);
   eq (S.show (S.filter)) ('filter :: Filterable f => (a -> Boolean) -> f a -> f a');
 
   eq (S.filter (S.odd) ([])) ([]);

--- a/test/find.js
+++ b/test/find.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('find', () => {
 
-  eq (typeof S.find) ('function');
-  eq (S.find.length) (1);
   eq (S.show (S.find)) ('find :: Foldable f => (a -> Boolean) -> f a -> Maybe a');
 
   eq (S.find (S.even) ([])) (S.Nothing);

--- a/test/flip.js
+++ b/test/flip.js
@@ -9,8 +9,6 @@ const map = require ('./internal/map');
 
 test ('flip', () => {
 
-  eq (typeof S.flip) ('function');
-  eq (S.flip.length) (1);
   eq (S.show (S.flip)) ('flip :: Functor f => f (a -> b) -> a -> f b');
 
   eq (S.flip (S.concat) ('foo') ('bar')) ('barfoo');

--- a/test/foldMap.js
+++ b/test/foldMap.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('foldMap', () => {
 
-  eq (typeof S.foldMap) ('function');
-  eq (S.foldMap.length) (1);
   eq (S.show (S.foldMap)) ('foldMap :: (Monoid b, Foldable f) => TypeRep b -> (a -> b) -> f a -> b');
 
   const repeat = n => (new Array (n + 1)).join (String (n));

--- a/test/fromEither.js
+++ b/test/fromEither.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('fromEither', () => {
 
-  eq (typeof S.fromEither) ('function');
-  eq (S.fromEither.length) (1);
   eq (S.show (S.fromEither)) ('fromEither :: b -> Either a b -> b');
 
   eq (S.fromEither (0) (S.Left (42))) (0);

--- a/test/fromMaybe.js
+++ b/test/fromMaybe.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('fromMaybe', () => {
 
-  eq (typeof S.fromMaybe) ('function');
-  eq (S.fromMaybe.length) (1);
   eq (S.show (S.fromMaybe)) ('fromMaybe :: a -> Maybe a -> a');
 
   eq (S.fromMaybe (0) (S.Nothing)) (0);

--- a/test/fromMaybe_.js
+++ b/test/fromMaybe_.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('fromMaybe_', () => {
 
-  eq (typeof S.fromMaybe_) ('function');
-  eq (S.fromMaybe_.length) (1);
   eq (S.show (S.fromMaybe_)) ('fromMaybe_ :: (() -> a) -> Maybe a -> a');
 
   eq (S.fromMaybe_ (() => 0) (S.Nothing)) (0);

--- a/test/fromPairs.js
+++ b/test/fromPairs.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('fromPairs', () => {
 
-  eq (typeof S.fromPairs) ('function');
-  eq (S.fromPairs.length) (1);
   eq (S.show (S.fromPairs)) ('fromPairs :: Foldable f => f (Pair String a) -> StrMap a');
 
   eq (S.fromPairs ([]))

--- a/test/fst.js
+++ b/test/fst.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('fst', () => {
 
-  eq (typeof S.fst) ('function');
-  eq (S.fst.length) (1);
   eq (S.show (S.fst)) ('fst :: Pair a b -> a');
 
   eq (S.fst (S.Pair ('foo') (42))) ('foo');

--- a/test/get.js
+++ b/test/get.js
@@ -11,8 +11,6 @@ const eq = require ('./internal/eq');
 
 test ('get', () => {
 
-  eq (typeof S.get) ('function');
-  eq (S.get.length) (1);
   eq (S.show (S.get)) ('get :: (Any -> Boolean) -> String -> a -> Maybe b');
 
   eq (S.get (S.is ($.Number)) ('x') ({x: 0, y: 42})) (S.Just (0));

--- a/test/gets.js
+++ b/test/gets.js
@@ -11,8 +11,6 @@ const eq = require ('./internal/eq');
 
 test ('gets', () => {
 
-  eq (typeof S.gets) ('function');
-  eq (S.gets.length) (1);
   eq (S.show (S.gets)) ('gets :: (Any -> Boolean) -> Array String -> a -> Maybe b');
 
   eq (S.gets (S.is ($.Number)) (['x']) ({x: {z: 0}, y: 42})) (S.Nothing);

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -10,8 +10,6 @@ const equals = require ('./internal/equals');
 
 test ('groupBy', () => {
 
-  eq (typeof S.groupBy) ('function');
-  eq (S.groupBy.length) (1);
   eq (S.show (S.groupBy)) ('groupBy :: (a -> a -> Boolean) -> Array a -> Array (Array a)');
 
   eq (S.groupBy (x => y => x * y % 3 === 0) ([])) ([]);

--- a/test/gt.js
+++ b/test/gt.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('gt', () => {
 
-  eq (typeof S.gt) ('function');
-  eq (S.gt.length) (1);
   eq (S.show (S.gt)) ('gt :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.gt (3)) ([1, 2, 3, 4, 5])) ([4, 5]);

--- a/test/gte.js
+++ b/test/gte.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('gte', () => {
 
-  eq (typeof S.gte) ('function');
-  eq (S.gte.length) (1);
   eq (S.show (S.gte)) ('gte :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.gte (3)) ([1, 2, 3, 4, 5])) ([3, 4, 5]);

--- a/test/head.js
+++ b/test/head.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('head', () => {
 
-  eq (typeof S.head) ('function');
-  eq (S.head.length) (1);
   eq (S.show (S.head)) ('head :: Foldable f => f a -> Maybe a');
 
   eq (S.head ([])) (S.Nothing);

--- a/test/id.js
+++ b/test/id.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('id', () => {
 
-  eq (typeof S.id) ('function');
-  eq (S.id.length) (1);
   eq (S.show (S.id)) ('id :: Category c => TypeRep c -> c');
 
   eq (S.id (Function) (42)) (42);

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('ifElse', () => {
 
-  eq (typeof S.ifElse) ('function');
-  eq (S.ifElse.length) (1);
   eq (S.show (S.ifElse)) ('ifElse :: (a -> Boolean) -> (a -> b) -> (a -> b) -> a -> b');
 
   eq (S.ifElse (S.odd) (S.sub (1)) (S.add (1)) (9)) (8);

--- a/test/init.js
+++ b/test/init.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('init', () => {
 
-  eq (typeof S.init) ('function');
-  eq (S.init.length) (1);
   eq (S.show (S.init)) ('init :: (Applicative f, Foldable f, Monoid f) => f a -> Maybe (f a)');
 
   eq (S.init ([])) (S.Nothing);

--- a/test/insert.js
+++ b/test/insert.js
@@ -10,8 +10,6 @@ const equals = require ('./internal/equals');
 
 test ('insert', () => {
 
-  eq (typeof S.insert) ('function');
-  eq (S.insert.length) (1);
   eq (S.show (S.insert)) ('insert :: String -> a -> StrMap a -> StrMap a');
 
   eq (S.insert ('a') (1) ({})) ({a: 1});

--- a/test/invert.js
+++ b/test/invert.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('invert', () => {
 
-  eq (typeof S.invert) ('function');
-  eq (S.invert.length) (1);
   eq (S.show (S.invert)) ('invert :: Group g => g -> g');
 
   eq (S.invert (Sum (5))) (Sum (-5));

--- a/test/is.js
+++ b/test/is.js
@@ -10,8 +10,6 @@ const eq = require ('./internal/eq');
 
 test ('is', () => {
 
-  eq (typeof S.is) ('function');
-  eq (S.is.length) (1);
   eq (S.show (S.is)) ('is :: Type -> Any -> Boolean');
 
   eq (S.is ($.Boolean) (true)) (true);

--- a/test/isJust.js
+++ b/test/isJust.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('isJust', () => {
 
-  eq (typeof S.isJust) ('function');
-  eq (S.isJust.length) (1);
   eq (S.show (S.isJust)) ('isJust :: Maybe a -> Boolean');
 
   eq (S.isJust (S.Nothing)) (false);

--- a/test/isLeft.js
+++ b/test/isLeft.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('isLeft', () => {
 
-  eq (typeof S.isLeft) ('function');
-  eq (S.isLeft.length) (1);
   eq (S.show (S.isLeft)) ('isLeft :: Either a b -> Boolean');
 
   eq (S.isLeft (S.Left (42))) (true);

--- a/test/isNothing.js
+++ b/test/isNothing.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('isNothing', () => {
 
-  eq (typeof S.isNothing) ('function');
-  eq (S.isNothing.length) (1);
   eq (S.show (S.isNothing)) ('isNothing :: Maybe a -> Boolean');
 
   eq (S.isNothing (S.Nothing)) (true);

--- a/test/isRight.js
+++ b/test/isRight.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('isRight', () => {
 
-  eq (typeof S.isRight) ('function');
-  eq (S.isRight.length) (1);
   eq (S.show (S.isRight)) ('isRight :: Either a b -> Boolean');
 
   eq (S.isRight (S.Left (42))) (false);

--- a/test/join.js
+++ b/test/join.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('join', () => {
 
-  eq (typeof S.join) ('function');
-  eq (S.join.length) (1);
   eq (S.show (S.join)) ('join :: Chain m => m (m a) -> m a');
 
   eq (S.join ([])) ([]);

--- a/test/joinWith.js
+++ b/test/joinWith.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('joinWith', () => {
 
-  eq (typeof S.joinWith) ('function');
-  eq (S.joinWith.length) (1);
   eq (S.show (S.joinWith)) ('joinWith :: String -> Array String -> String');
 
   eq (S.joinWith ('') (['a', 'b', 'c'])) ('abc');

--- a/test/justs.js
+++ b/test/justs.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('justs', () => {
 
-  eq (typeof S.justs) ('function');
-  eq (S.justs.length) (1);
   eq (S.show (S.justs)) ('justs :: (Filterable f, Functor f) => f (Maybe a) -> f a');
 
   eq (S.justs ([])) ([]);

--- a/test/keys.js
+++ b/test/keys.js
@@ -8,8 +8,6 @@ const strMap = require ('./internal/strMap');
 
 test ('keys', () => {
 
-  eq (typeof S.keys) ('function');
-  eq (S.keys.length) (1);
   eq (S.show (S.keys)) ('keys :: StrMap a -> Array String');
 
   eq (S.sort (S.keys ({}))) ([]);

--- a/test/last.js
+++ b/test/last.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('last', () => {
 
-  eq (typeof S.last) ('function');
-  eq (S.last.length) (1);
   eq (S.show (S.last)) ('last :: Foldable f => f a -> Maybe a');
 
   eq (S.last ([])) (S.Nothing);

--- a/test/lefts.js
+++ b/test/lefts.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('lefts', () => {
 
-  eq (typeof S.lefts) ('function');
-  eq (S.lefts.length) (1);
   eq (S.show (S.lefts)) ('lefts :: (Filterable f, Functor f) => f (Either a b) -> f a');
 
   eq (S.lefts ([])) ([]);

--- a/test/lift2.js
+++ b/test/lift2.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('lift2', () => {
 
-  eq (typeof S.lift2) ('function');
-  eq (S.lift2.length) (1);
   eq (S.show (S.lift2)) ('lift2 :: Apply f => (a -> b -> c) -> f a -> f b -> f c');
 
   eq (S.lift2 (S.add) (S.Just (3)) (S.Just (3))) (S.Just (6));

--- a/test/lift3.js
+++ b/test/lift3.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('lift3', () => {
 
-  eq (typeof S.lift3) ('function');
-  eq (S.lift3.length) (1);
   eq (S.show (S.lift3)) ('lift3 :: Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d');
 
   eq (S.lift3 (S.reduce) (S.Just (S.add)) (S.Just (0)) (S.Just ([1, 2, 3]))) (S.Just (6));

--- a/test/lines.js
+++ b/test/lines.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('lines', () => {
 
-  eq (typeof S.lines) ('function');
-  eq (S.lines.length) (1);
   eq (S.show (S.lines)) ('lines :: String -> Array String');
 
   eq (S.lines ('')) ([]);

--- a/test/lt.js
+++ b/test/lt.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('lt', () => {
 
-  eq (typeof S.lt) ('function');
-  eq (S.lt.length) (1);
   eq (S.show (S.lt)) ('lt :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.lt (3)) ([1, 2, 3, 4, 5])) ([1, 2]);

--- a/test/lte.js
+++ b/test/lte.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('lte', () => {
 
-  eq (typeof S.lte) ('function');
-  eq (S.lte.length) (1);
   eq (S.show (S.lte)) ('lte :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.lte (3)) ([1, 2, 3, 4, 5])) ([1, 2, 3]);

--- a/test/map.js
+++ b/test/map.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('map', () => {
 
-  eq (typeof S.map) ('function');
-  eq (S.map.length) (1);
   eq (S.show (S.map)) ('map :: Functor f => (a -> b) -> f a -> f b');
 
   eq (S.map (S.not) (S.odd) (2)) (true);

--- a/test/mapLeft.js
+++ b/test/mapLeft.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('mapLeft', () => {
 
-  eq (typeof S.mapLeft) ('function');
-  eq (S.mapLeft.length) (1);
   eq (S.show (S.mapLeft)) ('mapLeft :: Bifunctor p => (a -> b) -> p a c -> p b c');
 
   eq (S.mapLeft (S.toUpper) (S.Left ('xxx'))) (S.Left ('XXX'));

--- a/test/mapMaybe.js
+++ b/test/mapMaybe.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('mapMaybe', () => {
 
-  eq (typeof S.mapMaybe) ('function');
-  eq (S.mapMaybe.length) (1);
   eq (S.show (S.mapMaybe)) ('mapMaybe :: (Filterable f, Functor f) => (a -> Maybe b) -> f a -> f b');
 
   eq (S.mapMaybe (S.head) ([])) ([]);

--- a/test/match.js
+++ b/test/match.js
@@ -10,8 +10,6 @@ const equals = require ('./internal/equals');
 
 test ('match', () => {
 
-  eq (typeof S.match) ('function');
-  eq (S.match.length) (1);
   eq (S.show (S.match)) ('match :: NonGlobalRegExp -> String -> Maybe { groups :: Array (Maybe String), match :: String }');
 
   const scheme = '([a-z][a-z0-9+.-]*)';

--- a/test/matchAll.js
+++ b/test/matchAll.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('matchAll', () => {
 
-  eq (typeof S.matchAll) ('function');
-  eq (S.matchAll.length) (1);
   eq (S.show (S.matchAll)) ('matchAll :: GlobalRegExp -> String -> Array { groups :: Array (Maybe String), match :: String }');
 
   const pattern = S.regex ('g') ('<(h[1-6])(?: id="([^"]*)")?>([^<]*)</\\1>');

--- a/test/max.js
+++ b/test/max.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('max', () => {
 
-  eq (typeof S.max) ('function');
-  eq (S.max.length) (1);
   eq (S.show (S.max)) ('max :: Ord a => a -> a -> a');
 
   eq (S.max (10) (2)) (10);

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('maybe', () => {
 
-  eq (typeof S.maybe) ('function');
-  eq (S.maybe.length) (1);
   eq (S.show (S.maybe)) ('maybe :: b -> (a -> b) -> Maybe a -> b');
 
   eq (S.maybe (0) (Math.sqrt) (S.Nothing)) (0);

--- a/test/maybeToEither.js
+++ b/test/maybeToEither.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('maybeToEither', () => {
 
-  eq (typeof S.maybeToEither) ('function');
-  eq (S.maybeToEither.length) (1);
   eq (S.show (S.maybeToEither)) ('maybeToEither :: a -> Maybe b -> Either a b');
 
   eq (S.maybeToEither ('error msg') (S.Nothing)) (S.Left ('error msg'));

--- a/test/maybeToNullable.js
+++ b/test/maybeToNullable.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('maybeToNullable', () => {
 
-  eq (typeof S.maybeToNullable) ('function');
-  eq (S.maybeToNullable.length) (1);
   eq (S.show (S.maybeToNullable)) ('maybeToNullable :: Maybe a -> Nullable a');
 
   eq (S.maybeToNullable (S.Nothing)) (null);

--- a/test/maybe_.js
+++ b/test/maybe_.js
@@ -8,8 +8,6 @@ const factorial = require ('./internal/factorial');
 
 test ('maybe_', () => {
 
-  eq (typeof S.maybe_) ('function');
-  eq (S.maybe_.length) (1);
   eq (S.show (S.maybe_)) ('maybe_ :: (() -> b) -> (a -> b) -> Maybe a -> b');
 
   eq (S.maybe_ (() => factorial (10)) (Math.sqrt) (S.Nothing)) (3628800);

--- a/test/mean.js
+++ b/test/mean.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('mean', () => {
 
-  eq (typeof S.mean) ('function');
-  eq (S.mean.length) (1);
   eq (S.show (S.mean)) ('mean :: Foldable f => f FiniteNumber -> Maybe FiniteNumber');
 
   eq (S.mean ([])) (S.Nothing);

--- a/test/min.js
+++ b/test/min.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('min', () => {
 
-  eq (typeof S.min) ('function');
-  eq (S.min.length) (1);
   eq (S.show (S.min)) ('min :: Ord a => a -> a -> a');
 
   eq (S.min (10) (2)) (2);

--- a/test/mult.js
+++ b/test/mult.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('mult', () => {
 
-  eq (typeof S.mult) ('function');
-  eq (S.mult.length) (1);
   eq (S.show (S.mult)) ('mult :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.mult (4) (2)) (8);

--- a/test/negate.js
+++ b/test/negate.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('negate', () => {
 
-  eq (typeof S.negate) ('function');
-  eq (S.negate.length) (1);
   eq (S.show (S.negate)) ('negate :: ValidNumber -> ValidNumber');
 
   eq (S.negate (0.5)) (-0.5);

--- a/test/none.js
+++ b/test/none.js
@@ -11,8 +11,6 @@ const equals = require ('./internal/equals');
 
 test ('none', () => {
 
-  eq (typeof S.none) ('function');
-  eq (S.none.length) (1);
   eq (S.show (S.none)) ('none :: Foldable f => (a -> Boolean) -> f a -> Boolean');
 
   eq (S.none (S.gt (0)) ([])) (true);

--- a/test/not.js
+++ b/test/not.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('not', () => {
 
-  eq (typeof S.not) ('function');
-  eq (S.not.length) (1);
   eq (S.show (S.not)) ('not :: Boolean -> Boolean');
 
   eq (S.not (false)) (true);

--- a/test/odd.js
+++ b/test/odd.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('odd', () => {
 
-  eq (typeof S.odd) ('function');
-  eq (S.odd.length) (1);
   eq (S.show (S.odd)) ('odd :: Integer -> Boolean');
 
   eq (S.odd (1)) (true);

--- a/test/of.js
+++ b/test/of.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('of', () => {
 
-  eq (typeof S.of) ('function');
-  eq (S.of.length) (1);
   eq (S.show (S.of)) ('of :: Applicative f => TypeRep (f a) -> a -> f a');
 
   eq (S.of (Array) (42)) ([42]);

--- a/test/on.js
+++ b/test/on.js
@@ -8,8 +8,6 @@ const rem = require ('./internal/rem');
 
 test ('on', () => {
 
-  eq (typeof S.on) ('function');
-  eq (S.on.length) (1);
   eq (S.show (S.on)) ('on :: (b -> b -> c) -> (a -> b) -> a -> a -> c');
 
   eq (S.on (rem) (S.prop ('x')) ({x: 5, y: 5}) ({x: 3, y: 3})) (2);

--- a/test/or.js
+++ b/test/or.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('or', () => {
 
-  eq (typeof S.or) ('function');
-  eq (S.or.length) (1);
   eq (S.show (S.or)) ('or :: Boolean -> Boolean -> Boolean');
 
   eq (S.or (false) (false)) (false);

--- a/test/pairs.js
+++ b/test/pairs.js
@@ -8,8 +8,6 @@ const strMap = require ('./internal/strMap');
 
 test ('pairs', () => {
 
-  eq (typeof S.pairs) ('function');
-  eq (S.pairs.length) (1);
   eq (S.show (S.pairs)) ('pairs :: StrMap a -> Array (Pair String a)');
 
   eq (S.sort (S.pairs ({}))) ([]);

--- a/test/pair~.js
+++ b/test/pair~.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('pair', () => {
 
-  eq (typeof S.pair) ('function');
-  eq (S.pair.length) (1);
   eq (S.show (S.pair)) ('pair :: (a -> b -> c) -> Pair a b -> c');
 
   eq (S.pair (S.concat) (S.Pair ('foo') ('bar'))) ('foobar');

--- a/test/parseDate.js
+++ b/test/parseDate.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('parseDate', () => {
 
-  eq (typeof S.parseDate) ('function');
-  eq (S.parseDate.length) (1);
   eq (S.show (S.parseDate)) ('parseDate :: String -> Maybe ValidDate');
 
   eq (S.parseDate ('2001-02-03T04:05:06Z')) (S.Just (new Date ('2001-02-03T04:05:06Z')));

--- a/test/parseFloat.js
+++ b/test/parseFloat.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('parseFloat', () => {
 
-  eq (typeof S.parseFloat) ('function');
-  eq (S.parseFloat.length) (1);
   eq (S.show (S.parseFloat)) ('parseFloat :: String -> Maybe Number');
 
   eq (S.parseFloat ('12.34')) (S.Just (12.34));

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -8,8 +8,6 @@ const throws = require ('./internal/throws');
 
 test ('parseInt', () => {
 
-  eq (typeof S.parseInt) ('function');
-  eq (S.parseInt.length) (1);
   eq (S.show (S.parseInt)) ('parseInt :: Radix -> String -> Maybe Integer');
 
   eq (S.parseInt (10) ('42')) (S.Just (42));

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('parseJson', () => {
 
-  eq (typeof S.parseJson) ('function');
-  eq (S.parseJson.length) (1);
   eq (S.show (S.parseJson)) ('parseJson :: (Any -> Boolean) -> String -> Maybe a');
 
   eq (S.parseJson (S.is ($.Any)) ('[Invalid JSON]')) (S.Nothing);

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('pipe', () => {
 
-  eq (typeof S.pipe) ('function');
-  eq (S.pipe.length) (1);
   eq (S.show (S.pipe)) ('pipe :: Foldable f => f (Any -> Any) -> a -> b');
 
   eq (S.pipe ([]) ('99')) ('99');

--- a/test/pipeK.js
+++ b/test/pipeK.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('pipeK', () => {
 
-  eq (typeof S.pipeK) ('function');
-  eq (S.pipeK.length) (1);
   eq (S.show (S.pipeK)) ('pipeK :: (Foldable f, Chain m) => f (Any -> m Any) -> m a -> m b');
 
   eq (S.pipeK ([]) (S.Just ([1, 2, 3]))) (S.Just ([1, 2, 3]));

--- a/test/pow.js
+++ b/test/pow.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('pow', () => {
 
-  eq (typeof S.pow) ('function');
-  eq (S.pow.length) (1);
   eq (S.show (S.pow)) ('pow :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.pow (2) (8)) (64);

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('prepend', () => {
 
-  eq (typeof S.prepend) ('function');
-  eq (S.prepend.length) (1);
   eq (S.show (S.prepend)) ('prepend :: (Applicative f, Semigroup f) => a -> f a -> f a');
 
   eq (S.prepend (1) ([])) ([1]);

--- a/test/product.js
+++ b/test/product.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('product', () => {
 
-  eq (typeof S.product) ('function');
-  eq (S.product.length) (1);
   eq (S.show (S.product)) ('product :: Foldable f => f FiniteNumber -> FiniteNumber');
 
   eq (S.product ([])) (1);

--- a/test/promap.js
+++ b/test/promap.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('promap', () => {
 
-  eq (typeof S.promap) ('function');
-  eq (S.promap.length) (1);
   eq (S.show (S.promap)) ('promap :: Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d');
 
   const before = S.map (S.prop ('length'));

--- a/test/prop.js
+++ b/test/prop.js
@@ -8,8 +8,6 @@ const throws = require ('./internal/throws');
 
 test ('prop', () => {
 
-  eq (typeof S.prop) ('function');
-  eq (S.prop.length) (1);
   eq (S.show (S.prop)) ('prop :: String -> a -> b');
 
   throws (() => { S.prop ('xxx') ([1, 2, 3]); })

--- a/test/props.js
+++ b/test/props.js
@@ -8,8 +8,6 @@ const throws = require ('./internal/throws');
 
 test ('props', () => {
 
-  eq (typeof S.props) ('function');
-  eq (S.props.length) (1);
   eq (S.show (S.props)) ('props :: Array String -> a -> b');
 
   throws (() => { S.props (['a', 'b', 'c']) ([1, 2, 3]); })

--- a/test/range.js
+++ b/test/range.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('range', () => {
 
-  eq (typeof S.range) ('function');
-  eq (S.range.length) (1);
   eq (S.show (S.range)) ('range :: Integer -> Integer -> Array Integer');
 
   eq (S.range (0) (0)) ([]);

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('reduce', () => {
 
-  eq (typeof S.reduce) ('function');
-  eq (S.reduce.length) (1);
   eq (S.show (S.reduce)) ('reduce :: Foldable f => (a -> b -> a) -> a -> f b -> a');
 
   eq (S.reduce (S.concat) ('x') ([])) ('x');

--- a/test/regex.js
+++ b/test/regex.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('regex', () => {
 
-  eq (typeof S.regex) ('function');
-  eq (S.regex.length) (1);
   eq (S.show (S.regex)) ('regex :: RegexFlags -> String -> RegExp');
 
   eq (S.regex ('') ('\\d')) (/\d/);

--- a/test/regexEscape.js
+++ b/test/regexEscape.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('regexEscape', () => {
 
-  eq (typeof S.regexEscape) ('function');
-  eq (S.regexEscape.length) (1);
   eq (S.show (S.regexEscape)) ('regexEscape :: String -> String');
 
   eq (S.regexEscape ('-=*{XYZ}*=-')) ('\\-=\\*\\{XYZ\\}\\*=\\-');

--- a/test/reject.js
+++ b/test/reject.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('reject', () => {
 
-  eq (typeof S.reject) ('function');
-  eq (S.reject.length) (1);
   eq (S.show (S.reject)) ('reject :: Filterable f => (a -> Boolean) -> f a -> f a');
 
   eq (S.reject (S.odd) ([])) ([]);

--- a/test/remove.js
+++ b/test/remove.js
@@ -10,8 +10,6 @@ const equals = require ('./internal/equals');
 
 test ('remove', () => {
 
-  eq (typeof S.remove) ('function');
-  eq (S.remove.length) (1);
   eq (S.show (S.remove)) ('remove :: String -> StrMap a -> StrMap a');
 
   eq (S.remove ('a') ({})) ({});

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('reverse', () => {
 
-  eq (typeof S.reverse) ('function');
-  eq (S.reverse.length) (1);
   eq (S.show (S.reverse)) ('reverse :: (Applicative f, Foldable f, Monoid f) => f a -> f a');
 
   eq (S.reverse ([])) ([]);

--- a/test/rights.js
+++ b/test/rights.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('rights', () => {
 
-  eq (typeof S.rights) ('function');
-  eq (S.rights.length) (1);
   eq (S.show (S.rights)) ('rights :: (Filterable f, Functor f) => f (Either a b) -> f b');
 
   eq (S.rights ([])) ([]);

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('sequence', () => {
 
-  eq (typeof S.sequence) ('function');
-  eq (S.sequence.length) (1);
   eq (S.show (S.sequence)) ('sequence :: (Applicative f, Traversable t) => TypeRep (f a) -> t (f a) -> f (t a)');
 
   eq (S.sequence (Identity) ([])) (Identity ([]));

--- a/test/show.js
+++ b/test/show.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('show', () => {
 
-  eq (typeof S.show) ('function');
-  eq (S.show.length) (1);
   eq (S.show (S.show)) ('show :: Any -> String');
 
   eq (S.show (null)) ('null');

--- a/test/singleton.js
+++ b/test/singleton.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('singleton', () => {
 
-  eq (typeof S.singleton) ('function');
-  eq (S.singleton.length) (1);
   eq (S.show (S.singleton)) ('singleton :: String -> a -> StrMap a');
 
   eq (S.singleton ('foo') (42)) ({foo: 42});

--- a/test/size.js
+++ b/test/size.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('size', () => {
 
-  eq (typeof S.size) ('function');
-  eq (S.size.length) (1);
   eq (S.show (S.size)) ('size :: Foldable f => f a -> Integer');
 
   eq (S.size ([])) (0);

--- a/test/snd.js
+++ b/test/snd.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('snd', () => {
 
-  eq (typeof S.snd) ('function');
-  eq (S.snd.length) (1);
   eq (S.show (S.snd)) ('snd :: Pair a b -> b');
 
   eq (S.snd (S.Pair ('foo') (42))) (42);

--- a/test/sort.js
+++ b/test/sort.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('sort', () => {
 
-  eq (typeof S.sort) ('function');
-  eq (S.sort.length) (1);
   eq (S.show (S.sort)) ('sort :: (Ord a, Applicative m, Foldable m, Monoid m) => m a -> m a');
 
   eq (S.sort ([])) ([]);

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('sortBy', () => {
 
-  eq (typeof S.sortBy) ('function');
-  eq (S.sortBy.length) (1);
   eq (S.show (S.sortBy)) ('sortBy :: (Ord b, Applicative m, Foldable m, Monoid m) => (a -> b) -> m a -> m a');
 
   eq (S.sortBy (S.I) ([])) ([]);

--- a/test/splitOn.js
+++ b/test/splitOn.js
@@ -10,8 +10,6 @@ const equals = require ('./internal/equals');
 
 test ('splitOn', () => {
 
-  eq (typeof S.splitOn) ('function');
-  eq (S.splitOn.length) (1);
   eq (S.show (S.splitOn)) ('splitOn :: String -> String -> Array String');
 
   eq (S.splitOn ('') ('abc')) (['a', 'b', 'c']);

--- a/test/splitOnRegex.js
+++ b/test/splitOnRegex.js
@@ -10,8 +10,6 @@ const equals = require ('./internal/equals');
 
 test ('splitOnRegex', () => {
 
-  eq (typeof S.splitOnRegex) ('function');
-  eq (S.splitOnRegex.length) (1);
   eq (S.show (S.splitOnRegex)) ('splitOnRegex :: GlobalRegExp -> String -> Array String');
 
   eq (S.splitOnRegex (/b/g) ('abc')) (['a', 'c']);

--- a/test/stripPrefix.js
+++ b/test/stripPrefix.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('stripPrefix', () => {
 
-  eq (typeof S.stripPrefix) ('function');
-  eq (S.stripPrefix.length) (1);
   eq (S.show (S.stripPrefix)) ('stripPrefix :: String -> String -> Maybe String');
 
   eq (S.stripPrefix ('') ('')) (S.Just (''));

--- a/test/stripSuffix.js
+++ b/test/stripSuffix.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('stripSuffix', () => {
 
-  eq (typeof S.stripSuffix) ('function');
-  eq (S.stripSuffix.length) (1);
   eq (S.show (S.stripSuffix)) ('stripSuffix :: String -> String -> Maybe String');
 
   eq (S.stripSuffix ('') ('')) (S.Just (''));

--- a/test/sub.js
+++ b/test/sub.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('sub', () => {
 
-  eq (typeof S.sub) ('function');
-  eq (S.sub.length) (1);
   eq (S.show (S.sub)) ('sub :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.map (S.sub (1)) ([1, 2, 3])) ([0, 1, 2]);

--- a/test/sum.js
+++ b/test/sum.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('sum', () => {
 
-  eq (typeof S.sum) ('function');
-  eq (S.sum.length) (1);
   eq (S.show (S.sum)) ('sum :: Foldable f => f FiniteNumber -> FiniteNumber');
 
   eq (S.sum ([])) (0);

--- a/test/swap.js
+++ b/test/swap.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('swap', () => {
 
-  eq (typeof S.swap) ('function');
-  eq (S.swap.length) (1);
   eq (S.show (S.swap)) ('swap :: Pair a b -> Pair b a');
 
   eq (S.swap (S.Pair ('foo') (42))) (S.Pair (42) ('foo'));

--- a/test/tagBy.js
+++ b/test/tagBy.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('tagBy', () => {
 
-  eq (typeof S.tagBy) ('function');
-  eq (S.tagBy.length) (1);
   eq (S.show (S.tagBy)) ('tagBy :: (a -> Boolean) -> a -> Either a a');
 
   eq (S.tagBy (S.odd) (5)) (S.Right (5));

--- a/test/tail.js
+++ b/test/tail.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('tail', () => {
 
-  eq (typeof S.tail) ('function');
-  eq (S.tail.length) (1);
   eq (S.show (S.tail)) ('tail :: (Applicative f, Foldable f, Monoid f) => f a -> Maybe (f a)');
 
   eq (S.tail ([])) (S.Nothing);

--- a/test/take.js
+++ b/test/take.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('take', () => {
 
-  eq (typeof S.take) ('function');
-  eq (S.take.length) (1);
   eq (S.show (S.take)) ('take :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.take (0) ([1, 2, 3, 4, 5])) (S.Just ([]));

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -8,8 +8,6 @@ const eq = require ('./internal/eq');
 
 test ('takeLast', () => {
 
-  eq (typeof S.takeLast) ('function');
-  eq (S.takeLast.length) (1);
   eq (S.show (S.takeLast)) ('takeLast :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.takeLast (0) ([1, 2, 3, 4, 5])) (S.Just ([]));

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('takeWhile', () => {
 
-  eq (typeof S.takeWhile) ('function');
-  eq (S.takeWhile.length) (1);
   eq (S.show (S.takeWhile)) ('takeWhile :: (a -> Boolean) -> Array a -> Array a');
 
   eq (S.takeWhile (S.odd) ([3, 3, 3, 7, 6, 3, 5, 4])) ([3, 3, 3, 7]);

--- a/test/test.js
+++ b/test/test.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('test', () => {
 
-  eq (typeof S.test) ('function');
-  eq (S.test.length) (1);
   eq (S.show (S.test)) ('test :: RegExp -> String -> Boolean');
 
   eq (S.test (/^a/) ('abacus')) (true);

--- a/test/toEither.js
+++ b/test/toEither.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('toEither', () => {
 
-  eq (typeof S.toEither) ('function');
-  eq (S.toEither.length) (1);
   eq (S.show (S.toEither)) ('toEither :: a -> b -> Either a b');
 
   eq (S.toEither ('a') (null)) (S.Left ('a'));

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('toLower', () => {
 
-  eq (typeof S.toLower) ('function');
-  eq (S.toLower.length) (1);
   eq (S.show (S.toLower)) ('toLower :: String -> String');
 
   eq (S.toLower ('')) ('');

--- a/test/toMaybe.js
+++ b/test/toMaybe.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('toMaybe', () => {
 
-  eq (typeof S.toMaybe) ('function');
-  eq (S.toMaybe.length) (1);
   eq (S.show (S.toMaybe)) ('toMaybe :: a -> Maybe a');
 
   eq (S.toMaybe (null)) (S.Nothing);

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('toUpper', () => {
 
-  eq (typeof S.toUpper) ('function');
-  eq (S.toUpper.length) (1);
   eq (S.show (S.toUpper)) ('toUpper :: String -> String');
 
   eq (S.toUpper ('')) ('');

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('traverse', () => {
 
-  eq (typeof S.traverse) ('function');
-  eq (S.traverse.length) (1);
   eq (S.show (S.traverse)) ('traverse :: (Applicative f, Traversable t) => TypeRep (f b) -> (a -> f b) -> t a -> f (t b)');
 
   eq (S.traverse (S.Maybe) (S.parseInt (16)) (['A', 'B', 'C'])) (S.Just ([10, 11, 12]));

--- a/test/trim.js
+++ b/test/trim.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('trim', () => {
 
-  eq (typeof S.trim) ('function');
-  eq (S.trim.length) (1);
   eq (S.show (S.trim)) ('trim :: String -> String');
 
   eq (S.trim ('')) ('');

--- a/test/type.js
+++ b/test/type.js
@@ -9,8 +9,6 @@ const eq = require ('./internal/eq');
 
 test ('type', () => {
 
-  eq (typeof S.type) ('function');
-  eq (S.type.length) (1);
   eq (S.show (S.type)) ('type :: Any -> { name :: String, namespace :: Maybe String, version :: NonNegativeInteger }');
 
   // eslint-disable-next-line prefer-rest-params

--- a/test/unfoldr.js
+++ b/test/unfoldr.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('unfoldr', () => {
 
-  eq (typeof S.unfoldr) ('function');
-  eq (S.unfoldr.length) (1);
   eq (S.show (S.unfoldr)) ('unfoldr :: (b -> Maybe (Pair a b)) -> b -> Array a');
 
   const f = n => n >= 5 ? S.Nothing : S.Just (S.Pair (n) (n + 1));

--- a/test/unless.js
+++ b/test/unless.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('unless', () => {
 
-  eq (typeof S.unless) ('function');
-  eq (S.unless.length) (1);
   eq (S.show (S.unless)) ('unless :: (a -> Boolean) -> (a -> a) -> a -> a');
 
   eq (S.unless (S.lt (0)) (Math.sqrt) (16)) (4);

--- a/test/unlines.js
+++ b/test/unlines.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('unlines', () => {
 
-  eq (typeof S.unlines) ('function');
-  eq (S.unlines.length) (1);
   eq (S.show (S.unlines)) ('unlines :: Array String -> String');
 
   eq (S.unlines ([])) ('');

--- a/test/unwords.js
+++ b/test/unwords.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('unwords', () => {
 
-  eq (typeof S.unwords) ('function');
-  eq (S.unwords.length) (1);
   eq (S.show (S.unwords)) ('unwords :: Array String -> String');
 
   eq (S.unwords ([])) ('');

--- a/test/value.js
+++ b/test/value.js
@@ -8,8 +8,6 @@ const strMap = require ('./internal/strMap');
 
 test ('value', () => {
 
-  eq (typeof S.value) ('function');
-  eq (S.value.length) (1);
   eq (S.show (S.value)) ('value :: String -> StrMap a -> Maybe a');
 
   eq (S.value ('foo') ({foo: 1, bar: 2})) (S.Just (1));

--- a/test/values.js
+++ b/test/values.js
@@ -8,8 +8,6 @@ const strMap = require ('./internal/strMap');
 
 test ('values', () => {
 
-  eq (typeof S.values) ('function');
-  eq (S.values.length) (1);
   eq (S.show (S.values)) ('values :: StrMap a -> Array a');
 
   eq (S.sort (S.values ({}))) ([]);

--- a/test/when.js
+++ b/test/when.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('when', () => {
 
-  eq (typeof S.when) ('function');
-  eq (S.when.length) (1);
   eq (S.show (S.when)) ('when :: (a -> Boolean) -> (a -> a) -> a -> a');
 
   eq (S.when (S.gte (0)) (Math.sqrt) (16)) (4);

--- a/test/words.js
+++ b/test/words.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('words', () => {
 
-  eq (typeof S.words) ('function');
-  eq (S.words.length) (1);
   eq (S.show (S.words)) ('words :: String -> Array String');
 
   eq (S.words ('')) ([]);

--- a/test/zero.js
+++ b/test/zero.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('zero', () => {
 
-  eq (typeof S.zero) ('function');
-  eq (S.zero.length) (1);
   eq (S.show (S.zero)) ('zero :: Plus f => TypeRep (f a) -> f a');
 
   eq (S.zero (Array)) ([]);

--- a/test/zip.js
+++ b/test/zip.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('zip', () => {
 
-  eq (typeof S.zip) ('function');
-  eq (S.zip.length) (1);
   eq (S.show (S.zip)) ('zip :: Array a -> Array b -> Array (Pair a b)');
 
   eq (S.zip (['a', 'b']) (['x', 'y', 'z']))

--- a/test/zipWith.js
+++ b/test/zipWith.js
@@ -7,8 +7,6 @@ const eq = require ('./internal/eq');
 
 test ('zipWith', () => {
 
-  eq (typeof S.zipWith) ('function');
-  eq (S.zipWith.length) (1);
   eq (S.show (S.zipWith)) ('zipWith :: (a -> b -> c) -> Array a -> Array b -> Array c');
 
   eq (S.zipWith (x => y => x + y) (['a', 'b']) (['x', 'y', 'z'])) (['ax', 'by']);


### PR DESCRIPTION
These assertions only show that `def` returns a unary function, a fact established in the sanctuary-def test suite.
