### PR TITLE
[WIP] add support for TypedArrays/arraBuffer/nodejs' Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -2834,8 +2834,8 @@
       return function(xs) {
         if (n < 0) return Nothing;
 
-        //  Fast path for arrays.
-        if (Array.isArray (xs)) {
+        //  Fast path for objects supporting `slice`.
+        if (xs.slice) { // we want to support TypedArrays e.i. buffers
           return n <= xs.length ? Just (arrayCase (n, xs)) : Nothing;
         }
 

--- a/test/drop.js
+++ b/test/drop.js
@@ -28,4 +28,7 @@ test ('drop', () => {
 
   eq (S.drop (-1) (Cons (1) (Cons (2) (Cons (3) (Nil))))) (S.Nothing);
 
+  // eq (S.unchecked.drop (0) (new Uint8Array([10, 20, 30, 40, 50]))) (S.unchecked.Just (new Uint8Array([10, 20, 30, 40, 50])));
+  eq (S.unchecked.drop (1) (new Uint8Array([10, 20, 30, 40, 50]))) (S.unchecked.Just (new Uint8Array([20, 30, 40, 50])));
+
 });


### PR DESCRIPTION
Currently failing to implement tests for TypedArray.

In `assert.strictEqual (equals (actual) (expected), true);` the
`Setoid.test` test fails unconditionaly for a TypedArray (`Uint8Array`).

Need help ;)

Reproduce:

```js
const S = require ('./internal/sanctuary');
const eq = require ('./internal/eq');

eq (S.unchecked.drop (1) (new Uint8Array([10, 20, 30, 40, 50]))) (S.unchecked.Just (new Uint8Array([20, 30, 40, 50])));
```

PS. For now my goal is to support various Buffers for `unchecked` functions, since it seems like this should be opt-in and I don't know how to implement support in https://github.com/sanctuary-js/sanctuary-def yet.