### PR TITLE
documentation: prefix heading identifiers to avoid collisions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1876,7 +1876,7 @@
     impl: on
   };
 
-  //. ### Pair type
+  //. ### Pair
   //.
   //. Pair is the canonical product type: a value of type `Pair a b` always
   //. contains exactly two values: one of type `a`; one of type `b`.
@@ -1959,7 +1959,7 @@
     impl: pair (C (Pair))
   };
 
-  //. ### Maybe type
+  //. ### Maybe
   //.
   //. The Maybe type represents optional values: a value of type `Maybe a` is
   //. either Nothing (the empty value) or a Just whose value is of type `a`.
@@ -2215,7 +2215,7 @@
     impl: maybeToEither
   };
 
-  //. ### Either type
+  //. ### Either
   //.
   //. The Either type represents values with two possibilities: a value of type
   //. `Either a b` is either a Left whose value is of type `a` or a Right whose
@@ -4686,14 +4686,14 @@
 //. [#488]:                     https://github.com/sanctuary-js/sanctuary/issues/488
 //. [Apply]:                    v:fantasyland/fantasy-land#apply
 //. [Chain]:                    v:fantasyland/fantasy-land#chain
-//. [Either]:                   #either-type
+//. [Either]:                   #section:either
 //. [Fantasy Land]:             v:fantasyland/fantasy-land
 //. [Foldable]:                 v:fantasyland/fantasy-land#foldable
 //. [Folktale]:                 https://folktale.origamitower.com/
 //. [GIGO]:                     https://en.wikipedia.org/wiki/Garbage_in,_garbage_out
 //. [Haskell]:                  https://www.haskell.org/
 //. [Kleisli]:                  https://en.wikipedia.org/wiki/Kleisli_category
-//. [Maybe]:                    #maybe-type
+//. [Maybe]:                    #section:maybe
 //. [Nullable]:                 v:sanctuary-js/sanctuary-def#Nullable
 //. [PureScript]:               http://www.purescript.org/
 //. [Ramda]:                    https://ramdajs.com/
@@ -4756,7 +4756,7 @@
 //. [stable sort]:              https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
 //. [thrush]:                   https://github.com/raganwald-deprecated/homoiconic/blob/master/2008-10-30/thrush.markdown
 //. [total functions]:          https://en.wikipedia.org/wiki/Partial_function#Total_function
-//. [type checking]:            #type-checking
+//. [type checking]:            #section:type-checking
 //. [type identifier]:          v:sanctuary-js/sanctuary-type-identifiers
 //. [type representative]:      v:fantasyland/fantasy-land#type-representatives
 //. [variadic functions]:       https://en.wikipedia.org/wiki/Variadic_function

--- a/scripts/generate-readme
+++ b/scripts/generate-readme
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euf -o pipefail
+
+cp index.js index.js.orig
+trap 'mv index.js.orig index.js' EXIT
+
+awk '
+  {
+    if ($1 == "//." && $2 ~ /^#{1,6}$/) {
+      text = "❑ "
+      slug = "section:"
+      for (n = 3 ; ; n += 1) {
+        text = text $n
+        gsub(/\W/, "", $n)
+        slug = slug tolower($n)
+        if (n == NF) {
+          break
+        }
+        text = text " "
+        slug = slug "-"
+      }
+      print "//. " $2 " <span id=\x22" slug "\x22>" text "</span>"
+    } else {
+      print
+    }
+  }
+' index.js.orig >index.js
+
+node_modules/.bin/sanctuary-generate-readme


### PR DESCRIPTION
Commit message:

>Identifiers are automatically generated for both headings and functions. Currently these can collide. It is currently impossible to link directly to `S.array` because it has the same fragment identifier as the ‘Array’ section in which it resides.
>
> This commit adds a script to be run during readme generation, which wraps the text of each heading in `<span id="section:...">❑ ...</span>`. GitHub's algorithm converts the LOWER RIGHT SHADOWED WHITE SQUARE to a hyphen, which prevents GitHub's heading identifiers from colliding with function identifiers (control characters are rendered as �, and GitHub's algorithm ignores space characters, so a visible character is required).
>
> Before:
>
>     ### Array
>
> After:
>
>     ### <span id="section:array">❑ Array</span>
>
> The heading above will have two fragment identifiers, `#section:array` and `#-array` (assigned by GitHub), neither of which collides with `#array`, the fragment identifier for `S.array`.
