### PR TITLE
update `is` to only work with concrete types

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,7 +526,6 @@
       S[name] = def (name) (consts) (types) (impl);
     }
     S.env = env;
-    S.is = def ('is') ({}) ([$.Type, $.Any, $.Boolean]) ($.test (env));
     S.Maybe = Maybe;
     S.Nothing = Nothing;
     S.Either = Either;
@@ -633,7 +632,7 @@
   //# is :: Type -> Any -> Boolean
   //.
   //. Returns `true` [iff][] the given value is a member of the specified type.
-  //. See [`$.test`][] for details.
+  //. See [`$.test`][] for details, and for advanced use cases.
   //.
   //. ```javascript
   //. > S.is ($.Array ($.Integer)) ([1, 2, 3])
@@ -642,6 +641,11 @@
   //. > S.is ($.Array ($.Integer)) ([1, 2, 3.14])
   //. false
   //. ```
+  _.is = {
+    consts: {},
+    types: [$.Type, $.Any, $.Boolean],
+    impl: $.test ([]),
+  };
 
   //. ### Showable
 

--- a/test/is.js
+++ b/test/is.js
@@ -4,8 +4,6 @@ import $ from 'sanctuary-def';
 
 import S from '../index.js';
 
-import {Sum} from './internal/Sum.mjs';
-
 
 test ('is', () => {
 
@@ -34,19 +32,5 @@ test ('is', () => {
   eq (S.is ($.Either ($.String) ($.Integer)) (S.Right ('')), false);
   eq (S.is ($.Either ($.String) ($.Integer)) (S.Left ('')), true);
   eq (S.is ($.Either ($.String) ($.Integer)) (S.Right (0)), true);
-
-  const a = $.TypeVariable ('a');
-
-  eq (S.is ($.Array (a)) ([]), true);
-  eq (S.is ($.Array (a)) ([1, 2, 3]), true);
-  eq (S.is ($.Array (a)) (['foo', 'bar', 'baz']), true);
-  eq (S.is ($.Array (a)) (['foo', true, 42]), false);
-  eq (S.is ($.Array (a)) ([Sum (1), Sum (2), Sum (3)]), false);
-
-  eq ((S.create ({checkTypes: true, env: []})).is ($.Array (a)) ([]), false);
-  eq ((S.create ({checkTypes: true, env: [$.String]})).is ($.Array (a)) ([]), true);
-  eq ((S.create ({checkTypes: true, env: [$.String]})).is ($.Array (a)) ([1, 2, 3]), false);
-  eq ((S.create ({checkTypes: true, env: [$.Number]})).is ($.Array (a)) ([1, 2, 3]), true);
-  eq ((S.create ({checkTypes: true, env: [Sum.Type]})).is ($.Array (a)) ([Sum (1), Sum (2), Sum (3)]), true);
 
 });


### PR DESCRIPTION
This change is motivated by our desire to support tree shaking. `create` is the most problematic function, but `is` also depends on the [environment][1].

This pull request makes `is` independent of the environment. This means that `S.is ($.Array ($.TypeVariable ('a')))` no longer works, but I imagine no one has ever used this functionality. [`$.test`][1] is still available for advanced use cases, and is almost as convenient given that one must import sanctuary-def to create a type variable anyway.


[1]: https://github.com/sanctuary-js/sanctuary/tree/v3.1.0#env
[2]: https://github.com/sanctuary-js/sanctuary-def/tree/v0.22.0#test
