### PR TITLE
array: update return type of S.size

### DIFF
--- a/index.js
+++ b/index.js
@@ -3024,7 +3024,7 @@
     impl: dropWhile
   };
 
-  //# size :: Foldable f => f a -> Integer
+  //# size :: Foldable f => f a -> NonNegativeInteger
   //.
   //. Returns the number of elements of the given structure.
   //.
@@ -3052,7 +3052,7 @@
   //. ```
   _.size = {
     consts: {f: [Z.Foldable]},
-    types: [f (a), $.Integer],
+    types: [f (a), $.NonNegativeInteger],
     impl: Z.size
   };
 

--- a/test/size.js
+++ b/test/size.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('size', () => {
 
-  eq (S.show (S.size)) ('size :: Foldable f => f a -> Integer');
+  eq (S.show (S.size)) ('size :: Foldable f => f a -> NonNegativeInteger');
 
   eq (S.size ([])) (0);
   eq (S.size (['foo'])) (1);


### PR DESCRIPTION
This is a breaking change if functions' string representations are considered part of the public API, but they are primarily for use in the REPL. Are others comfortable with this change being included in a minor or patch release?
