### PR TITLE
remove test/internal/equals module

### DIFF
--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('..');
 
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('groupBy', () => {
@@ -14,13 +14,13 @@ test ('groupBy', () => {
 
   eq (S.groupBy (x => y => x * y % 3 === 0) ([])) ([]);
   eq (S.groupBy (x => y => x * y % 3 === 0) ([1, 2, 3, 4, 5, 6, 7, 8, 9])) ([[1], [2, 3], [4], [5, 6], [7], [8, 9]]);
-  eq (S.groupBy (equals) ([1, 1, 2, 1, 1])) ([[1, 1], [2], [1, 1]]);
+  eq (S.groupBy (S.equals) ([1, 1, 2, 1, 1])) ([[1, 1], [2], [1, 1]]);
   eq (S.groupBy (x => y => x + y === 0) ([2, -3, 3, 3, 3, 4, -4, 4])) ([[2], [-3, 3, 3, 3], [4, -4], [4]]);
 
   jsc.assert (jsc.forall ('nat -> nat -> bool', 'array nat', (f, xs) => {
     const lhs = S.join (S.groupBy (f) (xs));
     const rhs = xs;
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });

--- a/test/insert.js
+++ b/test/insert.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('..');
 
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('insert', () => {
@@ -20,7 +20,7 @@ test ('insert', () => {
     const insert = S.insert (key) (val);
     const lhs = insert (insert (map));
     const rhs = insert (map);
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });

--- a/test/internal/eq.js
+++ b/test/internal/eq.js
@@ -3,8 +3,7 @@
 const assert = require ('assert');
 
 const show = require ('sanctuary-show');
-
-const equals = require ('./equals');
+const Z = require ('sanctuary-type-classes');
 
 //    eq :: a -> b -> Undefined !
 module.exports = function eq(actual) {
@@ -12,6 +11,6 @@ module.exports = function eq(actual) {
   return function eq$1(expected) {
     assert.strictEqual (arguments.length, eq$1.length);
     assert.strictEqual (show (actual), show (expected));
-    assert.strictEqual (equals (actual) (expected), true);
+    assert.strictEqual (Z.equals (actual, expected), true);
   };
 };

--- a/test/internal/equals.js
+++ b/test/internal/equals.js
@@ -1,8 +1,0 @@
-'use strict';
-
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
-
-//    equals :: a -> b -> Boolean
-module.exports = curry2 (Z.equals);

--- a/test/internal/throws.js
+++ b/test/internal/throws.js
@@ -2,13 +2,13 @@
 
 const assert = require ('assert');
 
-const equals = require ('./equals');
+const Z = require ('sanctuary-type-classes');
 
 //    throws :: (() -> Undefined !) -> Error -> Undefined !
 module.exports = function throws(thunk) {
   assert.strictEqual (arguments.length, throws.length);
   return function throws$1(expected) {
     assert.strictEqual (arguments.length, throws$1.length);
-    assert.throws (thunk, equals (expected));
+    assert.throws (thunk, actual => Z.equals (actual, expected));
   };
 };

--- a/test/match.js
+++ b/test/match.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('..');
 
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('match', () => {
@@ -31,7 +31,7 @@ test ('match', () => {
     const p = '([A-Za-z]+)';
     const lhs = S.head (S.matchAll (S.regex ('g') (p)) (s));
     const rhs = S.match (S.regex ('') (p)) (s);
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });

--- a/test/none.js
+++ b/test/none.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('./internal/sanctuary');
 
 const {Nil, Cons} = require ('./internal/List');
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('none', () => {
@@ -37,14 +37,14 @@ test ('none', () => {
     const p = S.odd;
     const lhs = S.none (p) (xs);
     const rhs = S.not (S.any (p) (xs));
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
   jsc.assert (jsc.forall (jsc.array (jsc.integer), xs => {
     const p = S.odd;
     const lhs = S.none (p) (xs);
     const rhs = S.all (S.complement (p)) (xs);
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });

--- a/test/remove.js
+++ b/test/remove.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('..');
 
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('remove', () => {
@@ -20,7 +20,7 @@ test ('remove', () => {
     const remove = S.remove (key);
     const lhs = remove (remove (map));
     const rhs = remove (map);
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });

--- a/test/splitOn.js
+++ b/test/splitOn.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('..');
 
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('splitOn', () => {
@@ -27,7 +27,7 @@ test ('splitOn', () => {
     const s = t.slice (Math.min (i, j), Math.max (i, j));
     const lhs = S.joinWith (s) (S.splitOn (s) (t));
     const rhs = t;
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });

--- a/test/splitOnRegex.js
+++ b/test/splitOnRegex.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const jsc = require ('jsverify');
+const Z = require ('sanctuary-type-classes');
 
 const S = require ('..');
 
 const eq = require ('./internal/eq');
-const equals = require ('./internal/equals');
 
 
 test ('splitOnRegex', () => {
@@ -64,7 +64,7 @@ test ('splitOnRegex', () => {
     const s = t.slice (Math.min (i, j), Math.max (i, j));
     const lhs = S.joinWith (s) (S.splitOnRegex (S.regex ('g') (S.regexEscape (s))) (t));
     const rhs = t;
-    return equals (lhs) (rhs);
+    return Z.equals (lhs, rhs);
   }), {tests: 1000});
 
 });


### PR DESCRIPTION
This pull request reduces indirection in the test suite by using `Z.equals` directly in place of the curried wrapper function.
