### PR TITLE
array: add S.elem_

### DIFF
--- a/index.js
+++ b/index.js
@@ -3168,7 +3168,7 @@
   //. Takes a value and a structure and returns `true` [iff][] the value is an
   //. element of the structure.
   //.
-  //. See also [`find`](#find).
+  //. See also [`elem_`](#elem_) and [`find`](#find).
   //.
   //. ```javascript
   //. > S.elem ('c') (['a', 'b', 'c'])
@@ -3192,10 +3192,33 @@
   //. > S.elem (0) (S.Nothing)
   //. false
   //. ```
+  var elem = (
+    curry2 (Z.elem)
+  );
   _.elem = {
     consts: {a: [Z.Setoid], f: [Z.Foldable]},
     types: [a, f (a), $.Boolean],
-    impl: curry2 (Z.elem)
+    impl: elem
+  };
+
+  //# elem_ :: (Setoid a, Foldable f) => f a -> a -> Boolean
+  //.
+  //. Variant of [`elem`](#elem) with arguments flipped.
+  //.
+  //. ```javascript
+  //. > S.filter (S.elem_ (['yes', 'oui', 'ja'])) (['yes', 'no'])
+  //. ['yes']
+  //.
+  //. > S.filter (S.elem_ (['yes', 'oui', 'ja'])) (['oui', 'non'])
+  //. ['oui']
+  //.
+  //. > S.filter (S.elem_ (['yes', 'oui', 'ja'])) (['ja', 'nein'])
+  //. ['ja']
+  //. ```
+  _.elem_ = {
+    consts: {a: [Z.Setoid], f: [Z.Foldable]},
+    types: [f (a), a, $.Boolean],
+    impl: C (elem)
   };
 
   //# find :: Foldable f => (a -> Boolean) -> f a -> Maybe a

--- a/test/elem_.js
+++ b/test/elem_.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const S = require ('..');
+
+const eq = require ('./internal/eq');
+
+
+test ('elem_', () => {
+
+  eq (S.show (S.elem_)) ('elem_ :: (Setoid a, Foldable f) => f a -> a -> Boolean');
+
+  eq (S.elem_ (['a', 'b', 'c']) ('c')) (true);
+  eq (S.elem_ (['a', 'b', 'c']) ('x')) (false);
+  eq (S.elem_ ({x: 1, y: 2, z: 3}) (3)) (true);
+  eq (S.elem_ ({x: 1, y: 2, z: 3}) (8)) (false);
+  eq (S.elem_ (S.Just (0)) (0)) (true);
+  eq (S.elem_ (S.Just (1)) (0)) (false);
+  eq (S.elem_ (S.Nothing) (0)) (false);
+
+});


### PR DESCRIPTION
I find myself flipping [`elem`][1] quite often.

Do you agree with this addition?


[1]: https://sanctuary.js.org/#elem
