### PR TITLE
circle: specify test matrix via node/test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,20 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.3.0
-
-jobs:
-  test:
-    executor:
-      name: node/default
-      tag: <<parameters.version>>
-    parameters:
-      version:
-        type: string
-    steps:
-      - checkout
-      - run: npm install
-      - run: npm test
+  node: circleci/node@5.0.0
 
 workflows:
   test:
     jobs:
-      - test:
-          version: 10.14.2
-      - test:
-          version: 12.0.0
-      - test:
-          version: 14.0.0
-      - test:
-          version: 16.0.0
+      - node/test:
+          setup:
+            # derive cache key from package.json
+            - run: cp package.json package-lock.json
+          override-ci-command: rm package-lock.json && npm install && git checkout -- package.json
+          matrix:
+            parameters:
+              version:
+                - 10.14.2
+                - 12.0.0
+                - 14.0.0
+                - 16.0.0


### PR DESCRIPTION
This is a bit nicer than my approach in #712.

We are forced to do a few counter-intuitive things in order to run `npm install` rather than `npm ci`.
