### PR TITLE
use `String` rather than `show` to test type signatures

### DIFF
--- a/test/I.js
+++ b/test/I.js
@@ -8,7 +8,7 @@ const properties = require ('./properties');
 
 test ('I', () => {
 
-  eq (S.show (S.I)) ('I :: a -> a');
+  eq (String (S.I)) ('I :: a -> a');
 
   eq (S.I ([1, 2, 3])) ([1, 2, 3]);
   eq (S.I (['foo', 42])) (['foo', 42]);

--- a/test/Just.js
+++ b/test/Just.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('Just', () => {
 
-  eq (S.show (S.Just)) ('Just :: a -> Maybe a');
+  eq (String (S.Just)) ('Just :: a -> Maybe a');
 
   eq (S.Just (42)) (S.Just (42));
 

--- a/test/K.js
+++ b/test/K.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('K', () => {
 
-  eq (S.show (S.K)) ('K :: a -> b -> a');
+  eq (String (S.K)) ('K :: a -> b -> a');
 
   eq (S.K (21) ([])) (21);
   eq (S.K (42) (null)) (42);

--- a/test/Left.js
+++ b/test/Left.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('Left', () => {
 
-  eq (S.show (S.Left)) ('Left :: a -> Either a b');
+  eq (String (S.Left)) ('Left :: a -> Either a b');
 
   eq (S.Left (42)) (S.Left (42));
 

--- a/test/Pair.js
+++ b/test/Pair.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('Pair', () => {
 
-  eq (S.show (S.Pair)) ('Pair :: a -> b -> Pair a b');
+  eq (String (S.Pair)) ('Pair :: a -> b -> Pair a b');
 
   eq (S.Pair ('foo') (42)) (S.Pair ('foo') (42));
 

--- a/test/Right.js
+++ b/test/Right.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('Right', () => {
 
-  eq (S.show (S.Right)) ('Right :: b -> Either a b');
+  eq (String (S.Right)) ('Right :: b -> Either a b');
 
   eq (S.Right (42)) (S.Right (42));
 

--- a/test/T.js
+++ b/test/T.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('T', () => {
 
-  eq (S.show (S.T)) ('T :: a -> (a -> b) -> b');
+  eq (String (S.T)) ('T :: a -> (a -> b) -> b');
 
   eq (S.T ('!') (S.concat ('foo'))) ('foo!');
   eq (S.T ('!') (S.concat ('bar'))) ('bar!');

--- a/test/add.js
+++ b/test/add.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('add', () => {
 
-  eq (S.show (S.add)) ('add :: FiniteNumber -> FiniteNumber -> FiniteNumber');
+  eq (String (S.add)) ('add :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.add (1) (1)) (2);
   eq (S.add (-1) (-1)) (-2);

--- a/test/all.js
+++ b/test/all.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('all', () => {
 
-  eq (S.show (S.all)) ('all :: Foldable f => (a -> Boolean) -> f a -> Boolean');
+  eq (String (S.all)) ('all :: Foldable f => (a -> Boolean) -> f a -> Boolean');
 
   eq (S.all (S.gt (0)) ([])) (true);
   eq (S.all (S.gt (0)) ([0])) (false);

--- a/test/alt.js
+++ b/test/alt.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('alt', () => {
 
-  eq (S.show (S.alt)) ('alt :: Alt f => f a -> f a -> f a');
+  eq (String (S.alt)) ('alt :: Alt f => f a -> f a -> f a');
 
   eq (S.alt ([]) ([])) ([]);
   eq (S.alt ([1, 2, 3]) ([])) ([1, 2, 3]);

--- a/test/and.js
+++ b/test/and.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('and', () => {
 
-  eq (S.show (S.and)) ('and :: Boolean -> Boolean -> Boolean');
+  eq (String (S.and)) ('and :: Boolean -> Boolean -> Boolean');
 
   eq (S.and (false) (false)) (false);
   eq (S.and (false) (true)) (false);

--- a/test/any.js
+++ b/test/any.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('any', () => {
 
-  eq (S.show (S.any)) ('any :: Foldable f => (a -> Boolean) -> f a -> Boolean');
+  eq (String (S.any)) ('any :: Foldable f => (a -> Boolean) -> f a -> Boolean');
 
   eq (S.any (S.gt (0)) ([])) (false);
   eq (S.any (S.gt (0)) ([0])) (false);

--- a/test/ap.js
+++ b/test/ap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('ap', () => {
 
-  eq (S.show (S.ap)) ('ap :: Apply f => f (a -> b) -> f a -> f b');
+  eq (String (S.ap)) ('ap :: Apply f => f (a -> b) -> f a -> f b');
 
   eq (S.ap ([]) ([])) ([]);
   eq (S.ap ([]) ([1, 2, 3])) ([]);

--- a/test/apFirst.js
+++ b/test/apFirst.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('apFirst', () => {
 
-  eq (S.show (S.apFirst)) ('apFirst :: Apply f => f a -> f b -> f a');
+  eq (String (S.apFirst)) ('apFirst :: Apply f => f a -> f b -> f a');
 
   eq (S.apFirst ([1, 2]) ([3, 4])) ([1, 1, 2, 2]);
   eq (S.apFirst (S.Just (1)) (S.Just (2))) (S.Just (1));

--- a/test/apSecond.js
+++ b/test/apSecond.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('apSecond', () => {
 
-  eq (S.show (S.apSecond)) ('apSecond :: Apply f => f a -> f b -> f b');
+  eq (String (S.apSecond)) ('apSecond :: Apply f => f a -> f b -> f b');
 
   eq (S.apSecond ([1, 2]) ([3, 4])) ([3, 4, 3, 4]);
   eq (S.apSecond (S.Just (1)) (S.Just (2))) (S.Just (2));

--- a/test/append.js
+++ b/test/append.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('append', () => {
 
-  eq (S.show (S.append)) ('append :: (Applicative f, Semigroup f) => a -> f a -> f a');
+  eq (String (S.append)) ('append :: (Applicative f, Semigroup f) => a -> f a -> f a');
 
   eq (S.append (3) ([])) ([3]);
   eq (S.append (3) ([1, 2])) ([1, 2, 3]);

--- a/test/array.js
+++ b/test/array.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('array', () => {
 
-  eq (S.show (S.array)) ('array :: b -> (a -> Array a -> b) -> Array a -> b');
+  eq (String (S.array)) ('array :: b -> (a -> Array a -> b) -> Array a -> b');
 
   const size = S.array (0) (head => tail => 1 + size (tail));
   eq (size ([])) (0);

--- a/test/bimap.js
+++ b/test/bimap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('bimap', () => {
 
-  eq (S.show (S.bimap)) ('bimap :: Bifunctor p => (a -> b) -> (c -> d) -> p a c -> p b d');
+  eq (String (S.bimap)) ('bimap :: Bifunctor p => (a -> b) -> (c -> d) -> p a c -> p b d');
 
   eq (S.bimap (S.toUpper) (S.add (1)) (S.Left ('xxx'))) (S.Left ('XXX'));
   eq (S.bimap (S.toUpper) (S.add (1)) (S.Right (1000))) (S.Right (1001));

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('boolean', () => {
 
-  eq (S.show (S.boolean)) ('boolean :: a -> a -> Boolean -> a');
+  eq (String (S.boolean)) ('boolean :: a -> a -> Boolean -> a');
 
   eq (S.boolean ('no') ('yes') (false)) ('no');
   eq (S.boolean ('no') ('yes') (true)) ('yes');

--- a/test/chain.js
+++ b/test/chain.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('chain', () => {
 
-  eq (S.show (S.chain)) ('chain :: Chain m => (a -> m b) -> m a -> m b');
+  eq (String (S.chain)) ('chain :: Chain m => (a -> m b) -> m a -> m b');
 
   eq (S.chain (S.I) ([[1, 2], [3, 4], [5, 6]])) ([1, 2, 3, 4, 5, 6]);
   eq (S.chain (S.parseFloat) (S.Nothing)) (S.Nothing);

--- a/test/chainRec.js
+++ b/test/chainRec.js
@@ -8,7 +8,7 @@ const map = require ('./internal/map');
 
 test ('chainRec', () => {
 
-  eq (S.show (S.chainRec)) ('chainRec :: ChainRec m => TypeRep (m b) -> (a -> m (Either a b)) -> a -> m b');
+  eq (String (S.chainRec)) ('chainRec :: ChainRec m => TypeRep (m b) -> (a -> m (Either a b)) -> a -> m b');
 
   eq (S.chainRec (Array)
                  (s => s.length === 2 ? map (S.Right) ([s + '!', s + '?'])

--- a/test/clamp.js
+++ b/test/clamp.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('clamp', () => {
 
-  eq (S.show (S.clamp)) ('clamp :: Ord a => a -> a -> a -> a');
+  eq (String (S.clamp)) ('clamp :: Ord a => a -> a -> a -> a');
 
   eq (S.clamp (0) (100) (-1)) (0);
   eq (S.clamp (0) (100) (0)) (0);

--- a/test/complement.js
+++ b/test/complement.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('complement', () => {
 
-  eq (S.show (S.complement)) ('complement :: (a -> Boolean) -> a -> Boolean');
+  eq (String (S.complement)) ('complement :: (a -> Boolean) -> a -> Boolean');
 
   eq (S.complement (S.odd) (1)) (false);
   eq (S.complement (S.odd) (2)) (true);

--- a/test/compose.js
+++ b/test/compose.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('compose', () => {
 
-  eq (S.show (S.compose)) ('compose :: Semigroupoid s => s b c -> s a b -> s a c');
+  eq (String (S.compose)) ('compose :: Semigroupoid s => s b c -> s a b -> s a c');
 
   eq (S.compose (S.mult (2)) (S.add (1)) (20)) (42);
 

--- a/test/concat.js
+++ b/test/concat.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('concat', () => {
 
-  eq (S.show (S.concat)) ('concat :: Semigroup a => a -> a -> a');
+  eq (String (S.concat)) ('concat :: Semigroup a => a -> a -> a');
 
   eq (S.concat ([]) ([])) ([]);
   eq (S.concat ([1, 2, 3]) ([])) ([1, 2, 3]);

--- a/test/contramap.js
+++ b/test/contramap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('contramap', () => {
 
-  eq (S.show (S.contramap)) ('contramap :: Contravariant f => (b -> a) -> f a -> f b');
+  eq (String (S.contramap)) ('contramap :: Contravariant f => (b -> a) -> f a -> f b');
 
   eq (S.contramap (S.prop ('length')) (Math.sqrt) ('Sanctuary')) (3);
 

--- a/test/create.js
+++ b/test/create.js
@@ -22,7 +22,7 @@ const uncheckedCustomEnv  = S.create ({checkTypes: false, env: customEnv});
 
 test ('create', () => {
 
-  eq (S.show (S.create)) ('create :: { checkTypes :: Boolean, env :: Array Any } -> Object');
+  eq (String (S.create)) ('create :: { checkTypes :: Boolean, env :: Array Any } -> Object');
 
   const expected = S.sort (Object.keys (S));
   eq (S.sort (Object.keys (checkedDefaultEnv))) (expected);

--- a/test/div.js
+++ b/test/div.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('div', () => {
 
-  eq (S.show (S.div)) ('div :: NonZeroFiniteNumber -> FiniteNumber -> FiniteNumber');
+  eq (String (S.div)) ('div :: NonZeroFiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.map (S.div (2)) ([0, 1, 2, 3])) ([0, 0.5, 1, 1.5]);
 

--- a/test/drop.js
+++ b/test/drop.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('drop', () => {
 
-  eq (S.show (S.drop)) ('drop :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
+  eq (String (S.drop)) ('drop :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.drop (0) ([1, 2, 3, 4, 5])) (S.Just ([1, 2, 3, 4, 5]));
   eq (S.drop (1) ([1, 2, 3, 4, 5])) (S.Just ([2, 3, 4, 5]));

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('dropLast', () => {
 
-  eq (S.show (S.dropLast)) ('dropLast :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
+  eq (String (S.dropLast)) ('dropLast :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.dropLast (0) ([1, 2, 3, 4, 5])) (S.Just ([1, 2, 3, 4, 5]));
   eq (S.dropLast (1) ([1, 2, 3, 4, 5])) (S.Just ([1, 2, 3, 4]));

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('dropWhile', () => {
 
-  eq (S.show (S.dropWhile)) ('dropWhile :: (a -> Boolean) -> Array a -> Array a');
+  eq (String (S.dropWhile)) ('dropWhile :: (a -> Boolean) -> Array a -> Array a');
 
   eq (S.dropWhile (S.odd) ([3, 3, 3, 7, 6, 3, 5, 4])) ([6, 3, 5, 4]);
   eq (S.dropWhile (S.even) ([3, 3, 3, 7, 6, 3, 5, 4])) ([3, 3, 3, 7, 6, 3, 5, 4]);

--- a/test/duplicate.js
+++ b/test/duplicate.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('duplicate', () => {
 
-  eq (S.show (S.duplicate)) ('duplicate :: Extend w => w a -> w (w a)');
+  eq (String (S.duplicate)) ('duplicate :: Extend w => w a -> w (w a)');
 
   eq (S.duplicate ([])) ([]);
   eq (S.duplicate ([1])) ([[1]]);

--- a/test/either.js
+++ b/test/either.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('either', () => {
 
-  eq (S.show (S.either)) ('either :: (a -> c) -> (b -> c) -> Either a b -> c');
+  eq (String (S.either)) ('either :: (a -> c) -> (b -> c) -> Either a b -> c');
 
   eq (S.either (S.prop ('length')) (Math.sqrt) (S.Left ('abc'))) (3);
   eq (S.either (S.prop ('length')) (Math.sqrt) (S.Right (256))) (16);

--- a/test/elem.js
+++ b/test/elem.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('elem', () => {
 
-  eq (S.show (S.elem)) ('elem :: (Setoid a, Foldable f) => a -> f a -> Boolean');
+  eq (String (S.elem)) ('elem :: (Setoid a, Foldable f) => a -> f a -> Boolean');
 
   eq (S.elem ('c') (['a', 'b', 'c'])) (true);
   eq (S.elem ('x') (['a', 'b', 'c'])) (false);

--- a/test/elem_.js
+++ b/test/elem_.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('elem_', () => {
 
-  eq (S.show (S.elem_)) ('elem_ :: (Setoid a, Foldable f) => f a -> a -> Boolean');
+  eq (String (S.elem_)) ('elem_ :: (Setoid a, Foldable f) => f a -> a -> Boolean');
 
   eq (S.elem_ (['a', 'b', 'c']) ('c')) (true);
   eq (S.elem_ (['a', 'b', 'c']) ('x')) (false);

--- a/test/empty.js
+++ b/test/empty.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('empty', () => {
 
-  eq (S.show (S.empty)) ('empty :: Monoid a => TypeRep a -> a');
+  eq (String (S.empty)) ('empty :: Monoid a => TypeRep a -> a');
 
   eq (S.empty (String)) ('');
   eq (S.empty (Array)) ([]);

--- a/test/encase.js
+++ b/test/encase.js
@@ -10,7 +10,7 @@ const rem = require ('./internal/rem');
 
 test ('encase', () => {
 
-  eq (S.show (S.encase)) ('encase :: (Throwing e a b) -> a -> Either e b');
+  eq (String (S.encase)) ('encase :: (Throwing e a b) -> a -> Either e b');
 
   //    safeFactorial :: Number -> Maybe Number
   const safeFactorial = S.encase (factorial);

--- a/test/equals.js
+++ b/test/equals.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('equals', () => {
 
-  eq (S.show (S.equals)) ('equals :: Setoid a => a -> a -> Boolean');
+  eq (String (S.equals)) ('equals :: Setoid a => a -> a -> Boolean');
 
   eq (S.equals (S.Nothing) (S.Nothing)) (true);
   eq (S.equals (S.Just (NaN)) (S.Just (NaN))) (true);

--- a/test/even.js
+++ b/test/even.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('even', () => {
 
-  eq (S.show (S.even)) ('even :: Integer -> Boolean');
+  eq (String (S.even)) ('even :: Integer -> Boolean');
 
   eq (S.even (0)) (true);
   eq (S.even (2)) (true);

--- a/test/extend.js
+++ b/test/extend.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('extend', () => {
 
-  eq (S.show (S.extend)) ('extend :: Extend w => (w a -> b) -> w a -> w b');
+  eq (String (S.extend)) ('extend :: Extend w => (w a -> b) -> w a -> w b');
 
   eq (S.extend (S.joinWith ('')) ([])) ([]);
   eq (S.extend (S.joinWith ('')) (['x'])) (['x']);

--- a/test/extract.js
+++ b/test/extract.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('extract', () => {
 
-  eq (S.show (S.extract)) ('extract :: Comonad w => w a -> a');
+  eq (String (S.extract)) ('extract :: Comonad w => w a -> a');
 
   eq (S.extract (Identity (42))) (42);
 

--- a/test/filter.js
+++ b/test/filter.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('filter', () => {
 
-  eq (S.show (S.filter)) ('filter :: Filterable f => (a -> Boolean) -> f a -> f a');
+  eq (String (S.filter)) ('filter :: Filterable f => (a -> Boolean) -> f a -> f a');
 
   eq (S.filter (S.odd) ([])) ([]);
   eq (S.filter (S.odd) ([0, 2, 4, 6, 8])) ([]);

--- a/test/find.js
+++ b/test/find.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('find', () => {
 
-  eq (S.show (S.find)) ('find :: Foldable f => (a -> Boolean) -> f a -> Maybe a');
+  eq (String (S.find)) ('find :: Foldable f => (a -> Boolean) -> f a -> Maybe a');
 
   eq (S.find (S.even) ([])) (S.Nothing);
   eq (S.find (S.even) ([1, 3, 5, 7, 9])) (S.Nothing);

--- a/test/findMap.js
+++ b/test/findMap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('findMap', () => {
 
-  eq (S.show (S.findMap)) ('findMap :: Foldable f => (a -> Maybe b) -> f a -> Maybe b');
+  eq (String (S.findMap)) ('findMap :: Foldable f => (a -> Maybe b) -> f a -> Maybe b');
 
   eq (S.findMap (S.parseInt (16)) ([])) (S.Nothing);
   eq (S.findMap (S.parseInt (16)) (['H', 'G'])) (S.Nothing);

--- a/test/flip.js
+++ b/test/flip.js
@@ -9,7 +9,7 @@ const map = require ('./internal/map');
 
 test ('flip', () => {
 
-  eq (S.show (S.flip)) ('flip :: Functor f => f (a -> b) -> a -> f b');
+  eq (String (S.flip)) ('flip :: Functor f => f (a -> b) -> a -> f b');
 
   eq (S.flip (S.concat) ('foo') ('bar')) ('barfoo');
   eq (map (S.flip (S.concat) ('!')) (['BAM', 'POW', 'KA-POW'])) (['BAM!', 'POW!', 'KA-POW!']);

--- a/test/foldMap.js
+++ b/test/foldMap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('foldMap', () => {
 
-  eq (S.show (S.foldMap)) ('foldMap :: (Monoid b, Foldable f) => TypeRep b -> (a -> b) -> f a -> b');
+  eq (String (S.foldMap)) ('foldMap :: (Monoid b, Foldable f) => TypeRep b -> (a -> b) -> f a -> b');
 
   const repeat = n => (new Array (n + 1)).join (String (n));
   eq (S.foldMap (String) (repeat) ([])) ('');

--- a/test/fromEither.js
+++ b/test/fromEither.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fromEither', () => {
 
-  eq (S.show (S.fromEither)) ('fromEither :: Either a a -> a');
+  eq (String (S.fromEither)) ('fromEither :: Either a a -> a');
 
   eq (S.fromEither (S.Left (42))) (42);
   eq (S.fromEither (S.Right (42))) (42);

--- a/test/fromLeft.js
+++ b/test/fromLeft.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fromLeft', () => {
 
-  eq (S.show (S.fromLeft)) ('fromLeft :: a -> Either a b -> a');
+  eq (String (S.fromLeft)) ('fromLeft :: a -> Either a b -> a');
 
   eq (S.fromLeft ('abc') (S.Left ('xyz'))) ('xyz');
   eq (S.fromLeft ('abc') (S.Right (123))) ('abc');

--- a/test/fromMaybe.js
+++ b/test/fromMaybe.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fromMaybe', () => {
 
-  eq (S.show (S.fromMaybe)) ('fromMaybe :: a -> Maybe a -> a');
+  eq (String (S.fromMaybe)) ('fromMaybe :: a -> Maybe a -> a');
 
   eq (S.fromMaybe (0) (S.Nothing)) (0);
   eq (S.fromMaybe (0) (S.Just (42))) (42);

--- a/test/fromMaybe_.js
+++ b/test/fromMaybe_.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fromMaybe_', () => {
 
-  eq (S.show (S.fromMaybe_)) ('fromMaybe_ :: (() -> a) -> Maybe a -> a');
+  eq (String (S.fromMaybe_)) ('fromMaybe_ :: (() -> a) -> Maybe a -> a');
 
   eq (S.fromMaybe_ (() => 0) (S.Nothing)) (0);
   eq (S.fromMaybe_ (() => 0) (S.Just (42))) (42);

--- a/test/fromPairs.js
+++ b/test/fromPairs.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fromPairs', () => {
 
-  eq (S.show (S.fromPairs)) ('fromPairs :: Foldable f => f (Pair String a) -> StrMap a');
+  eq (String (S.fromPairs)) ('fromPairs :: Foldable f => f (Pair String a) -> StrMap a');
 
   eq (S.fromPairs ([]))
      ({});

--- a/test/fromRight.js
+++ b/test/fromRight.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fromRight', () => {
 
-  eq (S.show (S.fromRight)) ('fromRight :: b -> Either a b -> b');
+  eq (String (S.fromRight)) ('fromRight :: b -> Either a b -> b');
 
   eq (S.fromRight (123) (S.Right (789))) (789);
   eq (S.fromRight (123) (S.Left ('abc'))) (123);

--- a/test/fst.js
+++ b/test/fst.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('fst', () => {
 
-  eq (S.show (S.fst)) ('fst :: Pair a b -> a');
+  eq (String (S.fst)) ('fst :: Pair a b -> a');
 
   eq (S.fst (S.Pair ('foo') (42))) ('foo');
 

--- a/test/get.js
+++ b/test/get.js
@@ -11,7 +11,7 @@ const eq = require ('./internal/eq');
 
 test ('get', () => {
 
-  eq (S.show (S.get)) ('get :: (Any -> Boolean) -> String -> a -> Maybe b');
+  eq (String (S.get)) ('get :: (Any -> Boolean) -> String -> a -> Maybe b');
 
   eq (S.get (S.is ($.Number)) ('x') ({x: 0, y: 42})) (S.Just (0));
   eq (S.get (S.is ($.Number)) ('y') ({x: 0, y: 42})) (S.Just (42));

--- a/test/gets.js
+++ b/test/gets.js
@@ -11,7 +11,7 @@ const eq = require ('./internal/eq');
 
 test ('gets', () => {
 
-  eq (S.show (S.gets)) ('gets :: (Any -> Boolean) -> Array String -> a -> Maybe b');
+  eq (String (S.gets)) ('gets :: (Any -> Boolean) -> Array String -> a -> Maybe b');
 
   eq (S.gets (S.is ($.Number)) (['x']) ({x: {z: 0}, y: 42})) (S.Nothing);
   eq (S.gets (S.is ($.Number)) (['y']) ({x: {z: 0}, y: 42})) (S.Just (42));

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('groupBy', () => {
 
-  eq (S.show (S.groupBy)) ('groupBy :: (a -> a -> Boolean) -> Array a -> Array (Array a)');
+  eq (String (S.groupBy)) ('groupBy :: (a -> a -> Boolean) -> Array a -> Array (Array a)');
 
   eq (S.groupBy (x => y => x * y % 3 === 0) ([])) ([]);
   eq (S.groupBy (x => y => x * y % 3 === 0) ([1, 2, 3, 4, 5, 6, 7, 8, 9])) ([[1], [2, 3], [4], [5, 6], [7], [8, 9]]);

--- a/test/gt.js
+++ b/test/gt.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('gt', () => {
 
-  eq (S.show (S.gt)) ('gt :: Ord a => a -> a -> Boolean');
+  eq (String (S.gt)) ('gt :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.gt (3)) ([1, 2, 3, 4, 5])) ([4, 5]);
 

--- a/test/gte.js
+++ b/test/gte.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('gte', () => {
 
-  eq (S.show (S.gte)) ('gte :: Ord a => a -> a -> Boolean');
+  eq (String (S.gte)) ('gte :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.gte (3)) ([1, 2, 3, 4, 5])) ([3, 4, 5]);
 

--- a/test/head.js
+++ b/test/head.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('head', () => {
 
-  eq (S.show (S.head)) ('head :: Foldable f => f a -> Maybe a');
+  eq (String (S.head)) ('head :: Foldable f => f a -> Maybe a');
 
   eq (S.head ([])) (S.Nothing);
   eq (S.head (['foo'])) (S.Just ('foo'));

--- a/test/id.js
+++ b/test/id.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('id', () => {
 
-  eq (S.show (S.id)) ('id :: Category c => TypeRep c -> c');
+  eq (String (S.id)) ('id :: Category c => TypeRep c -> c');
 
   eq (S.id (Function) (42)) (42);
 

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('ifElse', () => {
 
-  eq (S.show (S.ifElse)) ('ifElse :: (a -> Boolean) -> (a -> b) -> (a -> b) -> a -> b');
+  eq (String (S.ifElse)) ('ifElse :: (a -> Boolean) -> (a -> b) -> (a -> b) -> a -> b');
 
   eq (S.ifElse (S.odd) (S.sub (1)) (S.add (1)) (9)) (8);
   eq (S.ifElse (S.odd) (S.sub (1)) (S.add (1)) (0)) (1);

--- a/test/init.js
+++ b/test/init.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('init', () => {
 
-  eq (S.show (S.init)) ('init :: (Applicative f, Foldable f, Monoid f) => f a -> Maybe (f a)');
+  eq (String (S.init)) ('init :: (Applicative f, Foldable f, Monoid f) => f a -> Maybe (f a)');
 
   eq (S.init ([])) (S.Nothing);
   eq (S.init (['foo'])) (S.Just ([]));

--- a/test/insert.js
+++ b/test/insert.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('insert', () => {
 
-  eq (S.show (S.insert)) ('insert :: String -> a -> StrMap a -> StrMap a');
+  eq (String (S.insert)) ('insert :: String -> a -> StrMap a -> StrMap a');
 
   eq (S.insert ('a') (1) ({})) ({a: 1});
   eq (S.insert ('b') (2) ({a: 1})) ({a: 1, b: 2});

--- a/test/intercalate.js
+++ b/test/intercalate.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('intercalate', () => {
 
-  eq (S.show (S.intercalate)) ('intercalate :: (Monoid a, Foldable f) => a -> f a -> a');
+  eq (String (S.intercalate)) ('intercalate :: (Monoid a, Foldable f) => a -> f a -> a');
 
   eq (S.intercalate (', ') ([])) ('');
   eq (S.intercalate (', ') (['foo'])) ('foo');

--- a/test/invert.js
+++ b/test/invert.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('invert', () => {
 
-  eq (S.show (S.invert)) ('invert :: Group g => g -> g');
+  eq (String (S.invert)) ('invert :: Group g => g -> g');
 
   eq (S.invert (Sum (5))) (Sum (-5));
   eq (S.invert (Sum (-5))) (Sum (5));

--- a/test/is.js
+++ b/test/is.js
@@ -10,7 +10,7 @@ const eq = require ('./internal/eq');
 
 test ('is', () => {
 
-  eq (S.show (S.is)) ('is :: Type -> Any -> Boolean');
+  eq (String (S.is)) ('is :: Type -> Any -> Boolean');
 
   eq (S.is ($.Boolean) (true)) (true);
   eq (S.is ($.Boolean) (false)) (true);

--- a/test/isJust.js
+++ b/test/isJust.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('isJust', () => {
 
-  eq (S.show (S.isJust)) ('isJust :: Maybe a -> Boolean');
+  eq (String (S.isJust)) ('isJust :: Maybe a -> Boolean');
 
   eq (S.isJust (S.Nothing)) (false);
   eq (S.isJust (S.Just (42))) (true);

--- a/test/isLeft.js
+++ b/test/isLeft.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('isLeft', () => {
 
-  eq (S.show (S.isLeft)) ('isLeft :: Either a b -> Boolean');
+  eq (String (S.isLeft)) ('isLeft :: Either a b -> Boolean');
 
   eq (S.isLeft (S.Left (42))) (true);
   eq (S.isLeft (S.Right (42))) (false);

--- a/test/isNothing.js
+++ b/test/isNothing.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('isNothing', () => {
 
-  eq (S.show (S.isNothing)) ('isNothing :: Maybe a -> Boolean');
+  eq (String (S.isNothing)) ('isNothing :: Maybe a -> Boolean');
 
   eq (S.isNothing (S.Nothing)) (true);
   eq (S.isNothing (S.Just (42))) (false);

--- a/test/isRight.js
+++ b/test/isRight.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('isRight', () => {
 
-  eq (S.show (S.isRight)) ('isRight :: Either a b -> Boolean');
+  eq (String (S.isRight)) ('isRight :: Either a b -> Boolean');
 
   eq (S.isRight (S.Left (42))) (false);
   eq (S.isRight (S.Right (42))) (true);

--- a/test/join.js
+++ b/test/join.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('join', () => {
 
-  eq (S.show (S.join)) ('join :: Chain m => m (m a) -> m a');
+  eq (String (S.join)) ('join :: Chain m => m (m a) -> m a');
 
   eq (S.join ([])) ([]);
   eq (S.join ([[]])) ([]);

--- a/test/joinWith.js
+++ b/test/joinWith.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('joinWith', () => {
 
-  eq (S.show (S.joinWith)) ('joinWith :: String -> Array String -> String');
+  eq (String (S.joinWith)) ('joinWith :: String -> Array String -> String');
 
   eq (S.joinWith ('') (['a', 'b', 'c'])) ('abc');
   eq (S.joinWith (':') ([])) ('');

--- a/test/justs.js
+++ b/test/justs.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('justs', () => {
 
-  eq (S.show (S.justs)) ('justs :: (Filterable f, Functor f) => f (Maybe a) -> f a');
+  eq (String (S.justs)) ('justs :: (Filterable f, Functor f) => f (Maybe a) -> f a');
 
   eq (S.justs ([])) ([]);
   eq (S.justs ([S.Nothing, S.Nothing])) ([]);

--- a/test/keys.js
+++ b/test/keys.js
@@ -8,7 +8,7 @@ const strMap = require ('./internal/strMap');
 
 test ('keys', () => {
 
-  eq (S.show (S.keys)) ('keys :: StrMap a -> Array String');
+  eq (String (S.keys)) ('keys :: StrMap a -> Array String');
 
   eq (S.sort (S.keys ({}))) ([]);
   eq (S.sort (S.keys ({a: 1, b: 2, c: 3}))) (['a', 'b', 'c']);

--- a/test/last.js
+++ b/test/last.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('last', () => {
 
-  eq (S.show (S.last)) ('last :: Foldable f => f a -> Maybe a');
+  eq (String (S.last)) ('last :: Foldable f => f a -> Maybe a');
 
   eq (S.last ([])) (S.Nothing);
   eq (S.last (['foo'])) (S.Just ('foo'));

--- a/test/lefts.js
+++ b/test/lefts.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('lefts', () => {
 
-  eq (S.show (S.lefts)) ('lefts :: (Filterable f, Functor f) => f (Either a b) -> f a');
+  eq (String (S.lefts)) ('lefts :: (Filterable f, Functor f) => f (Either a b) -> f a');
 
   eq (S.lefts ([])) ([]);
   eq (S.lefts ([S.Right (2), S.Right (1)])) ([]);

--- a/test/lift2.js
+++ b/test/lift2.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('lift2', () => {
 
-  eq (S.show (S.lift2)) ('lift2 :: Apply f => (a -> b -> c) -> f a -> f b -> f c');
+  eq (String (S.lift2)) ('lift2 :: Apply f => (a -> b -> c) -> f a -> f b -> f c');
 
   eq (S.lift2 (S.add) (S.Just (3)) (S.Just (3))) (S.Just (6));
   eq (S.lift2 (S.add) (S.Nothing) (S.Just (3))) (S.Nothing);

--- a/test/lift3.js
+++ b/test/lift3.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('lift3', () => {
 
-  eq (S.show (S.lift3)) ('lift3 :: Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d');
+  eq (String (S.lift3)) ('lift3 :: Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d');
 
   eq (S.lift3 (S.reduce) (S.Just (S.add)) (S.Just (0)) (S.Just ([1, 2, 3]))) (S.Just (6));
   eq (S.lift3 (S.reduce) (S.Just (S.add)) (S.Just (0)) (S.Nothing)) (S.Nothing);

--- a/test/lines.js
+++ b/test/lines.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('lines', () => {
 
-  eq (S.show (S.lines)) ('lines :: String -> Array String');
+  eq (String (S.lines)) ('lines :: String -> Array String');
 
   eq (S.lines ('')) ([]);
   eq (S.lines ('\n')) (['']);

--- a/test/lt.js
+++ b/test/lt.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('lt', () => {
 
-  eq (S.show (S.lt)) ('lt :: Ord a => a -> a -> Boolean');
+  eq (String (S.lt)) ('lt :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.lt (3)) ([1, 2, 3, 4, 5])) ([1, 2]);
 

--- a/test/lte.js
+++ b/test/lte.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('lte', () => {
 
-  eq (S.show (S.lte)) ('lte :: Ord a => a -> a -> Boolean');
+  eq (String (S.lte)) ('lte :: Ord a => a -> a -> Boolean');
 
   eq (S.filter (S.lte (3)) ([1, 2, 3, 4, 5])) ([1, 2, 3]);
 

--- a/test/map.js
+++ b/test/map.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('map', () => {
 
-  eq (S.show (S.map)) ('map :: Functor f => (a -> b) -> f a -> f b');
+  eq (String (S.map)) ('map :: Functor f => (a -> b) -> f a -> f b');
 
   eq (S.map (S.not) (S.odd) (2)) (true);
   eq (S.map (S.not) (S.odd) (3)) (false);

--- a/test/mapLeft.js
+++ b/test/mapLeft.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('mapLeft', () => {
 
-  eq (S.show (S.mapLeft)) ('mapLeft :: Bifunctor p => (a -> b) -> p a c -> p b c');
+  eq (String (S.mapLeft)) ('mapLeft :: Bifunctor p => (a -> b) -> p a c -> p b c');
 
   eq (S.mapLeft (S.toUpper) (S.Left ('xxx'))) (S.Left ('XXX'));
   eq (S.mapLeft (S.toUpper) (S.Right (1000))) (S.Right (1000));

--- a/test/mapMaybe.js
+++ b/test/mapMaybe.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('mapMaybe', () => {
 
-  eq (S.show (S.mapMaybe)) ('mapMaybe :: (Filterable f, Functor f) => (a -> Maybe b) -> f a -> f b');
+  eq (String (S.mapMaybe)) ('mapMaybe :: (Filterable f, Functor f) => (a -> Maybe b) -> f a -> f b');
 
   eq (S.mapMaybe (S.head) ([])) ([]);
   eq (S.mapMaybe (S.head) ([[], [], []])) ([]);

--- a/test/match.js
+++ b/test/match.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('match', () => {
 
-  eq (S.show (S.match)) ('match :: NonGlobalRegExp -> String -> Maybe (Array (Maybe String))');
+  eq (String (S.match)) ('match :: NonGlobalRegExp -> String -> Maybe (Array (Maybe String))');
 
   const scheme = '([a-z][a-z0-9+.-]*)';
   const authentication = '(.*?):(.*?)@';

--- a/test/matchAll.js
+++ b/test/matchAll.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('matchAll', () => {
 
-  eq (S.show (S.matchAll)) ('matchAll :: GlobalRegExp -> String -> Array (Array (Maybe String))');
+  eq (String (S.matchAll)) ('matchAll :: GlobalRegExp -> String -> Array (Array (Maybe String))');
 
   const pattern = S.regex ('g') ('<(h[1-6])(?: id="([^"]*)")?>([^<]*)</\\1>');
 

--- a/test/max.js
+++ b/test/max.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('max', () => {
 
-  eq (S.show (S.max)) ('max :: Ord a => a -> a -> a');
+  eq (String (S.max)) ('max :: Ord a => a -> a -> a');
 
   eq (S.max (10) (2)) (10);
   eq (S.max (2) (10)) (10);

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('maybe', () => {
 
-  eq (S.show (S.maybe)) ('maybe :: b -> (a -> b) -> Maybe a -> b');
+  eq (String (S.maybe)) ('maybe :: b -> (a -> b) -> Maybe a -> b');
 
   eq (S.maybe (0) (Math.sqrt) (S.Nothing)) (0);
   eq (S.maybe (0) (Math.sqrt) (S.Just (9))) (3);

--- a/test/maybeToNullable.js
+++ b/test/maybeToNullable.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('maybeToNullable', () => {
 
-  eq (S.show (S.maybeToNullable)) ('maybeToNullable :: Maybe a -> Nullable a');
+  eq (String (S.maybeToNullable)) ('maybeToNullable :: Maybe a -> Nullable a');
 
   eq (S.maybeToNullable (S.Nothing)) (null);
   eq (S.maybeToNullable (S.Just (42))) (42);

--- a/test/maybe_.js
+++ b/test/maybe_.js
@@ -8,7 +8,7 @@ const factorial = require ('./internal/factorial');
 
 test ('maybe_', () => {
 
-  eq (S.show (S.maybe_)) ('maybe_ :: (() -> b) -> (a -> b) -> Maybe a -> b');
+  eq (String (S.maybe_)) ('maybe_ :: (() -> b) -> (a -> b) -> Maybe a -> b');
 
   eq (S.maybe_ (() => factorial (10)) (Math.sqrt) (S.Nothing)) (3628800);
   eq (S.maybe_ (() => factorial (10)) (Math.sqrt) (S.Just (9))) (3);

--- a/test/min.js
+++ b/test/min.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('min', () => {
 
-  eq (S.show (S.min)) ('min :: Ord a => a -> a -> a');
+  eq (String (S.min)) ('min :: Ord a => a -> a -> a');
 
   eq (S.min (10) (2)) (2);
   eq (S.min (2) (10)) (2);

--- a/test/mult.js
+++ b/test/mult.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('mult', () => {
 
-  eq (S.show (S.mult)) ('mult :: FiniteNumber -> FiniteNumber -> FiniteNumber');
+  eq (String (S.mult)) ('mult :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.mult (4) (2)) (8);
   eq (S.mult (4) (-2)) (-8);

--- a/test/negate.js
+++ b/test/negate.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('negate', () => {
 
-  eq (S.show (S.negate)) ('negate :: ValidNumber -> ValidNumber');
+  eq (String (S.negate)) ('negate :: ValidNumber -> ValidNumber');
 
   eq (S.negate (0.5)) (-0.5);
   eq (S.negate (-0.5)) (0.5);

--- a/test/none.js
+++ b/test/none.js
@@ -11,7 +11,7 @@ const equals = require ('./internal/equals');
 
 test ('none', () => {
 
-  eq (S.show (S.none)) ('none :: Foldable f => (a -> Boolean) -> f a -> Boolean');
+  eq (String (S.none)) ('none :: Foldable f => (a -> Boolean) -> f a -> Boolean');
 
   eq (S.none (S.gt (0)) ([])) (true);
   eq (S.none (S.gt (0)) ([0])) (true);

--- a/test/not.js
+++ b/test/not.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('not', () => {
 
-  eq (S.show (S.not)) ('not :: Boolean -> Boolean');
+  eq (String (S.not)) ('not :: Boolean -> Boolean');
 
   eq (S.not (false)) (true);
   eq (S.not (true)) (false);

--- a/test/odd.js
+++ b/test/odd.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('odd', () => {
 
-  eq (S.show (S.odd)) ('odd :: Integer -> Boolean');
+  eq (String (S.odd)) ('odd :: Integer -> Boolean');
 
   eq (S.odd (1)) (true);
   eq (S.odd (-1)) (true);

--- a/test/of.js
+++ b/test/of.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('of', () => {
 
-  eq (S.show (S.of)) ('of :: Applicative f => TypeRep (f a) -> a -> f a');
+  eq (String (S.of)) ('of :: Applicative f => TypeRep (f a) -> a -> f a');
 
   eq (S.of (Array) (42)) ([42]);
   eq (S.of (Function) (42) (null)) (42);

--- a/test/on.js
+++ b/test/on.js
@@ -8,7 +8,7 @@ const rem = require ('./internal/rem');
 
 test ('on', () => {
 
-  eq (S.show (S.on)) ('on :: (b -> b -> c) -> (a -> b) -> a -> a -> c');
+  eq (String (S.on)) ('on :: (b -> b -> c) -> (a -> b) -> a -> a -> c');
 
   eq (S.on (rem) (S.prop ('x')) ({x: 5, y: 5}) ({x: 3, y: 3})) (2);
   eq (S.on (S.concat) (S.reverse) ([1, 2, 3]) ([4, 5, 6])) ([3, 2, 1, 6, 5, 4]);

--- a/test/or.js
+++ b/test/or.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('or', () => {
 
-  eq (S.show (S.or)) ('or :: Boolean -> Boolean -> Boolean');
+  eq (String (S.or)) ('or :: Boolean -> Boolean -> Boolean');
 
   eq (S.or (false) (false)) (false);
   eq (S.or (false) (true)) (true);

--- a/test/pairs.js
+++ b/test/pairs.js
@@ -8,7 +8,7 @@ const strMap = require ('./internal/strMap');
 
 test ('pairs', () => {
 
-  eq (S.show (S.pairs)) ('pairs :: StrMap a -> Array (Pair String a)');
+  eq (String (S.pairs)) ('pairs :: StrMap a -> Array (Pair String a)');
 
   eq (S.sort (S.pairs ({}))) ([]);
   eq (S.sort (S.pairs ({a: 1, b: 2, c: 3}))) ([S.Pair ('a') (1), S.Pair ('b') (2), S.Pair ('c') (3)]);

--- a/test/pair~.js
+++ b/test/pair~.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('pair', () => {
 
-  eq (S.show (S.pair)) ('pair :: (a -> b -> c) -> Pair a b -> c');
+  eq (String (S.pair)) ('pair :: (a -> b -> c) -> Pair a b -> c');
 
   eq (S.pair (S.concat) (S.Pair ('foo') ('bar'))) ('foobar');
 

--- a/test/parseDate.js
+++ b/test/parseDate.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('parseDate', () => {
 
-  eq (S.show (S.parseDate)) ('parseDate :: String -> Maybe ValidDate');
+  eq (String (S.parseDate)) ('parseDate :: String -> Maybe ValidDate');
 
   eq (S.parseDate ('2001-02-03T04:05:06Z')) (S.Just (new Date ('2001-02-03T04:05:06Z')));
   eq (S.parseDate ('today')) (S.Nothing);

--- a/test/parseFloat.js
+++ b/test/parseFloat.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('parseFloat', () => {
 
-  eq (S.show (S.parseFloat)) ('parseFloat :: String -> Maybe Number');
+  eq (String (S.parseFloat)) ('parseFloat :: String -> Maybe Number');
 
   eq (S.parseFloat ('12.34')) (S.Just (12.34));
   eq (S.parseFloat ('Infinity')) (S.Just (Infinity));

--- a/test/parseInt.js
+++ b/test/parseInt.js
@@ -8,7 +8,7 @@ const throws = require ('./internal/throws');
 
 test ('parseInt', () => {
 
-  eq (S.show (S.parseInt)) ('parseInt :: Radix -> String -> Maybe Integer');
+  eq (String (S.parseInt)) ('parseInt :: Radix -> String -> Maybe Integer');
 
   eq (S.parseInt (10) ('42')) (S.Just (42));
   eq (S.parseInt (16) ('2A')) (S.Just (42));

--- a/test/parseJson.js
+++ b/test/parseJson.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('parseJson', () => {
 
-  eq (S.show (S.parseJson)) ('parseJson :: (Any -> Boolean) -> String -> Maybe a');
+  eq (String (S.parseJson)) ('parseJson :: (Any -> Boolean) -> String -> Maybe a');
 
   eq (S.parseJson (S.is ($.Any)) ('[Invalid JSON]')) (S.Nothing);
   eq (S.parseJson (S.is ($.Array ($.Any))) ('{"foo":"bar"}')) (S.Nothing);

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('pipe', () => {
 
-  eq (S.show (S.pipe)) ('pipe :: Foldable f => f (Any -> Any) -> a -> b');
+  eq (String (S.pipe)) ('pipe :: Foldable f => f (Any -> Any) -> a -> b');
 
   eq (S.pipe ([]) ('99')) ('99');
   eq (S.pipe ([parseInt]) ('99')) (99);

--- a/test/pipeK.js
+++ b/test/pipeK.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('pipeK', () => {
 
-  eq (S.show (S.pipeK)) ('pipeK :: (Foldable f, Chain m) => f (Any -> m Any) -> m a -> m b');
+  eq (String (S.pipeK)) ('pipeK :: (Foldable f, Chain m) => f (Any -> m Any) -> m a -> m b');
 
   eq (S.pipeK ([]) (S.Just ([1, 2, 3]))) (S.Just ([1, 2, 3]));
   eq (S.pipeK ([S.tail]) (S.Just ([1, 2, 3]))) (S.Just ([2, 3]));

--- a/test/pow.js
+++ b/test/pow.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('pow', () => {
 
-  eq (S.show (S.pow)) ('pow :: FiniteNumber -> FiniteNumber -> FiniteNumber');
+  eq (String (S.pow)) ('pow :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.pow (2) (8)) (64);
   eq (S.map (S.pow (2)) ([-3, -2, -1, 0, 1, 2, 3])) ([9, 4, 1, 0, 1, 4, 9]);

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('prepend', () => {
 
-  eq (S.show (S.prepend)) ('prepend :: (Applicative f, Semigroup f) => a -> f a -> f a');
+  eq (String (S.prepend)) ('prepend :: (Applicative f, Semigroup f) => a -> f a -> f a');
 
   eq (S.prepend (1) ([])) ([1]);
   eq (S.prepend (1) ([2, 3])) ([1, 2, 3]);

--- a/test/product.js
+++ b/test/product.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('product', () => {
 
-  eq (S.show (S.product)) ('product :: Foldable f => f FiniteNumber -> FiniteNumber');
+  eq (String (S.product)) ('product :: Foldable f => f FiniteNumber -> FiniteNumber');
 
   eq (S.product ([])) (1);
   eq (S.product ([0, 1, 2, 3])) (0);

--- a/test/promap.js
+++ b/test/promap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('promap', () => {
 
-  eq (S.show (S.promap)) ('promap :: Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d');
+  eq (String (S.promap)) ('promap :: Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d');
 
   const before = S.map (S.prop ('length'));
   const after = S.join (S.mult);

--- a/test/prop.js
+++ b/test/prop.js
@@ -8,7 +8,7 @@ const throws = require ('./internal/throws');
 
 test ('prop', () => {
 
-  eq (S.show (S.prop)) ('prop :: String -> a -> b');
+  eq (String (S.prop)) ('prop :: String -> a -> b');
 
   throws (() => { S.prop ('xxx') ([1, 2, 3]); })
          (new TypeError ('‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not'));

--- a/test/props.js
+++ b/test/props.js
@@ -8,7 +8,7 @@ const throws = require ('./internal/throws');
 
 test ('props', () => {
 
-  eq (S.show (S.props)) ('props :: Array String -> a -> b');
+  eq (String (S.props)) ('props :: Array String -> a -> b');
 
   throws (() => { S.props (['a', 'b', 'c']) ([1, 2, 3]); })
          (new TypeError ('‘props’ expected object to have a property at ["a", "b", "c"]; [1, 2, 3] does not'));

--- a/test/range.js
+++ b/test/range.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('range', () => {
 
-  eq (S.show (S.range)) ('range :: Integer -> Integer -> Array Integer');
+  eq (String (S.range)) ('range :: Integer -> Integer -> Array Integer');
 
   eq (S.range (0) (0)) ([]);
   eq (S.range (0) (10)) ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('reduce', () => {
 
-  eq (S.show (S.reduce)) ('reduce :: Foldable f => (b -> a -> b) -> b -> f a -> b');
+  eq (String (S.reduce)) ('reduce :: Foldable f => (b -> a -> b) -> b -> f a -> b');
 
   eq (S.reduce (S.concat) ('x') ([])) ('x');
   eq (S.reduce (S.concat) ('x') (['A', 'B', 'C'])) ('xABC');

--- a/test/reduce_.js
+++ b/test/reduce_.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('reduce_', () => {
 
-  eq (S.show (S.reduce_)) ('reduce_ :: Foldable f => (a -> b -> b) -> b -> f a -> b');
+  eq (String (S.reduce_)) ('reduce_ :: Foldable f => (a -> b -> b) -> b -> f a -> b');
 
   eq (S.reduce_ (S.append) ([]) ([])) ([]);
   eq (S.reduce_ (S.append) ([]) ([1, 2, 3])) ([1, 2, 3]);

--- a/test/regex.js
+++ b/test/regex.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('regex', () => {
 
-  eq (S.show (S.regex)) ('regex :: RegexFlags -> String -> RegExp');
+  eq (String (S.regex)) ('regex :: RegexFlags -> String -> RegExp');
 
   eq (S.regex ('') ('\\d')) (/\d/);
   eq (S.regex ('g') ('\\d')) (/\d/g);

--- a/test/regexEscape.js
+++ b/test/regexEscape.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('regexEscape', () => {
 
-  eq (S.show (S.regexEscape)) ('regexEscape :: String -> String');
+  eq (String (S.regexEscape)) ('regexEscape :: String -> String');
 
   eq (S.regexEscape ('-=*{XYZ}*=-')) ('\\-=\\*\\{XYZ\\}\\*=\\-');
 

--- a/test/reject.js
+++ b/test/reject.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('reject', () => {
 
-  eq (S.show (S.reject)) ('reject :: Filterable f => (a -> Boolean) -> f a -> f a');
+  eq (String (S.reject)) ('reject :: Filterable f => (a -> Boolean) -> f a -> f a');
 
   eq (S.reject (S.odd) ([])) ([]);
   eq (S.reject (S.odd) ([0, 2, 4, 6, 8])) ([0, 2, 4, 6, 8]);

--- a/test/remove.js
+++ b/test/remove.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('remove', () => {
 
-  eq (S.show (S.remove)) ('remove :: String -> StrMap a -> StrMap a');
+  eq (String (S.remove)) ('remove :: String -> StrMap a -> StrMap a');
 
   eq (S.remove ('a') ({})) ({});
   eq (S.remove ('b') ({a: 1})) ({a: 1});

--- a/test/replace.js
+++ b/test/replace.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('replace', () => {
 
-  eq (S.show (S.replace)) ('replace :: (Array (Maybe String) -> String) -> RegExp -> String -> String');
+  eq (String (S.replace)) ('replace :: (Array (Maybe String) -> String) -> RegExp -> String -> String');
 
   eq (S.replace (([$1]) => S.maybe ('') (S.toUpper) ($1)) (/(\w)/) ('foo')) ('Foo');
   eq (S.replace (([$1]) => S.maybe ('') (S.toUpper) ($1)) (/(\w)/g) ('foo')) ('FOO');

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('reverse', () => {
 
-  eq (S.show (S.reverse)) ('reverse :: (Applicative f, Foldable f, Monoid f) => f a -> f a');
+  eq (String (S.reverse)) ('reverse :: (Applicative f, Foldable f, Monoid f) => f a -> f a');
 
   eq (S.reverse ([])) ([]);
   eq (S.reverse ([1])) ([1]);

--- a/test/rights.js
+++ b/test/rights.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('rights', () => {
 
-  eq (S.show (S.rights)) ('rights :: (Filterable f, Functor f) => f (Either a b) -> f b');
+  eq (String (S.rights)) ('rights :: (Filterable f, Functor f) => f (Either a b) -> f b');
 
   eq (S.rights ([])) ([]);
   eq (S.rights ([S.Left ('a'), S.Left ('b')])) ([]);

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('sequence', () => {
 
-  eq (S.show (S.sequence)) ('sequence :: (Applicative f, Traversable t) => TypeRep (f a) -> t (f a) -> f (t a)');
+  eq (String (S.sequence)) ('sequence :: (Applicative f, Traversable t) => TypeRep (f a) -> t (f a) -> f (t a)');
 
   eq (S.sequence (Identity) ([])) (Identity ([]));
   eq (S.sequence (Identity) ([Identity (1), Identity (2), Identity (3)])) (Identity ([1, 2, 3]));

--- a/test/show.js
+++ b/test/show.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('show', () => {
 
-  eq (S.show (S.show)) ('show :: Any -> String');
+  eq (String (S.show)) ('show :: Any -> String');
 
   eq (S.show (null)) ('null');
   eq (S.show (undefined)) ('undefined');

--- a/test/singleton.js
+++ b/test/singleton.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('singleton', () => {
 
-  eq (S.show (S.singleton)) ('singleton :: String -> a -> StrMap a');
+  eq (String (S.singleton)) ('singleton :: String -> a -> StrMap a');
 
   eq (S.singleton ('foo') (42)) ({foo: 42});
 

--- a/test/size.js
+++ b/test/size.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('size', () => {
 
-  eq (S.show (S.size)) ('size :: Foldable f => f a -> NonNegativeInteger');
+  eq (String (S.size)) ('size :: Foldable f => f a -> NonNegativeInteger');
 
   eq (S.size ([])) (0);
   eq (S.size (['foo'])) (1);

--- a/test/snd.js
+++ b/test/snd.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('snd', () => {
 
-  eq (S.show (S.snd)) ('snd :: Pair a b -> b');
+  eq (String (S.snd)) ('snd :: Pair a b -> b');
 
   eq (S.snd (S.Pair ('foo') (42))) (42);
 

--- a/test/sort.js
+++ b/test/sort.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('sort', () => {
 
-  eq (S.show (S.sort)) ('sort :: (Ord a, Applicative m, Foldable m, Monoid m) => m a -> m a');
+  eq (String (S.sort)) ('sort :: (Ord a, Applicative m, Foldable m, Monoid m) => m a -> m a');
 
   eq (S.sort ([])) ([]);
   eq (S.sort (['foo', 'bar', 'baz'])) (['bar', 'baz', 'foo']);

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('sortBy', () => {
 
-  eq (S.show (S.sortBy)) ('sortBy :: (Ord b, Applicative m, Foldable m, Monoid m) => (a -> b) -> m a -> m a');
+  eq (String (S.sortBy)) ('sortBy :: (Ord b, Applicative m, Foldable m, Monoid m) => (a -> b) -> m a -> m a');
 
   eq (S.sortBy (S.I) ([])) ([]);
   eq (S.sortBy (S.I) (['five'])) (['five']);

--- a/test/splitOn.js
+++ b/test/splitOn.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('splitOn', () => {
 
-  eq (S.show (S.splitOn)) ('splitOn :: String -> String -> Array String');
+  eq (String (S.splitOn)) ('splitOn :: String -> String -> Array String');
 
   eq (S.splitOn ('') ('abc')) (['a', 'b', 'c']);
   eq (S.splitOn (':') ('')) (['']);

--- a/test/splitOnRegex.js
+++ b/test/splitOnRegex.js
@@ -10,7 +10,7 @@ const equals = require ('./internal/equals');
 
 test ('splitOnRegex', () => {
 
-  eq (S.show (S.splitOnRegex)) ('splitOnRegex :: GlobalRegExp -> String -> Array String');
+  eq (String (S.splitOnRegex)) ('splitOnRegex :: GlobalRegExp -> String -> Array String');
 
   eq (S.splitOnRegex (/b/g) ('abc')) (['a', 'c']);
   eq (S.splitOnRegex (/d/g) ('abc')) (['abc']);

--- a/test/stripPrefix.js
+++ b/test/stripPrefix.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('stripPrefix', () => {
 
-  eq (S.show (S.stripPrefix)) ('stripPrefix :: String -> String -> Maybe String');
+  eq (String (S.stripPrefix)) ('stripPrefix :: String -> String -> Maybe String');
 
   eq (S.stripPrefix ('') ('')) (S.Just (''));
   eq (S.stripPrefix ('') ('abc')) (S.Just ('abc'));

--- a/test/stripSuffix.js
+++ b/test/stripSuffix.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('stripSuffix', () => {
 
-  eq (S.show (S.stripSuffix)) ('stripSuffix :: String -> String -> Maybe String');
+  eq (String (S.stripSuffix)) ('stripSuffix :: String -> String -> Maybe String');
 
   eq (S.stripSuffix ('') ('')) (S.Just (''));
   eq (S.stripSuffix ('') ('xyz')) (S.Just ('xyz'));

--- a/test/sub.js
+++ b/test/sub.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('sub', () => {
 
-  eq (S.show (S.sub)) ('sub :: FiniteNumber -> FiniteNumber -> FiniteNumber');
+  eq (String (S.sub)) ('sub :: FiniteNumber -> FiniteNumber -> FiniteNumber');
 
   eq (S.map (S.sub (1)) ([1, 2, 3])) ([0, 1, 2]);
 

--- a/test/sum.js
+++ b/test/sum.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('sum', () => {
 
-  eq (S.show (S.sum)) ('sum :: Foldable f => f FiniteNumber -> FiniteNumber');
+  eq (String (S.sum)) ('sum :: Foldable f => f FiniteNumber -> FiniteNumber');
 
   eq (S.sum ([])) (0);
   eq (S.sum ([0, 1, 2, 3])) (6);

--- a/test/swap.js
+++ b/test/swap.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('swap', () => {
 
-  eq (S.show (S.swap)) ('swap :: Pair a b -> Pair b a');
+  eq (String (S.swap)) ('swap :: Pair a b -> Pair b a');
 
   eq (S.swap (S.Pair ('foo') (42))) (S.Pair (42) ('foo'));
 

--- a/test/tagBy.js
+++ b/test/tagBy.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('tagBy', () => {
 
-  eq (S.show (S.tagBy)) ('tagBy :: (a -> Boolean) -> a -> Either a a');
+  eq (String (S.tagBy)) ('tagBy :: (a -> Boolean) -> a -> Either a a');
 
   eq (S.tagBy (S.odd) (5)) (S.Right (5));
   eq (S.tagBy (S.odd) (6)) (S.Left (6));

--- a/test/tail.js
+++ b/test/tail.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('tail', () => {
 
-  eq (S.show (S.tail)) ('tail :: (Applicative f, Foldable f, Monoid f) => f a -> Maybe (f a)');
+  eq (String (S.tail)) ('tail :: (Applicative f, Foldable f, Monoid f) => f a -> Maybe (f a)');
 
   eq (S.tail ([])) (S.Nothing);
   eq (S.tail (['foo'])) (S.Just ([]));

--- a/test/take.js
+++ b/test/take.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('take', () => {
 
-  eq (S.show (S.take)) ('take :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
+  eq (String (S.take)) ('take :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.take (0) ([1, 2, 3, 4, 5])) (S.Just ([]));
   eq (S.take (1) ([1, 2, 3, 4, 5])) (S.Just ([1]));

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -8,7 +8,7 @@ const eq = require ('./internal/eq');
 
 test ('takeLast', () => {
 
-  eq (S.show (S.takeLast)) ('takeLast :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
+  eq (String (S.takeLast)) ('takeLast :: (Applicative f, Foldable f, Monoid f) => Integer -> f a -> Maybe (f a)');
 
   eq (S.takeLast (0) ([1, 2, 3, 4, 5])) (S.Just ([]));
   eq (S.takeLast (1) ([1, 2, 3, 4, 5])) (S.Just ([5]));

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('takeWhile', () => {
 
-  eq (S.show (S.takeWhile)) ('takeWhile :: (a -> Boolean) -> Array a -> Array a');
+  eq (String (S.takeWhile)) ('takeWhile :: (a -> Boolean) -> Array a -> Array a');
 
   eq (S.takeWhile (S.odd) ([3, 3, 3, 7, 6, 3, 5, 4])) ([3, 3, 3, 7]);
   eq (S.takeWhile (S.even) ([3, 3, 3, 7, 6, 3, 5, 4])) ([]);

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('test', () => {
 
-  eq (S.show (S.test)) ('test :: RegExp -> String -> Boolean');
+  eq (String (S.test)) ('test :: RegExp -> String -> Boolean');
 
   eq (S.test (/^a/) ('abacus')) (true);
   eq (S.test (/^a/) ('banana')) (false);

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('toLower', () => {
 
-  eq (S.show (S.toLower)) ('toLower :: String -> String');
+  eq (String (S.toLower)) ('toLower :: String -> String');
 
   eq (S.toLower ('')) ('');
   eq (S.toLower ('ABC def 123')) ('abc def 123');

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('toUpper', () => {
 
-  eq (S.show (S.toUpper)) ('toUpper :: String -> String');
+  eq (String (S.toUpper)) ('toUpper :: String -> String');
 
   eq (S.toUpper ('')) ('');
   eq (S.toUpper ('ABC def 123')) ('ABC DEF 123');

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('traverse', () => {
 
-  eq (S.show (S.traverse)) ('traverse :: (Applicative f, Traversable t) => TypeRep (f b) -> (a -> f b) -> t a -> f (t b)');
+  eq (String (S.traverse)) ('traverse :: (Applicative f, Traversable t) => TypeRep (f b) -> (a -> f b) -> t a -> f (t b)');
 
   eq (S.traverse (S.Maybe) (S.parseInt (16)) (['A', 'B', 'C'])) (S.Just ([10, 11, 12]));
   eq (S.traverse (S.Maybe) (S.parseInt (16)) (['A', 'B', 'C', 'X'])) (S.Nothing);

--- a/test/trim.js
+++ b/test/trim.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('trim', () => {
 
-  eq (S.show (S.trim)) ('trim :: String -> String');
+  eq (String (S.trim)) ('trim :: String -> String');
 
   eq (S.trim ('')) ('');
   eq (S.trim (' ')) ('');

--- a/test/type.js
+++ b/test/type.js
@@ -9,7 +9,7 @@ const eq = require ('./internal/eq');
 
 test ('type', () => {
 
-  eq (S.show (S.type)) ('type :: Any -> { name :: String, namespace :: Maybe String, version :: NonNegativeInteger }');
+  eq (String (S.type)) ('type :: Any -> { name :: String, namespace :: Maybe String, version :: NonNegativeInteger }');
 
   // eslint-disable-next-line prefer-rest-params
   eq (S.type (function() { return arguments; } ()))

--- a/test/unfold.js
+++ b/test/unfold.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('unfold', () => {
 
-  eq (S.show (S.unfold)) ('unfold :: (b -> Maybe (Pair a b)) -> b -> Array a');
+  eq (String (S.unfold)) ('unfold :: (b -> Maybe (Pair a b)) -> b -> Array a');
 
   const f = n => n >= 5 ? S.Nothing : S.Just (S.Pair (n) (n + 1));
   eq (S.unfold (f) (5)) ([]);

--- a/test/unless.js
+++ b/test/unless.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('unless', () => {
 
-  eq (S.show (S.unless)) ('unless :: (a -> Boolean) -> (a -> a) -> a -> a');
+  eq (String (S.unless)) ('unless :: (a -> Boolean) -> (a -> a) -> a -> a');
 
   eq (S.unless (S.lt (0)) (Math.sqrt) (16)) (4);
   eq (S.unless (S.lt (0)) (Math.sqrt) (-1)) (-1);

--- a/test/unlines.js
+++ b/test/unlines.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('unlines', () => {
 
-  eq (S.show (S.unlines)) ('unlines :: Array String -> String');
+  eq (String (S.unlines)) ('unlines :: Array String -> String');
 
   eq (S.unlines ([])) ('');
   eq (S.unlines ([''])) ('\n');

--- a/test/unwords.js
+++ b/test/unwords.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('unwords', () => {
 
-  eq (S.show (S.unwords)) ('unwords :: Array String -> String');
+  eq (String (S.unwords)) ('unwords :: Array String -> String');
 
   eq (S.unwords ([])) ('');
   eq (S.unwords ([''])) ('');

--- a/test/value.js
+++ b/test/value.js
@@ -8,7 +8,7 @@ const strMap = require ('./internal/strMap');
 
 test ('value', () => {
 
-  eq (S.show (S.value)) ('value :: String -> StrMap a -> Maybe a');
+  eq (String (S.value)) ('value :: String -> StrMap a -> Maybe a');
 
   eq (S.value ('foo') ({foo: 1, bar: 2})) (S.Just (1));
   eq (S.value ('bar') ({foo: 1, bar: 2})) (S.Just (2));

--- a/test/values.js
+++ b/test/values.js
@@ -8,7 +8,7 @@ const strMap = require ('./internal/strMap');
 
 test ('values', () => {
 
-  eq (S.show (S.values)) ('values :: StrMap a -> Array a');
+  eq (String (S.values)) ('values :: StrMap a -> Array a');
 
   eq (S.sort (S.values ({}))) ([]);
   eq (S.sort (S.values ({a: 1, b: 2, c: 3}))) ([1, 2, 3]);

--- a/test/when.js
+++ b/test/when.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('when', () => {
 
-  eq (S.show (S.when)) ('when :: (a -> Boolean) -> (a -> a) -> a -> a');
+  eq (String (S.when)) ('when :: (a -> Boolean) -> (a -> a) -> a -> a');
 
   eq (S.when (S.gte (0)) (Math.sqrt) (16)) (4);
   eq (S.when (S.gte (0)) (Math.sqrt) (-1)) (-1);

--- a/test/words.js
+++ b/test/words.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('words', () => {
 
-  eq (S.show (S.words)) ('words :: String -> Array String');
+  eq (String (S.words)) ('words :: String -> Array String');
 
   eq (S.words ('')) ([]);
   eq (S.words (' ')) ([]);

--- a/test/zero.js
+++ b/test/zero.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('zero', () => {
 
-  eq (S.show (S.zero)) ('zero :: Plus f => TypeRep (f a) -> f a');
+  eq (String (S.zero)) ('zero :: Plus f => TypeRep (f a) -> f a');
 
   eq (S.zero (Array)) ([]);
   eq (S.zero (Object)) ({});

--- a/test/zip.js
+++ b/test/zip.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('zip', () => {
 
-  eq (S.show (S.zip)) ('zip :: Array a -> Array b -> Array (Pair a b)');
+  eq (String (S.zip)) ('zip :: Array a -> Array b -> Array (Pair a b)');
 
   eq (S.zip (['a', 'b']) (['x', 'y', 'z']))
      ([S.Pair ('a') ('x'), S.Pair ('b') ('y')]);

--- a/test/zipWith.js
+++ b/test/zipWith.js
@@ -7,7 +7,7 @@ const eq = require ('./internal/eq');
 
 test ('zipWith', () => {
 
-  eq (S.show (S.zipWith)) ('zipWith :: (a -> b -> c) -> Array a -> Array b -> Array c');
+  eq (String (S.zipWith)) ('zipWith :: (a -> b -> c) -> Array a -> Array b -> Array c');
 
   eq (S.zipWith (x => y => x + y) (['a', 'b']) (['x', 'y', 'z'])) (['ax', 'by']);
   eq (S.zipWith (x => y => [x, y]) ([1, 3, 5]) ([2, 4])) ([[1, 2], [3, 4]]);


### PR DESCRIPTION
Currently, when `S.show` is applied to a function it just invokes the function's `toString` method. This is no longer the case for `show` as a result of sanctuary-js/sanctuary-show#15. This pull request switches to `String` for testing type signatures, paving the way for upgrading the sanctuary-show dependency.
