### PR TITLE
regexp: simplify return types of S.match and S.matchAll

### DIFF
--- a/test/match.js
+++ b/test/match.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('match', () => {
 
-  eq (S.show (S.match)) ('match :: NonGlobalRegExp -> String -> Maybe { groups :: Array (Maybe String), match :: String }');
+  eq (S.show (S.match)) ('match :: NonGlobalRegExp -> String -> Maybe (Array (Maybe String))');
 
   const scheme = '([a-z][a-z0-9+.-]*)';
   const authentication = '(.*?):(.*?)@';
@@ -22,12 +22,10 @@ test ('match', () => {
      (S.Nothing);
 
   eq (S.match (pattern) ('URL: http://example.com'))
-     (S.Just ({match: 'http://example.com',
-              groups: [S.Just ('http'), S.Nothing, S.Nothing, S.Just ('example.com'), S.Nothing]}));
+     (S.Just ([S.Just ('http'), S.Nothing, S.Nothing, S.Just ('example.com'), S.Nothing]));
 
   eq (S.match (pattern) ('URL: http://user:pass@example.com:80'))
-     (S.Just ({match: 'http://user:pass@example.com:80',
-              groups: [S.Just ('http'), S.Just ('user'), S.Just ('pass'), S.Just ('example.com'), S.Just ('80')]}));
+     (S.Just ([S.Just ('http'), S.Just ('user'), S.Just ('pass'), S.Just ('example.com'), S.Just ('80')]));
 
   jsc.assert (jsc.forall (jsc.string, s => {
     const p = '([A-Za-z]+)';

--- a/test/matchAll.js
+++ b/test/matchAll.js
@@ -7,16 +7,16 @@ const eq = require ('./internal/eq');
 
 test ('matchAll', () => {
 
-  eq (S.show (S.matchAll)) ('matchAll :: GlobalRegExp -> String -> Array { groups :: Array (Maybe String), match :: String }');
+  eq (S.show (S.matchAll)) ('matchAll :: GlobalRegExp -> String -> Array (Array (Maybe String))');
 
   const pattern = S.regex ('g') ('<(h[1-6])(?: id="([^"]*)")?>([^<]*)</\\1>');
 
   eq (S.matchAll (pattern) ('')) ([]);
 
   eq (S.matchAll (pattern) ('<h1>Foo</h1>\n<h2 id="bar">Bar</h2>\n<h2 id="baz">Baz</h2>\n'))
-     ([{match: '<h1>Foo</h1>', groups: [S.Just ('h1'), S.Nothing, S.Just ('Foo')]},
-       {match: '<h2 id="bar">Bar</h2>', groups: [S.Just ('h2'), S.Just ('bar'), S.Just ('Bar')]},
-       {match: '<h2 id="baz">Baz</h2>', groups: [S.Just ('h2'), S.Just ('baz'), S.Just ('Baz')]}]);
+     ([[S.Just ('h1'), S.Nothing, S.Just ('Foo')],
+       [S.Just ('h2'), S.Just ('bar'), S.Just ('Bar')],
+       [S.Just ('h2'), S.Just ('baz'), S.Just ('Baz')]]);
 
   eq (pattern.lastIndex) (0);
 


### PR DESCRIPTION
`match` and `matchAll` are currently not enjoyable to use. I know *why* the return types are complex, but I still find accessing captured values annoying:

```javascript
> S.join (S.chain (S.compose (S.head)
.                            (S.prop ('groups')))
.                 (S.match (/^(info|warn|error): (.*)$/i)
.                          ('info: Opening database connection...')))
Just ('info')
```

This pull request simplifies the match type, making captured values easier to access:

```javascript
> S.join (S.chain (S.head)
.                 (S.match (/^(info|warn|error): (.*)$/i)
.                          ('info: Opening database connection...')))
Just ('info')
```

Before:

```haskell
match :: NonGlobalRegExp -> String -> Maybe { match :: String, groups :: Array (Maybe String) }
matchAll :: GlobalRegExp -> String -> Array { match :: String, groups :: Array (Maybe String) }
```

After:

```haskell
match :: NonGlobalRegExp -> String -> Maybe (Array (Maybe String))
matchAll :: GlobalRegExp -> String -> Array (Array (Maybe String))
```

Losing `match :: String` is not a problem in most cases, for the reason given in #686:

> Unlike [`replace'`][], `S.replaceBy` ignores the “`match`” argument provided by [`String#replace`][] (when given a function). This simplifies the function's type, and saves one from using `S.K (...)` when only the captured groups are important (as is commonly the case). If one *does* require access to the matched substring as a whole, one can use `/(...)/` to capture it. Admittedly, this approach is impractical if the RegExp object is defined in another module, but in such exceptional cases one can of course use [`String#replace`][] directly.

Interestingly, the proposed type of `match` is the same as the function's type prior to #283. The incoherence @rjmk exposed in #253 does not apply, though, as the match is now omitted rather than prepended to the array of captured values.


[`String#replace`]:                     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
[`replace'`]:                           https://pursuit.purescript.org/packages/purescript-strings/4.0.1/docs/Data.String.Regex#v:replace'
