### PR TITLE
regexp: add S.replaceWith and S.replaceBy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
               nvm exec $1 npm test
             }
             case $CIRCLE_NODE_INDEX in
-              0) test_with_version 8 ;;
-              1) test_with_version 10 ;;
-              2) npm install && npm test ;;
+              0) test_with_version 10 ;;
+              1) npm install && npm test ;;
+              2) test_with_version 14 ;;
             esac

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,9 +1,11 @@
 {
   "root": true,
   "extends": ["../node_modules/sanctuary-style/eslint-es6.json"],
+  "parserOptions": {"ecmaVersion": 2018},
   "env": {"node": true},
   "globals": {"suite": false, "test": false},
   "rules": {
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline", "functions": "never"}],
     "max-len": ["off"]
   }
 }

--- a/test/replaceBy.js
+++ b/test/replaceBy.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('replaceBy', () => {
+
+  eq (S.show (S.replaceBy)) ('replaceBy :: (Array (Maybe String) -> String) -> RegExp -> String -> String');
+
+  eq (S.replaceBy (([$1]) => S.maybe ('') (S.toUpper) ($1)) (/(\w)/) ('foo')) ('Foo');
+  eq (S.replaceBy (([$1]) => S.maybe ('') (S.toUpper) ($1)) (/(\w)/g) ('foo')) ('FOO');
+  eq (S.replaceBy (S.show) (/(foo)(bar)?/) ('<>')) ('<>');
+  eq (S.replaceBy (S.show) (/(foo)(bar)?/) ('<foo>')) ('<[Just ("foo"), Nothing]>');
+  eq (S.replaceBy (S.show) (/(foo)(bar)?/) ('<foobar>')) ('<[Just ("foo"), Just ("bar")]>');
+  eq (S.replaceBy (S.show) (/@(?<username>[-\w]+)/) ('@sanctuary-js')) ('[Just ("sanctuary-js")]');
+
+});

--- a/test/replaceWith.js
+++ b/test/replaceWith.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('replaceWith', () => {
+
+  eq (S.show (S.replaceWith)) ('replaceWith :: String -> RegExp -> String -> String');
+
+  eq (S.replaceWith ('x') (/o/) ('<bar>')) ('<bar>');
+  eq (S.replaceWith ('x') (/o/) ('<foo>')) ('<fxo>');
+  eq (S.replaceWith ('x') (/o/g) ('<bar>')) ('<bar>');
+  eq (S.replaceWith ('x') (/o/g) ('<foo>')) ('<fxx>');
+  eq (S.replaceWith ('$1') (/(o)/) ('<bar>')) ('<bar>');
+  eq (S.replaceWith ('$1') (/(o)/) ('<foo>')) ('<f$1o>');
+  eq (S.replaceWith ('$1') (/(o)/g) ('<bar>')) ('<bar>');
+  eq (S.replaceWith ('$1') (/(o)/g) ('<foo>')) ('<f$1$1>');
+
+});


### PR DESCRIPTION
Competes with #685

This pull request adds the following two functions:

```haskell
replaceWith ::                          String  -> RegExp -> String -> String
replaceBy   :: (Array (Maybe String) -> String) -> RegExp -> String -> String
```

Design decisions:

  - Both functions take `pattern :: RegExp`, so there is no straightforward equivalent of `s1.replace (s2, s3)` for strings `s1`, `s2`, and `s3`. One *could* use `S.replaceWith (s3) (S.regex ('') (S.regexEscape (s2))) (s1)`, but it would be simpler and clearer to use [`String#replace`][] directly in such cases.

    Using `pattern :: RegExp` exclusively provides two benefits:

      - __Simplicity.__ Supporting both `RegExp` and `String` would require splitting `replaceWith` into two functions (which would pose a naming challenge) or using `Either RegExp String` (which would not be ergonomic).

      - __Clarity.__ It's unclear whether `R.replace ('o') ('x') ('foo')` should evaluate to `'fxo'` or to `'fxx'`, whereas the presence of the `g` flag in `/o/g` indicates that all occurrences of `o` should be replaced, and the absence of the `g` flag in `/o/` indicates that only the first occurrence of `o` should be replaced.

  - Unlike [`replace`][], `S.replaceWith` does not support [special replacement patterns][]. We are not obligated to expose every feature of the underlying API, and with `S.replaceBy` it is possible to reference values matched by capturing groups (the primary use case for special replacement patterns).

  - Like [`replace'`][], `S.replaceBy` ignores the “`offset`” and “`string`” arguments provided by [`String#replace`][] (when given a function). These are rarely useful.

  - Unlike [`replace'`][], `S.replaceBy` ignores the “`groups`” argument provided by [`String#replace`][] (when given a function) if the pattern contains any named capturing groups. I included a fix for this deficiency in [purescript/purescript-strings#126][].

  - Unlike [`replace'`][], `S.replaceBy` ignores the “`match`” argument provided by [`String#replace`][] (when given a function). This simplifies the function's type, and saves one from using `S.K (...)` when only the captured groups are important (as is commonly the case). If one *does* require access to the matched substring as a whole, one can use `/(...)/` to capture it. Admittedly, this approach is impractical if the RegExp object is defined in another module, but in such exceptional cases one can of course use [`String#replace`][] directly.

  - Unlike [`replace'`][], `S.replaceBy` acknowledges the existence of optional capturing groups:

    ```javascript
    > S.replaceBy (S.show) (S.regex ('') ('(Pure)?(Script)')) ('JavaScript')
    'Java[Nothing, Just ("Script")]'
    ```

    Evaluating the equivalent PureScript expression results in an exception being thrown:

    ```purescript
    > replace' (unsafeRegex "(Pure)?(Script)" noFlags) (const show) "JavaScript"
    ! TypeError: undefined is not an object (evaluating 's.length')
    ```

    I have proposed the use of `Array (Maybe String)` in place of `Array String` in [purescript/purescript-strings#126][].

I have opened sanctuary-js/sanctuary-site#88 to provide several examples of `replaceWith` and `replaceBy` in use.

@sanctuary-js/owners, what do you think of the proposed additions to the library?


[`R.replace`]:                          https://ramdajs.com/docs/#replace
[`String#replace`]:                     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
[`replace`]:                            https://pursuit.purescript.org/packages/purescript-strings/4.0.1/docs/Data.String.Regex#v:replace
[`replace'`]:                           https://pursuit.purescript.org/packages/purescript-strings/4.0.1/docs/Data.String.Regex#v:replace'
[purescript/purescript-strings#126]:    https://github.com/purescript/purescript-strings/pull/126
[special replacement patterns]:         https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
