### PR TITLE
dist: use VERSION when generating bundle header

### DIFF
--- a/scripts/bundle
+++ b/scripts/bundle
@@ -8,6 +8,12 @@ const path = require ('path');
 const sanctuary = require ('../package.json');
 
 
+if (!(Object.prototype.hasOwnProperty.call (process.env, 'VERSION'))) {
+  process.stderr.write ('VERSION not specified\n');
+  process.exit (1);
+}
+const VERSION = process.env.VERSION;
+
 //    expandDependencies :: StrMap String -> StrMap (Array String)
 const expandDependencies = children => {
   const descendants = Object.create (null);
@@ -38,14 +44,11 @@ const orderDependencies = deps => {
 const dependencies =
   orderDependencies (expandDependencies (sanctuary.dependencies));
 
-//    spec :: { name :: String, version :: String } -> String
-const spec = pkg => pkg.name + '@' + pkg.version;
-
 process.stdout.write (
-  `//  ${spec (sanctuary)} with bundled dependencies:
+  `//  sanctuary@${VERSION} with bundled dependencies:
 //
 ${dependencies
-  .map (name => '//  - ' + spec (require (name + '/package.json')))
+  .map (name => `//  - ${name}@${(require (name + '/package.json')).version}`)
   .join ('\n')}
 
 ${dependencies


### PR DESCRIPTION
`scripts/bundle`, added in #641, currently uses the value of the `version` field of __package.json__ when generating the header. This is incorrect: xyz runs scripts *before* updating the `version` field. This explains why the first line of [__bundle.js__][1] refers to version `2.0.1` rather than to version `2.0.2`.

/cc @Avaq


[1]: https://github.com/sanctuary-js/sanctuary/blob/v2.0.2/dist/bundle.js
